### PR TITLE
Python 3 syntax error lambda (r): --> lambda r:

### DIFF
--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -113,7 +113,7 @@ class Hypergraph(object):
         events = raw_events.copy().reset_index(drop=True)
         if defs['EVENTID'] in events.columns:
             events[defs['EVENTID']] = events.apply(
-                lambda (r): defs['EVENTID'] + defs['DELIM'] + vToUnicode(r[defs['EVENTID']]), 
+                lambda r: defs['EVENTID'] + defs['DELIM'] + vToUnicode(r[defs['EVENTID']]), 
                 axis=1)
         else:
             events[defs['EVENTID']] = events.reset_index().apply(


### PR DESCRIPTION
Parens around lambda parameters is a syntax error in Python 3