### PR TITLE
docs(edge weights and readme cleanup)

### DIFF
--- a/demos/more_examples/graphistry_features/edge-weights.ipynb
+++ b/demos/more_examples/graphistry_features/edge-weights.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Guiding Layout with Edge Weights\n",
+    "\n",
+    "We can use edge attributes to guide the layout by having how much the nodes of an edge get attracted to one another be influenced by that attribute. This is useful in several scenarios:\n",
+    "* An edge has a natural property, such as `affinity`\n",
+    "* An edge represents multiple edges and thus represents a non-uniform weight such as `count`\n",
+    "* Algorithms provide edge properties, such as `relevance`\n",
+    "\n",
+    "By binding such an edge column to **edge_weight** and optionally tuning how much to factor in that column with the **edgeInfluence** control, we can guide the clustering to factor in the edge weight.\n",
+    "\n",
+    "1. By default, every edge contributes a weight of `1` on how much to pull its nodes together. \n",
+    "  * Multiple edges between the same 2 nodes will thus cause those nodes to be closer together\n",
+    "2. Activate edge weights in `api=3` (2.0): Edges with high edge weights bring their nodes closer together; edges with low weight allow their nodes to move further appart\n",
+    "  * Set via binding `edge_weight` (`.bind(edge_weight='my_col')`)\n",
+    "  * Edge weight values automatically normalize between 0 and 1 starting with v2.30.25\n",
+    "2. The edge influence control guides whether to ignore edge weight (`0`) and use it primarily (`7+`)\n",
+    "  * Set via the UI (`Layout Controls` -> `Edge Influence`) or via url parameter `edgeInfluence` (`.settings(url_params={'edgeInfluence': 2})`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd, graphistry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graphistry.register(api=3,username='...', password='...')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Demo: Strongly connected graph of 20 nodes\n",
+    "\n",
+    "* No edge weight: Appears as a regular mesh\n",
+    "* Same edge weights: Appears as a regular mesh\n",
+    "* Edge weight `1` for edges (`i`, `i+1`), defining a chain, and the other edges set to weight `0`:\n",
+    "  * `'edgeInfluence': 0`: Appears as a regular mesh\n",
+    "  * `'edgeInfluence': 1`: Still a mesh, but start to see a chain interleaved\n",
+    "  * `'edgeInfluence': 2`: The chain starts to form a circle around the mesh\n",
+    "  * `'edgeInfluence': 7`: The chain starts to become a straight line; the other edges have little relative impact (no more mesh)\n",
+    "* Edge weight `100` instead of `1` for the chain: same as edge weight `1` due to normalization\n",
+    "* Edge weight `1` for the chain's edges and `-1` for the rest: Same due to normalization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edges = []\n",
+    "n = 20\n",
+    "k = 2\n",
+    "\n",
+    "edges = pd.DataFrame({\n",
+    "    's': [i for i in range(0,n) for j in range(0,n) if i != j],\n",
+    "    'd': [j for i in range(0,n) for j in range(0,n) if i != j]\n",
+    "})\n",
+    "edges['1_if_neighbor'] = edges.apply(\n",
+    "    lambda r: \\\n",
+    "            1 \\\n",
+    "                if (r['s'] == r['d'] - 1) \\\n",
+    "                or (r['s'] == r['d'] + 1) \\\n",
+    "            else 0,\n",
+    "    axis=1).astype('float32')\n",
+    "edges['100_if_neighbor'] = (edges['1_if_neighbor'] * 100).astype('int64')\n",
+    "edges['ec'] = edges['1_if_neighbor'].apply(lambda v: round(v) * 0xFF000000)\n",
+    "edges.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "URL_PARAMS = {'play': 5000, 'edgeCurvature': 0.1, 'precisionVsSpeed': -3}\n",
+    "g = graphistry.edges(edges).bind(source='s', destination='d', edge_color='ec').settings(url_params=URL_PARAMS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge Influence 0: No weights -- a mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g.bind(edge_weight='1_if_neighbor').settings(url_params={**URL_PARAMS, 'edgeInfluence': 0}).plot(render=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge influence 1: Some weight -- chain interleaved into the mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g.bind(edge_weight='1_if_neighbor').settings(url_params={**URL_PARAMS, 'edgeInfluence': 1}).plot(render=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge influence 2: Strong weight -- chain becomes circumference of mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g.bind(edge_weight='1_if_neighbor').settings(url_params={**URL_PARAMS, 'edgeInfluence': 2}).plot(render=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge influence 7: Non-chain edges lose relative influence -- chain becomes a straight line (no more mesh) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "g.bind(edge_weight='1_if_neighbor').settings(url_params={**URL_PARAMS, 'edgeInfluence': 7}).plot(render=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge weights -1 to 1, and 0 to 100: Same as if edge weights were between 0 and 1\n",
+    "Graphistry automatically normalizes edge weights in version 2.30.25+"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g.edges(g._edges.assign(with_negative=\\\n",
+    "        g._edges['1_if_neighbor'].apply(lambda v: \\\n",
+    "            -1 if v == 0 else 1 )))\\\n",
+    "    .bind(edge_weight='1_if_neighbor').settings(url_params={**URL_PARAMS, 'edgeInfluence': 1}).plot(render=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g.bind(edge_weight='100_if_neighbor').settings(url_params={**URL_PARAMS, 'edgeInfluence': 2}).plot(render=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7 (RAPIDS)",
+   "language": "python",
+   "name": "rapids"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add:
-- edge weight tutorial

Garden:
-- main README linking to docs
-- main README replaces `plotter` with `g` for standard style

![Screenshot from 2020-07-10 23-24-03](https://user-images.githubusercontent.com/4249447/87218127-cf188e80-c304-11ea-8dc7-fba80c1f0df7.png)
