### PR TITLE
Setup CI for Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+cache: pip
+python:
+    - 2.7.13
+    - 3.6
+install:
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
As mentioned in https://github.com/graphistry/pygraphistry/pull/80#issuecomment-323539463  Add CI to do free automated flake8 testing on all pull requests.  The owner of the this repo would need to go to https://travis-ci.org/profile and __flip the repository switch on__ to enable free automated flake8 testing on each pull request.