### PR TITLE
fix(hypergraph dropping edges)

### DIFF
--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -85,7 +85,7 @@ def format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs):
         fields = list(set([defs['EVENTID']] + ([x for x in events.columns] if not drop_edge_attrs else [col])))
         raw = events[ fields ]
         if drop_na:
-            raw = raw.dropna()
+            raw = raw.dropna(axis=0, subset=[col])            
         raw = raw.copy()
         if len(raw):            
             if is_using_categories:


### PR DESCRIPTION
In drop_na mode, only skip a synthesized hyperedge when the attribute node is nan, not an arbitrary edge attribute.

In the below, expect to get an edge `1 --[1: nan, bb]-->d:bb` despite the nan.

```
format_hyperedges(pd.DataFrame({'s': ['a', np.nan, 'c'], 'd': ['aa', 'bb', 'cc']}).reset_index(), ['s', 'd'], 
                  {'NODETYPE': 'node', 'CATEGORIES': {}, 'EVENTID': 'index', 'EDGETYPE': 'edge', 'ATTRIBID': 'attrib', 'DELIM': '::'}, True, True)
```

