### PR TITLE
feature(hypergraph direct connect mode)

### DIFF
--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -66,6 +66,8 @@ DEFS_HYPER = {
     'NODEID': 'nodeID',
     'ATTRIBID': 'attribID',
     'EVENTID': 'EventID',
+    'SOURCE': 'src',
+    'DESTINATION': 'dst',    
     'CATEGORY': 'category',
     'NODETYPE': 'type',
     'EDGETYPE': 'edgeType',
@@ -94,8 +96,6 @@ def format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs):
             else:
                 raw[defs['EDGETYPE']] = raw.apply(lambda r: col, axis=1)
             raw[defs['ATTRIBID']] = raw.apply(lambda r: col2cat(cat_lookup, col) + defs['DELIM'] + valToSafeStr(r[col]), axis=1)
-            if drop_edge_attrs:
-                raw = raw.drop([col], axis=1)
             subframes.append(raw)
 
     if len(subframes):
@@ -110,6 +110,55 @@ def format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs):
     else:
         return pd.DataFrame([])
 
+
+# [ str ] * {?'EDGES' : ?{str: [ str ] }} -> {str: [ str ]}
+def direct_edgelist_shape(entity_types, defs):  
+  if 'EDGES' in defs and not defs['EDGES'] is None:
+      return defs['EDGES']
+  else:
+      out = {}
+      for entity_i in range(len(entity_types)):
+        out[ entity_types[entity_i] ] = entity_types[(entity_i + 1):]
+      return out
+  
+      
+#ex output: pd.DataFrame([{'edgeType': 'state', 'attribID': 'state::CA', 'eventID': 'eventID::0'}])
+def format_direct_edges(events, entity_types, defs, edge_shape, drop_na, drop_edge_attrs):
+    is_using_categories = len(defs['CATEGORIES'].keys()) > 0
+    cat_lookup = make_reverse_lookup(defs['CATEGORIES'])
+
+    subframes = []
+    for col1 in sorted(edge_shape.keys()):
+      for col2 in edge_shape[col1]:
+          fields = list(set([defs['EVENTID']] + ([x for x in events.columns] if not drop_edge_attrs else [col1, col2])))
+          raw = events[ fields ]
+          if drop_na:
+              raw = raw.dropna(axis=0, subset=[col1, col2])            
+          raw = raw.copy()
+          if len(raw):            
+              if not drop_edge_attrs:
+                  if is_using_categories:
+                      raw[defs['EDGETYPE']] = raw.apply(lambda r: col2cat(cat_lookup, col1) + defs['DELIM'] + col2cat(cat_lookup, col2), axis=1)
+                      raw[defs['CATEGORY']] = raw.apply(lambda r: col1 + defs['DELIM'] + col2, axis=1)
+                  else:
+                      raw[defs['EDGETYPE']] = raw.apply(lambda r: col1 + defs['DELIM'] + col2, axis=1)
+              raw[defs['SOURCE']] = raw.apply(lambda r: col2cat(cat_lookup, col1) + defs['DELIM'] + valToSafeStr(r[col1]), axis=1)
+              raw[defs['DESTINATION']] = raw.apply(lambda r: col2cat(cat_lookup, col2) + defs['DELIM'] + valToSafeStr(r[col2]), axis=1)
+              subframes.append(raw)
+
+    if len(subframes):
+        result_cols = list(set(
+            ([x for x in events.columns.tolist() if not x == defs['NODETYPE']] 
+                if not drop_edge_attrs 
+                else [])
+            + [defs['EDGETYPE'], defs['SOURCE'], defs['DESTINATION'], defs['EVENTID']]
+            + ([defs['CATEGORY']] if is_using_categories else []) ))
+        out = pd.concat(subframes, ignore_index=True).reset_index(drop=True)[ result_cols ]
+        return out
+    else:
+        return pd.DataFrame([])
+
+
 def format_hypernodes(events, defs, drop_na):
     event_nodes = events.copy()
     event_nodes[defs['NODETYPE']] = defs['EVENTID']
@@ -118,7 +167,7 @@ def format_hypernodes(events, defs, drop_na):
     event_nodes[defs['TITLE']] = event_nodes[defs['EVENTID']]    
     return event_nodes
 
-def hyperbinding(g, defs, entities, event_entities, edges):
+def hyperbinding(g, defs, entities, event_entities, edges, source, destination):
     nodes = pd.concat([entities, event_entities], ignore_index=True).reset_index(drop=True)
     return {
         'entities': entities,
@@ -126,16 +175,15 @@ def hyperbinding(g, defs, entities, event_entities, edges):
         'edges': edges,
         'nodes': nodes,
         'graph': g\
-            .bind(source=defs['ATTRIBID'], destination=defs['EVENTID']).edges(edges)\
-            .bind(node=defs['NODEID'], point_title=defs['TITLE']).nodes(nodes)
-    }    
+            .bind(source=source, destination=destination).edges(edges)\
+            .bind(node=defs['NODEID'], point_title=defs['TITLE']).nodes(nodes) 
 
 ###########        
 
 class Hypergraph(object):        
 
     @staticmethod
-    def hypergraph(g, raw_events, entity_types=None, opts={}, drop_na=True, drop_edge_attrs=False, verbose=True):
+    def hypergraph(g, raw_events, entity_types=None, opts={}, drop_na=True, drop_edge_attrs=False, verbose=True, direct=False):
         defs = makeDefs(DEFS_HYPER, opts)
         entity_types = screen_entities(raw_events, entity_types, defs)
         events = raw_events.copy().reset_index(drop=True)
@@ -148,11 +196,22 @@ class Hypergraph(object):
                 lambda r: defs['EVENTID'] + defs['DELIM'] + valToSafeStr(r['index']),
                 axis=1)
         events[defs['NODETYPE']] = 'event'
+        
         entities = format_entities(events, entity_types, defs, drop_na)
-        event_entities = format_hypernodes(events, defs, drop_na)
-        edges = format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs)
+        event_entities = None
+        edges = None
+        if direct:
+            edge_shape = direct_edgelist_shape(entity_types, opts)
+            event_entities = pd.DataFrame()
+            edges = format_direct_edges(events, entity_types, defs, edge_shape, drop_na, drop_edge_attrs)
+        else:        
+            event_entities = format_hypernodes(events, defs, drop_na)
+            edges = format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs)
         if verbose:
             print('# links', len(edges))
-            print('# event entities', len(events))
+            print('# events', len(events))
             print('# attrib entities', len(entities))
-        return hyperbinding(g, defs, entities, event_entities, edges)
+        return hyperbinding(
+            g, defs, entities, event_entities, edges,
+            defs['SOURCE'] if direct else defs['ATTRIBID'],
+            defs['DESTINATION'] if direct else defs['EVENTID'])

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -56,7 +56,7 @@ def format_entities(events, entity_types, defs, drop_na):
                     defs['NODEID']: col2cat(cat_lookup, col) + defs['DELIM'] + valToSafeStr(v)
                 } 
                 for v in events[col].unique() if not drop_na or valToSafeStr(v) != 'nan'] for col in entity_types], [])
-    df = pd.DataFrame(lst)
+    df = pd.DataFrame(lst).drop_duplicates([defs['NODEID']])
     df[defs['CATEGORY']] = df[defs['NODETYPE']].apply(lambda col: col2cat(cat_lookup, col))
     return df
 

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -176,7 +176,8 @@ def hyperbinding(g, defs, entities, event_entities, edges, source, destination):
         'nodes': nodes,
         'graph': g\
             .bind(source=source, destination=destination).edges(edges)\
-            .bind(node=defs['NODEID'], point_title=defs['TITLE']).nodes(nodes) 
+            .bind(node=defs['NODEID'], point_title=defs['TITLE']).nodes(nodes)
+    } 
 
 ###########        
 

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -247,6 +247,7 @@ class PyGraphistry(object):
         * 'CATEGORIES': Dictionary mapping a category name to inhabiting columns. E.g., {'IP': ['srcAddress', 'dstAddress']}.  If the same IP appears in both columns, this makes the transform generate one node for it, instead of one for each column.
         * 'DELIM': When creating node IDs, defines the separator used between the column name and node value
         * 'SKIP': List of column names to not turn into nodes. For example, dates and numbers are often skipped.
+        * 'EDGES': For direct=True, instead of making all edges, pick column pairs. E.g., {'a': ['b', 'd'], 'd': ['d']} creates edges between columns a->b and a->d, and self-edges d->d.
 
 
         :returns: {'entities': DF, 'events': DF, 'edges': DF, 'nodes': DF, 'graph': Plotter}

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -211,7 +211,7 @@ class PyGraphistry(object):
 
 
     @staticmethod
-    def hypergraph(raw_events, entity_types=None, opts={}, drop_na=True, drop_edge_attrs=False, verbose=True):
+    def hypergraph(raw_events, entity_types=None, opts={}, drop_na=True, drop_edge_attrs=False, verbose=True, direct=False):
         """Transform a dataframe into a hypergraph.
 
         :param Dataframe raw_events: Dataframe to transform
@@ -219,14 +219,15 @@ class PyGraphistry(object):
         :param Dict opts: See below
         :param bool drop_edge_attrs: Whether to include each row's attributes on its edges, defaults to False (include)
         :param bool verbose: Whether to print size information
+        :param bool direct: Omit hypernode and instead strongly connect nodes in an event
 
         Create a graph out of the dataframe, and return the graph components as dataframes, 
         and the renderable result Plotter. It reveals relationships between the rows and between column values.
         This transform is useful for lists of events, samples, relationships, and other structured high-dimensional data.
 
         The transform creates a node for every row, and turns a row's column entries into node attributes. 
-        Every unique value within a column is also turned into a node. 
-        Edges are added to connect a row's node to each of its column nodes. 
+        If direct=False (default), every unique value within a column is also turned into a node. 
+        Edges are added to connect a row's nodes to each of its column nodes, or if direct=True, to one another.
         Nodes are given the attribute 'type' corresponding to the originating column name, or in the case of a row, 'EventID'.
 
 
@@ -261,7 +262,7 @@ class PyGraphistry(object):
 
         """
         from . import hyper
-        return hyper.Hypergraph().hypergraph(PyGraphistry, raw_events, entity_types, opts, drop_na, drop_edge_attrs, verbose)
+        return hyper.Hypergraph().hypergraph(PyGraphistry, raw_events, entity_types, opts, drop_na, drop_edge_attrs, verbose, direct)
 
 
     @staticmethod

--- a/graphistry/tests/test_hypergraph.py
+++ b/graphistry/tests/test_hypergraph.py
@@ -19,6 +19,8 @@ triangleNodesDict = {
 }
 triangleNodes = pd.DataFrame(triangleNodesDict)
 
+hyper_df = pd.DataFrame({'aa': [0, 1, 2], 'bb': ['a', 'b', 'c'], 'cc': ['b', 0, 1]})
+
 
 def assertFrameEqual(df1, df2, **kwds ):
     """ Assert that two dataframes are equal, ignoring ordering of columns"""
@@ -53,6 +55,20 @@ class TestHypergraphPlain(NoAuthTestCase):
         assertFrameEqual(h['edges'], edges)
         for (k, v) in [('entities', 12), ('nodes', 15), ('edges', 12), ('events', 3)]:
             self.assertEqual(len(h[k]), v)
+
+    def test_hyperedges_direct(self, mock_open):
+
+        h = graphistry.hypergraph(hyper_df, verbose=False)
+        
+        self.assertEqual(len(h['edges']), 9)
+        self.assertEqual(len(h['nodes']), 9)
+
+    def test_hyperedges_direct_categories(self, mock_open):
+
+        h = graphistry.hypergraph(hyper_df, verbose=False, direct=True, opts={'CATEGORIES': {'n': ['aa', 'bb', 'cc']}})
+        
+        self.assertEqual(len(h['edges']), 9)
+        self.assertEqual(len(h['nodes']), 6)
 
     def test_drop_edge_attrs(self, mock_open):
     

--- a/graphistry/tests/test_hypergraph.py
+++ b/graphistry/tests/test_hypergraph.py
@@ -58,7 +58,7 @@ class TestHypergraphPlain(NoAuthTestCase):
 
     def test_hyperedges_direct(self, mock_open):
 
-        h = graphistry.hypergraph(hyper_df, verbose=False)
+        h = graphistry.hypergraph(hyper_df, verbose=False, direct=True)
         
         self.assertEqual(len(h['edges']), 9)
         self.assertEqual(len(h['nodes']), 9)

--- a/graphistry/tests/test_hypergraph.py
+++ b/graphistry/tests/test_hypergraph.py
@@ -70,6 +70,15 @@ class TestHypergraphPlain(NoAuthTestCase):
         self.assertEqual(len(h['edges']), 9)
         self.assertEqual(len(h['nodes']), 6)
 
+    def test_hyperedges_direct_manual_shaping(self, mock_open):
+
+        h1 = graphistry.hypergraph(hyper_df, verbose=False, direct=True, opts={'EDGES': {'aa': ['cc'], 'cc': ['cc']}})
+        self.assertEqual(len(h1['edges']), 6)
+
+        h2 = graphistry.hypergraph(hyper_df, verbose=False, direct=True, opts={'EDGES': {'aa': ['cc', 'bb', 'aa'], 'cc': ['cc']}})
+        self.assertEqual(len(h2['edges']), 12)
+
+
     def test_drop_edge_attrs(self, mock_open):
     
         h = graphistry.hypergraph(triangleNodes, verbose=False, drop_edge_attrs=True)


### PR DESCRIPTION
Add optional flag `direct=True` and `opts.EDGES={'my_src': ['my_dest_1', ...], ...}` to hypergraph transform:

* `direct=True` (default=`False`): Instead of a hypergraph node, connect record entities to one another. Replicates `direct connect` checkbox in `/pivot`.
 
* `opts={"EDGES": {'my_src': ['my_dest_1', ...], ...}, ...}` : In direct mode, instead of default of connecting all entities to one another, for each column, pick which other columns to connect it to.

![image](https://user-images.githubusercontent.com/4249447/51229921-062a0180-1913-11e9-84ca-65f96c18b4f0.png)
