### PR TITLE
Dev/python3

### DIFF
--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -28,18 +28,17 @@ def make_reverse_lookup(categories):
     return lookup
 
 
+
+unicodeType = type(u's') #python3 fails to compile due to no unicode() ref
 def vToUnicode (v): 
     if sys.version_info >= (3,0,0):
         return str(v)
-    try: #python3 fails to compile vToUnicode() due to no unicode() identifier
-        if type(v) == unicode:
-            return v
-        elif type(v) == str:
-            return v.encode("utf-8").decode('utf-8')
-        else:
-            return str(v).encode("utf-8").decode('utf-8')
-    except:
+    elif type(v) == unicodeType:
         return v
+    elif type(v) == str:
+        return v.encode("utf-8").decode('utf-8')
+    else:
+        return str(v).encode("utf-8").decode('utf-8')
 
 
 

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import sys
 
 ### COMMON TO HYPERGRAPH AND SIMPLE GRAPH
 def makeDefs(DEFS, opts={}):

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -28,7 +28,9 @@ def make_reverse_lookup(categories):
 
 
 def vToUnicode (v): 
-    if type(v) == unicode:
+    if sys.version_info >= (3,0,0):
+        return str(v)
+    elif type(v) == unicode:
         return v
     elif type(v) == str:
         return v.encode("utf-8").decode('utf-8')

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -31,12 +31,16 @@ def make_reverse_lookup(categories):
 def vToUnicode (v): 
     if sys.version_info >= (3,0,0):
         return str(v)
-    elif type(v) == unicode:
+    try: #python3 fails to compile vToUnicode() due to no unicode() identifier
+        if type(v) == unicode:
+            return v
+        elif type(v) == str:
+            return v.encode("utf-8").decode('utf-8')
+        else:
+            return str(v).encode("utf-8").decode('utf-8')
+    except:
         return v
-    elif type(v) == str:
-        return v.encode("utf-8").decode('utf-8')
-    else:
-        return str(v).encode("utf-8").decode('utf-8')
+
 
 
 #ex output: pd.DataFrame([{'val::state': 'CA', 'nodeType': 'state', 'nodeID': 'state::CA'}])


### PR DESCRIPTION
Fixes reference to `unicode` that python3 is backwards-incompatible on. Unicode support overall should still be overhauled, however.