### PR TITLE
Dev/hypergraph arrow

### DIFF
--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -55,7 +55,7 @@ def format_entities(events, entity_types, defs, drop_na):
                     defs['NODETYPE']: col, 
                     defs['NODEID']: col2cat(cat_lookup, col) + defs['DELIM'] + valToSafeStr(v)
                 } 
-                for v in events[col].unique() if not drop_na or valToSafeStr(v) != 'nan'] for col in entity_types], [])
+                for v in events[col].unique() if not drop_na or (not (v is None) and valToSafeStr(v) != 'nan')] for col in entity_types], [])
     df = pd.DataFrame(lst).drop_duplicates([defs['NODEID']])
     df[defs['CATEGORY']] = df[defs['NODETYPE']].apply(lambda col: col2cat(cat_lookup, col))
     return df

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -51,7 +51,7 @@ def format_entities(events, entity_types, defs, drop_na):
     cat_lookup = make_reverse_lookup(defs['CATEGORIES'])
     lst = sum([[{
                     col: v,
-                    defs['TITLE']: v,
+                    defs['TITLE']: valToSafeStr(v),
                     defs['NODETYPE']: col, 
                     defs['NODEID']: col2cat(cat_lookup, col) + defs['DELIM'] + valToSafeStr(v)
                 } 


### PR DESCRIPTION
Fixes:

* `hypergraph(drop_na=True)` handles more cases
* `hypergraph(df)['graph'].plot()` now works with `api=3` when `df` is arrow-compatible (was not creating type-uniform `title` column)