### PR TITLE
Dev/api3

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -13,6 +13,12 @@
 3. `python setup.py test`
 4. To duplicate CI tests, in python2 and 3, run ` time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics`
 
+
+### Via Docker
+
+1. "docker pull graphistry/graphistry-forge-base:v<latest>"
+2. ./test-docker.sh
+
 ### CI
 
 Travis CI automatically runs on every branch (with a Travis CI file). To configure, go to the [Travis CI account](https://travis-ci.org/graphistry/pygraphistry) .

--- a/graphistry/__init__.py
+++ b/graphistry/__init__.py
@@ -8,5 +8,6 @@ register, bind, edges, nodes, graph, settings,
 hypergraph, 
 bolt, cypher,
 tigergraph, gsql, gsql_endpoint,
-nodexl
+nodexl,
+ArrowUploader
 )

--- a/graphistry/arrow_uploader.py
+++ b/graphistry/arrow_uploader.py
@@ -1,0 +1,325 @@
+import io, json, logging, pandas as pd, pyarrow as pa, requests, sys
+
+logger = logging.getLogger('ArrowUploader')
+
+class ArrowUploader:
+    
+    @property
+    def token(self) -> str:
+        if self.__token is None:
+            raise Exception("Not logged in")
+        return self.__token
+
+    @token.setter
+    def token(self, token: str):
+        self.__token = token
+
+    @property
+    def dataset_id(self) -> str:
+        if self.__dataset_id is None:
+            raise Exception("Must first create a dataset")
+        return self.__dataset_id
+
+    @dataset_id.setter
+    def dataset_id(self, dataset_id: str):
+        self.__dataset_id = dataset_id
+
+    @property
+    def server_base_path(self) -> str:
+        return self.__server_base_path
+
+    @server_base_path.setter
+    def server_base_path(self, server_base_path: str):
+        self.__server_base_path = server_base_path
+
+    @property
+    def view_base_path(self) -> str:
+        return self.__view_base_path
+
+    @view_base_path.setter
+    def view_base_path(self, view_base_path: str):
+        self.__view_base_path = view_base_path
+
+    @property
+    def edges(self) -> pa.Table:
+        return self.__edges
+
+    @edges.setter
+    def edges(self, edges: pa.Table):
+        self.__edges = edges
+
+    @property
+    def nodes(self) -> pa.Table:
+        return self.__nodes
+
+    @nodes.setter
+    def nodes(self, nodes: pa.Table):
+        self.__nodes = nodes
+
+    @property
+    def node_encodings(self):
+        if self.__node_encodings is None:
+            return {}
+        return self.__node_encodings
+
+    @node_encodings.setter
+    def node_encodings(self, node_encodings):
+        self.__node_encodings = node_encodings
+
+    @property
+    def edge_encodings(self):
+        if self.__edge_encodings is None:
+            return {}
+        return self.__edge_encodings
+    
+    @edge_encodings.setter
+    def edge_encodings(self, edge_encodings):
+        self.__edge_encodings = edge_encodings
+
+    @property
+    def name(self) -> str:
+        if self.__name is None:
+            return "untitled"
+        return self.__name
+
+    @name.setter
+    def name(self, name):
+        self.__name = name
+
+
+    @property
+    def metadata(self):
+        if self.__metadata is None:
+            return {
+                #'usertag': PyGraphistry._tag,
+                #'key': PyGraphistry.api_key()
+                'agent': 'pygraphistry',
+                'apiversion' : '3',
+                'agentversion': sys.modules['graphistry'].__version__,
+            }
+        return self.__metadata
+    
+    @metadata.setter
+    def metadata(self, metadata):
+        self.__metadata = metadata
+
+    #########################################################################
+
+    @property
+    def certificate_validation(self):
+        return self.__certificate_validation
+    
+    @certificate_validation.setter
+    def certificate_validation(self, certificate_validation):
+        self.__certificate_validation = certificate_validation
+
+
+    ########################################################################3
+
+    def __init__(self, 
+            server_base_path='http://nginx', view_base_path='http://localhost',
+            name = None,
+            edges = None, nodes = None,
+            node_encodings = None, edge_encodings = None,
+            token = None, dataset_id = None,
+            metadata = None,
+            certificate_validation = True):
+        self.__name = name
+        self.__server_base_path = server_base_path
+        self.__view_base_path = view_base_path
+        self.__token = token
+        self.__dataset_id = dataset_id
+        self.__edges = edges
+        self.__nodes = nodes
+        self.__node_encodings = node_encodings
+        self.__edge_encodings = edge_encodings
+        self.__metadata = metadata
+        self.__certificate_validation = certificate_validation
+    
+    def login(self, username, password):   
+        base_path = self.server_base_path
+        out = requests.post(
+            f'{base_path}/api-token-auth/',
+            verify=self.certificate_validation,
+            json={'username': username, 'password': password})
+        json_response = None
+        try:
+            json_response = out.json()
+            if not ('token' in json_response):
+                raise Exception(out.text)
+        except Exception:
+            logger.error('Error: %s', out, exc_info=True)
+            raise Exception(out.text)
+            
+        self.token = out.json()['token']        
+        return self
+    
+    def create_dataset(self, json):
+        tok = self.token 
+        
+        res = requests.post(
+            self.server_base_path + '/api/v2/upload/datasets/',
+            verify=self.certificate_validation,
+            headers={'Authorization': f'Bearer {tok}'},
+            json=json)
+             
+        try:            
+            out = res.json()
+            if not out['success']:
+                raise Exception(out)
+        except Exception as e:
+            logger.error('Failed creating dataset: %s', res.text, exc_info=True)
+            raise e
+        
+        self.dataset_id = out['data']['dataset_id']
+
+        return out
+        
+    #PyArrow's table.getvalues().to_pybytes() fails to hydrate some reason, 
+    #  so work around by consolidate into a virtual file and sending that
+    def arrow_to_buffer(self, table: pa.Table):
+        b = io.BytesIO()
+        writer = pa.RecordBatchFileWriter(b, table.schema)
+        writer.write_table(table)
+        writer.close()
+        return b.getvalue()
+
+
+    def maybe_bindings(self, g, bindings, base = {}):
+        out = { **base }
+        for old_field_name, new_field_name in bindings:
+            try:
+                val = getattr(g, old_field_name)
+                if val is None:
+                    continue
+                else:
+                    out[new_field_name] = val
+            except AttributeError:
+                continue
+        logger.debug('bindings: %s', out)
+        return out
+
+    def g_to_node_encodings(self, g):
+        node_encodings = self.maybe_bindings(
+                g,
+                [
+                    ['_node', 'node'],
+                    ['_point_color', 'node_color'],
+                    ['_point_label', 'node_label'],
+                    ['_point_opacity', 'node_opacity'],
+                    ['_point_size', 'node_size'],
+                    ['_point_title', 'node_title'],
+                    ['_point_weight', 'node_weight']
+                ])
+        if not (g._nodes is None):
+            if 'x' in g._nodes:
+                node_encodings['x'] = 'x'
+            if 'y' in g._nodes:
+                node_encodings['y'] = 'y'
+
+        return node_encodings
+
+    def g_to_edge_encodings(self, g):
+        edge_encodings = self.maybe_bindings(
+                g,
+                [
+                    ['_source', 'source'],
+                    ['_destination', 'destination'],
+                    ['_edge_color', 'edge_color'],
+                    ['_edge_label', 'edge_label'],
+                    ['_edge_opacity', 'edge_opacity'],
+                    ['_edge_size', 'edge_size'],
+                    ['_edge_title', 'edge_title'],
+                    ['_edge_weight', 'edge_weight']
+                ])
+        return edge_encodings
+
+    
+    def post(self):
+        self.create_dataset({
+            "node_encodings": {"bindings": self.node_encodings},
+            "edge_encodings": {"bindings": self.edge_encodings},
+            "metadata": self.metadata,
+            "name": self.name
+        })
+        
+        self.post_edges_arrow()
+        
+        if not (self.nodes is None):
+            self.post_nodes_arrow()
+        
+        return self
+
+    ###########################################
+
+
+    def post_edges_arrow(self, arr=None, opts=''):
+        if arr is None:
+            arr = self.edges
+        return self.post_arrow(arr, 'edges', opts) 
+
+    def post_nodes_arrow(self, arr=None, opts=''):
+        if arr is None:
+            arr = self.nodes
+        return self.post_arrow(arr, 'nodes', opts) 
+
+    def post_arrow(self, arr, graph_type, opts=''):
+        buf = self.arrow_to_buffer(arr)
+
+        dataset_id = self.dataset_id
+        tok = self.token
+        base_path = self.server_base_path
+
+        url = f'{base_path}/api/v2/upload/datasets/{dataset_id}/{graph_type}/arrow'
+        if len(opts) > 0:
+            url = f'{url}?{opts}'
+        out = requests.post(
+            url,
+            verify=self.certificate_validation,
+            headers={'Authorization': f'Bearer {tok}'},
+            data=buf).json()
+        
+        if not out['success']:
+            raise Exception(out)
+            
+        return out
+
+
+    ###########################################
+
+
+    def post_g(self, g, name=None):
+
+        self.edge_encodings = self.g_to_edge_encodings(g)
+        self.node_encodings = self.g_to_node_encodings(g)
+        if not (name is None):
+            self.name = name
+
+        self.edges = pa.Table.from_pandas(g._edges, preserve_index=False).replace_schema_metadata({})
+        if not (g._nodes is None):
+            self.nodes = pa.Table.from_pandas(g._nodes, preserve_index=False).replace_schema_metadata({})
+
+        return self.post()
+    
+    def post_edges_file(self, file_path, file_type='csv'):
+        return self.post_file(file_path, 'edges', file_type)
+
+    def post_nodes_file(self, file_path, file_type='csv'):
+        return self.post_file(file_path, 'nodes', file_type)
+
+    def post_file(self, file_path, graph_type='edges', file_type='csv'):
+
+        dataset_id = self.dataset_id
+        tok = self.token
+        base_path = self.server_base_path
+
+        with open(file_path, 'rb') as file:        
+            out = requests.post(
+                f'{base_path}/api/v2/upload/datasets/{dataset_id}/{graph_type}/{file_type}',
+                verify=self.certificate_validation,
+                headers={'Authorization': f'Bearer {tok}'},
+                data=file.read()).json()
+            if not out['success']:
+                raise Exception(out)
+            
+            return out

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -733,7 +733,7 @@ class Plotter(object):
                 'apiversion' : '3',
                 'agentversion': sys.modules['graphistry'].__version__,
             },
-            certificate_validation=PyGraphistry._config['certificate_validation'])
+            certificate_validation=PyGraphistry.certificate_validation())
         au.edge_encodings = au.g_to_edge_encodings(self)
         au.node_encodings = au.g_to_node_encodings(self)
         return au

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -7,7 +7,14 @@ from .pygraphistry import util
 from .pygraphistry import bolt_util
 from .nodexlistry import NodeXLGraphistry
 from .tigeristry import Tigeristry
+from .arrow_uploader import ArrowUploader
 
+maybe_cudf = None
+try:
+    import cudf
+    maybe_cudf = cudf
+except ImportError:
+    1
 
 class Plotter(object):
     """Graph plotting class.
@@ -321,16 +328,28 @@ class Plotter(object):
         self._check_mandatory_bindings(not isinstance(n, type(None)))
 
         api_version = PyGraphistry.api_version()
-        if (api_version == 1):
+        if api_version == 1:
             dataset = self._plot_dispatch(g, n, name, 'json')
             if skip_upload:
                 return dataset
             info = PyGraphistry._etl1(dataset)
-        elif (api_version == 2):
+        elif api_version == 2:
             dataset = self._plot_dispatch(g, n, name, 'vgraph')
             if skip_upload:
                 return dataset
             info = PyGraphistry._etl2(dataset)
+        elif api_version == 3:
+            dataset = self._plot_dispatch(g, n, name, 'arrow')
+            if skip_upload:
+                return dataset
+            #fresh
+            dataset.token = PyGraphistry.api_token()
+            dataset.post()
+            info = {
+                'name': dataset.dataset_id,
+                'type': 'arrow',
+                'viztoken': str(uuid.uuid4())
+            }
 
         viz_url = PyGraphistry._viz_url(info, self._url_params)
         cfg_client_protocol_hostname = PyGraphistry._config['client_protocol_hostname']
@@ -469,7 +488,10 @@ class Plotter(object):
 
 
     def _plot_dispatch(self, graph, nodes, name, mode='json'):
-        if isinstance(graph, pandas.core.frame.DataFrame):
+
+        if isinstance(graph, pandas.core.frame.DataFrame) \
+            or isinstance(graph, pa.Table) \
+            or ( not (maybe_cudf is None) and isinstance(graph, maybe_cudf.DataFrame) ):
             return self._make_dataset(graph, nodes, name, mode)
 
         try:
@@ -491,7 +513,7 @@ class Plotter(object):
         except ImportError:
             pass
 
-        util.error('Expected Pandas dataframe(s) or Igraph/NetworkX graph.')
+        util.error('Expected Pandas/Arrow/cuDF dataframe(s) or Igraph/NetworkX graph.')
 
 
     # Sanitize node/edge dataframe by
@@ -603,15 +625,56 @@ class Plotter(object):
         }
         return (elist, nlist, encodings)
 
+    def _table_to_pandas(self, table) -> pandas.DataFrame:
+
+        if table is None:
+            return table
+
+        if isinstance(table, pandas.DataFrame):
+            return table
+
+        if isinstance(table, pa.Table):
+            return table.to_pandas()
+        
+        if not (maybe_cudf is None) and isinstance(table, maybe_cudf.DataFrame):
+            return table.to_pandas()
+        
+        raise Exception('Unknown type %s: Could not convert data to Pandas dataframe' % str(type(table)))
+
+    def _table_to_arrow(self, table) -> pa.Table:
+
+        if table is None:
+            return table
+
+        if isinstance(table, pa.Table):
+            return table
+        
+        if isinstance(table, pandas.DataFrame):
+            return pa.Table.from_pandas(table, preserve_index=False).replace_schema_metadata({})
+
+        if not (maybe_cudf is None) and isinstance(table, maybe_cudf.DataFrame):
+            return table.to_arrow()
+        
+        raise Exception('Unknown type %s: Could not convert data to Arrow' % str(type(table)))
+
 
     def _make_dataset(self, edges, nodes, name, mode):
         if len(edges.index) == 0:
             util.error('Graph has no edges (at least 1 edge required)')
 
         if mode == 'json':
-            return self._make_json_dataset(edges, nodes, name)
+            edges_df = self._table_to_pandas(edges)
+            nodes_df = self._table_to_pandas(nodes)
+            return self._make_json_dataset(edges_df, nodes_df, name)
         elif mode == 'vgraph':
-            return self._make_vgraph_dataset(edges, nodes, name)
+            edges_df = self._table_to_pandas(edges)
+            nodes_df = self._table_to_pandas(nodes)
+            return self._make_vgraph_dataset(edges_df, nodes_df, name)
+        elif mode == 'arrow':
+            edges_arr = self._table_to_arrow(edges)
+            nodes_arr = self._table_to_arrow(nodes)
+            return self._make_arrow_dataset(edges_arr, nodes_arr, name)
+            #token=None, dataset_id=None, url_params = None)
         else:
             raise ValueError('Unknown mode: ' + mode)
 
@@ -656,6 +719,20 @@ class Plotter(object):
         dataset['encodings'] = encodings
         return dataset
 
+    def _make_arrow_dataset(self, edges: pa.Table, nodes: pa.Table, name: str) -> ArrowUploader:
+        au = ArrowUploader(
+            edges=edges, nodes=nodes, name=name,
+            metadata={
+                'usertag': PyGraphistry._tag,
+                'key': PyGraphistry.api_key(),
+                'agent': 'pygraphistry',
+                'apiversion' : '3',
+                'agentversion': sys.modules['graphistry'].__version__,
+            },
+            certificate_validation=PyGraphistry._config['certificate_validation'])
+        au.edge_encodings = au.g_to_edge_encodings(self)
+        au.node_encodings = au.g_to_node_encodings(self)
+        return au
 
     def bolt(self, driver):
         res = copy.copy(self)

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1,17 +1,11 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import str
-from builtins import object
-import copy
-import numpy
-import pandas
+from __future__ import absolute_import, print_function
+from builtins import object, str
+import copy, numpy, pandas, pyarrow as pa, sys, uuid
 
 from .pygraphistry import PyGraphistry
 from .pygraphistry import util
 from .pygraphistry import bolt_util
-
 from .nodexlistry import NodeXLGraphistry
-
 from .tigeristry import Tigeristry
 
 

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -724,6 +724,7 @@ class Plotter(object):
 
     def _make_arrow_dataset(self, edges: pa.Table, nodes: pa.Table, name: str) -> ArrowUploader:
         au = ArrowUploader(
+            server_base_path=PyGraphistry.protocol() + '://' + PyGraphistry.server(),
             edges=edges, nodes=nodes, name=name,
             metadata={
                 'usertag': PyGraphistry._tag,

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -659,8 +659,11 @@ class Plotter(object):
 
 
     def _make_dataset(self, edges, nodes, name, mode):
-        if len(edges.index) == 0:
-            util.error('Graph has no edges (at least 1 edge required)')
+        try:
+            if len(edges) == 0:
+                util.warn('Graph has no edges, may have rendering issues')
+        except:
+            1
 
         if mode == 'json':
             edges_df = self._table_to_pandas(edges)

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -95,7 +95,10 @@ class PyGraphistry(object):
     def login(username, password, fail_silent=False):
         """Authenticate and set token for reuse (api=3). Periodically call if risk of token going stale."""
 
-        token = ArrowUploader().login(username, password).token
+        token = ArrowUploader(
+            server_base_path=PyGraphistry.protocol() + '://' + PyGraphistry.server(),
+            certificate_validation=PyGraphistry.certificate_validation())\
+                .login(username, password).token
         PyGraphistry.api_token(token)
         PyGraphistry._is_authenticated = True
 
@@ -228,15 +231,15 @@ class PyGraphistry(object):
                     graphistry.register()
         """
         PyGraphistry.api_key(key)
-        if not (username is None) and not (password is None):
-            PyGraphistry.login(username, password)
-        PyGraphistry.api_token(token)
         PyGraphistry.server(server)
         PyGraphistry.api_version(api)
         PyGraphistry.protocol(protocol)
         PyGraphistry.certificate_validation(certificate_validation)
         PyGraphistry.authenticate()
         PyGraphistry.set_bolt_driver(bolt)
+        if not (username is None) and not (password is None):
+            PyGraphistry.login(username, password)
+        PyGraphistry.api_token(token)
 
 
     @staticmethod

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -4,16 +4,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object
-from builtins import str
-from builtins import bytes
+from builtins import bytes, object, str
 from past.utils import old_div
 from past.builtins import basestring
 
-import os
-import sys
-import calendar
-import time
+import calendar, gzip, io, json, os, numpy, pandas, requests, sys, time, warnings
+
 from datetime import datetime
 from distutils.util import strtobool
 import gzip

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -12,13 +12,8 @@ import calendar, gzip, io, json, os, numpy, pandas, requests, sys, time, warning
 
 from datetime import datetime
 from distutils.util import strtobool
-import gzip
-import io
-import json
-import requests
-import pandas
-import numpy
-import warnings
+
+from .arrow_uploader import ArrowUploader
 
 from . import util
 from . import bolt_util
@@ -26,6 +21,9 @@ from . import bolt_util
 
 EnvVarNames = {
     'api_key': 'GRAPHISTRY_API_KEY',
+    #'api_token': 'GRAPHISTRY_API_TOKEN',
+    #'username': 'GRAPHISTRY_USERNAME',
+    #'password': 'GRAPHISTRY_PASSWORD',
     'api_version': 'GRAPHISTRY_API_VERSION',
     'dataset_prefix': 'GRAPHISTRY_DATASET_PREFIX',
     'hostname': 'GRAPHISTRY_HOSTNAME',
@@ -42,6 +40,9 @@ config_paths = [
 
 default_config = {
     'api_key': None, # Dummy key
+    'api_token': None,
+    #'username': None,
+    #'password': None,
     'api_version': 1,
     'dataset_prefix': 'PyGraphistry/',
     'hostname': 'labs.graphistry.com',
@@ -79,7 +80,7 @@ class PyGraphistry(object):
 
     @staticmethod
     def authenticate():
-        """Authenticate via already provided configuration.
+        """Authenticate via already provided configuration (api=1,2).
         This is called once automatically per session when uploading and rendering a visualization."""
         key = PyGraphistry.api_key()
         #Mocks may set to True, so bypass in that case
@@ -88,6 +89,16 @@ class PyGraphistry(object):
         if not PyGraphistry._is_authenticated:
             PyGraphistry._check_key_and_version()
             PyGraphistry._is_authenticated = True
+
+
+    @staticmethod
+    def login(username, password, fail_silent=False):
+        """Authenticate and set token for reuse (api=3). Periodically call if risk of token going stale."""
+
+        token = ArrowUploader().login(username, password).token
+        PyGraphistry.api_token(token)
+        PyGraphistry._is_authenticated = True
+
 
 
     @staticmethod
@@ -121,6 +132,20 @@ class PyGraphistry(object):
         # setter
         if value is not PyGraphistry._config['api_key']:
             PyGraphistry._config['api_key'] = value.strip()
+            PyGraphistry._is_authenticated = False
+
+
+    @staticmethod
+    def api_token(value=None):
+        """Set or get the API token.
+        Also set via environment variable GRAPHISTRY_API_TOKEN."""
+
+        if value is None:
+            return PyGraphistry._config['api_token']
+
+        # setter
+        if value is not PyGraphistry._config['api_token']:
+            PyGraphistry._config['api_token'] = value.strip()
             PyGraphistry._is_authenticated = False
 
 
@@ -165,10 +190,12 @@ class PyGraphistry(object):
 
 
     @staticmethod
-    def register(key=None, server=None, protocol=None, api=None, certificate_validation=None, bolt=None):
+    def register(key=None, username=None, password=None, token=None, server=None, protocol=None, api=None, certificate_validation=None, bolt=None):
         """API key registration and server selection
 
         Changing the key effects all derived Plotter instances.
+
+        Provide one of key (api=1,2) or username/password (api=3) or token (api=3). 
 
         :param key: API key.
         :type key: String.
@@ -201,6 +228,9 @@ class PyGraphistry(object):
                     graphistry.register()
         """
         PyGraphistry.api_key(key)
+        if not (username is None) and not (password is None):
+            PyGraphistry.login(username, password)
+        PyGraphistry.api_token(token)
         PyGraphistry.server(server)
         PyGraphistry.api_version(api)
         PyGraphistry.protocol(protocol)

--- a/graphistry/tests/test_arrow_uploader.py
+++ b/graphistry/tests/test_arrow_uploader.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+import mock, pandas as pd, pytest, unittest
+
+import graphistry
+from common import NoAuthTestCase
+from graphistry import ArrowUploader
+
+#TODO mock requests for testing actual effectful code
+
+class TestArrowUploader_Core(unittest.TestCase):
+    def test_au_init_plain(self):
+        au = ArrowUploader()
+        with pytest.raises(Exception):
+            au.token
+        with pytest.raises(Exception):
+            au.dataset_id
+        assert au.edges is None
+        assert au.nodes is None
+        assert au.node_encodings == {}
+        assert au.edge_encodings == {}
+        assert len(au.name) > 0
+        assert not (au.metadata is None)
+    
+    def test_au_init_args(self):
+        n = pd.DataFrame({'n': []})
+        e = pd.DataFrame({'e': []})
+        sbp = "s"
+        vbp = "v"
+        name = "n"
+        t = "t"
+        d = "d"
+        ne = {"point_color": "c"}
+        ee = {"edge_color": "c"}
+        m = {"n": "n"}
+        ce = False
+        au = ArrowUploader(server_base_path=sbp, view_base_path=vbp,
+            name = name,
+            edges = e, nodes = n,
+            node_encodings = ne, edge_encodings = ee,
+            token = t, dataset_id = d,
+            metadata = m,
+            certificate_validation = ce)
+        assert au.server_base_path == sbp
+        assert au.view_base_path == vbp
+        assert au.name == name
+        assert au.edges is e
+        assert au.nodes is n
+        assert au.edge_encodings == ee
+        assert au.node_encodings == ne
+        assert au.token == t
+        assert au.dataset_id == d
+        assert au.certificate_validation == ce
+
+    def test_au_n_enc_mt(self):
+        g = graphistry.bind()
+        au = ArrowUploader()
+        assert au.g_to_node_encodings(g) == {}
+
+    def test_au_n_enc_full(self):        
+        g = graphistry.bind(node='n', point_color='c', point_size='s', point_title='t', point_label='l')
+        au = ArrowUploader()
+        assert au.g_to_node_encodings(g) == \
+            {
+                'node': 'n',
+                'node_color': 'c',
+                'node_size': 's',
+                'node_title': 't',
+                'node_label': 'l'
+            }
+
+    def test_au_e_enc_mt(self):
+        g = graphistry.bind()
+        au = ArrowUploader()
+        assert au.g_to_edge_encodings(g) == {}
+
+    def test_au_e_enc_full(self):        
+        g = graphistry.bind(source='s', destination='d', edge_color='c', edge_title='t', edge_label='l', edge_weight='w')
+        au = ArrowUploader()
+        assert au.g_to_edge_encodings(g) == \
+            {
+                'source': 's',
+                'destination': 'd',
+                'edge_color': 'c',
+                'edge_title': 't',
+                'edge_label': 'l',
+                'edge_weight': 'w'
+            }
+
+
+class TestArrowUploader_Comms(unittest.TestCase):
+
+    def _mock_response(
+            self,
+            status=200,
+            content="CONTENT",
+            json_data=None,
+            raise_for_status=None):
+
+        mock_resp = mock.Mock()
+        # mock raise_for_status call w/optional error
+        mock_resp.raise_for_status = mock.Mock()
+        if raise_for_status:
+            mock_resp.raise_for_status.side_effect = raise_for_status
+        # set status code and content
+        mock_resp.status_code = status
+        mock_resp.content = content
+        # add json data if provided
+        if json_data:
+            mock_resp.json = mock.Mock(return_value=json_data)
+        return mock_resp
+    
+    @mock.patch('requests.post')
+    def test_login(self, mock_post):
+
+        mock_resp = self._mock_response(json_data={'token': '123'})
+        mock_post.return_value = mock_resp
+
+        au = ArrowUploader()
+        tok = au.login(username="u", password="p").token
+
+        assert tok == "123"
+

--- a/graphistry/tests/test_hypergraph.py
+++ b/graphistry/tests/test_hypergraph.py
@@ -7,7 +7,6 @@ import numpy
 import datetime
 import graphistry
 import graphistry.plotter
-from mock import patch
 from common import NoAuthTestCase
 
 nid = graphistry.plotter.Plotter._defaultNodeId
@@ -64,11 +63,10 @@ def assertFrameEqual(df1, df2, **kwds ):
     return assert_frame_equal(df1.sort_index(axis=1), df2.sort_index(axis=1), check_names=True, **kwds)
 
 
-@patch('webbrowser.open')
 class TestHypergraphPlain(NoAuthTestCase):
 
   
-    def test_hyperedges(self, mock_open):
+    def test_hyperedges(self):
 
         h = graphistry.hypergraph(triangleNodes, verbose=False)
         
@@ -91,21 +89,21 @@ class TestHypergraphPlain(NoAuthTestCase):
         for (k, v) in [('entities', 12), ('nodes', 15), ('edges', 12), ('events', 3)]:
             self.assertEqual(len(h[k]), v)
 
-    def test_hyperedges_direct(self, mock_open):
+    def test_hyperedges_direct(self):
 
         h = graphistry.hypergraph(hyper_df, verbose=False, direct=True)
         
         self.assertEqual(len(h['edges']), 9)
         self.assertEqual(len(h['nodes']), 9)
 
-    def test_hyperedges_direct_categories(self, mock_open):
+    def test_hyperedges_direct_categories(self):
 
         h = graphistry.hypergraph(hyper_df, verbose=False, direct=True, opts={'CATEGORIES': {'n': ['aa', 'bb', 'cc']}})
         
         self.assertEqual(len(h['edges']), 9)
         self.assertEqual(len(h['nodes']), 6)
 
-    def test_hyperedges_direct_manual_shaping(self, mock_open):
+    def test_hyperedges_direct_manual_shaping(self):
 
         h1 = graphistry.hypergraph(hyper_df, verbose=False, direct=True, opts={'EDGES': {'aa': ['cc'], 'cc': ['cc']}})
         self.assertEqual(len(h1['edges']), 6)
@@ -114,7 +112,7 @@ class TestHypergraphPlain(NoAuthTestCase):
         self.assertEqual(len(h2['edges']), 12)
 
 
-    def test_drop_edge_attrs(self, mock_open):
+    def test_drop_edge_attrs(self):
     
         h = graphistry.hypergraph(triangleNodes, verbose=False, drop_edge_attrs=True)
 
@@ -135,7 +133,7 @@ class TestHypergraphPlain(NoAuthTestCase):
             self.assertEqual(len(h[k]), v)
 
 
-    def test_skip_na_hyperedge(self, mock_open):
+    def test_skip_na_hyperedge(self):
     
         nans_df = pd.DataFrame({
           'x': ['a', 'b', 'c'],
@@ -149,5 +147,5 @@ class TestHypergraphPlain(NoAuthTestCase):
         default_h_edges = graphistry.hypergraph(nans_df)['edges']
         self.assertEqual(len(default_h_edges), len(expected_hits))
 
-    def test_hyper_evil(self, mock_open):
+    def test_hyper_evil(self):
         graphistry.hypergraph(squareEvil)

--- a/graphistry/tests/test_nodexl.py
+++ b/graphistry/tests/test_nodexl.py
@@ -3,7 +3,6 @@
 import unittest
 import pandas as pd
 import graphistry
-from mock import patch
 from common import NoAuthTestCase
 
 class TestNodexlBindings(NoAuthTestCase):

--- a/graphistry/tests/test_plotter.py
+++ b/graphistry/tests/test_plotter.py
@@ -6,8 +6,6 @@ import unittest
 import pandas as pd
 import requests
 import IPython
-import igraph
-import networkx as nx
 import graphistry
 import datetime as dt
 from mock import patch
@@ -291,6 +289,7 @@ class TestPlotterCallChaining(NoAuthTestCase):
 class TestPlotterConversions(NoAuthTestCase):
 
     def test_igraph2pandas(self):
+        import igraph
         ig = igraph.Graph.Tree(4, 2)
         ig.vs['vattrib'] = 0
         ig.es['eattrib'] = 1
@@ -319,6 +318,7 @@ class TestPlotterConversions(NoAuthTestCase):
 
 
     def test_networkx2igraph(self):
+        import networkx as nx
         ng = nx.complete_graph(3)
         [x, y] = [int(x) for x in nx.__version__.split('.')]
         if x == 1:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     author='The Graphistry Team',
     author_email='pygraphistry@graphistry.com',
     setup_requires=['numpy', 'pytest-runner'],
-    install_requires=['numpy', 'pandas >= 0.17.0', 'requests', 'future >= 0.15.0', 'protobuf >= 2.6.0'],
+    install_requires=['numpy', 'pandas >= 0.17.0', 'pyarrow >= 0.15.0', 'requests', 'future >= 0.15.0', 'protobuf >= 2.6.0'],
     extras_require={
         'igraph': ['python-igraph'],
         'networkx': ['networkx'],

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# docker pull graphistry/graphistry-blazing
+
+sudo docker run \
+    -e GRAPHISTRY_LOG_LEVEL=TRACE \
+    -e PYTEST_CURRENT_TEST=TRUE \
+    --rm -it \
+    --gpus all \
+    -v ${PWD}:/opt/pygraphistry:ro \
+    -w /opt/pygraphistry \
+    graphistry/graphistry-forge-base:v2.29.5 \
+    /opt/pygraphistry/test.sh --maxfail=5 --timeout=10 $@

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+echo "=========== TEST DATA =========="
+echo "PWD: `pwd`"
+ls
+
+source activate rapids
+conda-env list
+
+echo "install mock"
+conda install --no-deps mock -y
+#conda install --no-deps -c conda-forge python-igraph textable -y
+
+echo "=========== TEST ==============="
+echo "Test args: $@"
+GRAPHISTRY_API_KEY="" python -B -O -m pytest -v  graphistry/tests $@
+#python -B setup.py test $@


### PR DESCRIPTION
Adds api=3 for binding pandas/arrow/cudf dataframes and more effectively uploading them. Requires new username/password (which gets a token) or new token system. If a token goes still, invoke graphistry.login(...).

Also:
-- Adds docker-ized tests
-- Internal helpers for file-based uploads when wanting to skip the arrow step

![Screenshot from 2020-05-30 17-41-35](https://user-images.githubusercontent.com/4249447/83341901-46d2b280-a29d-11ea-9bf8-24e3effb843d.png)
