### PR TITLE
feat(use file upload api): via plot(as_files=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+## [0.15.0] - 2021-01-10
+
+* File API: Enable via `.plot(as_files=True)`. By default, auto-skips file uploads (`.plot(memoize=True)`) for tables with same hash as those already uploaded in the same session (https://github.com/graphistry/pygraphistry/pull/195).
 * Auth service account docs in README.md (12.2.2020)
 
 ## [0.14.1] - 2020-11-16

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -15,6 +15,10 @@ cd docker && docker-compose build && docker-compose up -d
 cd docker && ./test-cpu-local.sh
 ```
 
+Connector tests (currently neo4j-only): `cd docker && WITH_NEO4J=1 ./test-cpu-local.sh`
+
+* Will start a local neo4j (docker) then enable+run tests against it
+
 
 ## Native - DEPRECATED
 ### Install Git Checkout - DEPRECATED
@@ -41,6 +45,12 @@ To manually build, see `docs/`.
 ## CI
 
 We intend to move to Github Actions / DockerHub Automated Builds for CPU and TBD for GPU
+
+
+## Debugging Tips
+
+* Use the unit tests
+* use the `logging` module per-file
 
 ### Travis - DEPRECATED
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Graphistry, Inc.
+Copyright (c) 2021, Graphistry, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 PyGraphistry is a Python visual graph analytics library to extract, transform, and load big graphs into [Graphistry](https://www.graphistry.com) end-to-end GPU  visual graph analytics sessions.
 
-Graphistry gets used on problems like visually mapping the behavior of devices and users and inspecting machine learning results. It provides point-and-click features like timebars, search, filtering, clustering, coloring, sharing, and more. Graphistry is the only tool built ground-up for large graphs. The client's custom WebGL rendering engine renders up to 8MM nodes + edges at a time, and most older client GPUs smoothly support somewhere between 100K and 1MM elements. The serverside GPU analytics engine supports even bigger graphs.
+Graphistry gets used on problems like visually mapping the behavior of devices and users and for analyzing machine learning results. It provides point-and-click features like timebars, search, filtering, clustering, coloring, sharing, and more. Graphistry is the only tool built ground-up for large graphs. The client's custom WebGL rendering engine renders up to 8MM nodes + edges at a time, and most older client GPUs smoothly support somewhere between 100K and 1MM elements. The serverside GPU analytics engine supports even bigger graphs.
 
 The PyGraphistry Python client helps several kinds of usage modes:
 

--- a/docker/test-cpu-entrypoint.sh
+++ b/docker/test-cpu-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python -B -m pytest -vv  graphistry/tests $@
+python -B -m pytest -vv $@

--- a/docker/test-cpu-local.sh
+++ b/docker/test-cpu-local.sh
@@ -2,7 +2,7 @@
 
 # Run tests using local mounts
 
-WITH_NEO4J=${WITH_NEO4J:-1}
+WITH_NEO4J=${WITH_NEO4J:-0}
 
 if [ "$WITH_NEO4J" == "1" ]
 then

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PyGraphistry'
-copyright = u'2015, Graphistry, Inc.'
+copyright = u'2021, Graphistry, Inc.'
 author = u'Graphistry, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/graphistry.rst
+++ b/docs/source/graphistry.rst
@@ -20,6 +20,21 @@ graphistry.pygraphistry module
     :undoc-members:
     :show-inheritance:
 
+graphistry.arrow_uploader module
+------------------------------
+
+.. automodule:: graphistry.arrow_uploader
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+graphistry.ArrowFileUploader module
+------------------------------
+
+.. automodule:: graphistry.ArrowFileUploader
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import pyarrow as pa
+    from .arrow_uploader import ArrowUploader
+
+import logging, requests
+from functools import lru_cache
+from weakref import WeakKeyDictionary
+
+logger = logging.getLogger('ArrowFileUploader')
+
+
+# WrappedTable -> {'file_id': str, 'output': dict}
+DF_TO_FILE_ID_CACHE : WeakKeyDictionary = WeakKeyDictionary()
+"""
+NOTE: Will switch to pa.Table -> ... when RAPIDS upgrades from pyarrow, 
+     which adds weakref support
+"""
+
+class ArrowFileUploader():
+    """
+        Implement file API with focus on Arrow support
+
+        Example: Upload files with per-session memoization
+            uploader : ArrowUploader
+            arr : pa.Table
+            afu = ArrowFileUploader(uploader)
+
+            file1_id = afu.create_and_post_file(arr)[0]
+            file2_id = afu.create_and_post_file(arr)[0]
+
+            assert file1_id == file2_id # memoizes by default (memory-safe: weak refs)
+
+        Example: Explicitly create a file and upload data for it
+            uploader : ArrowUploader
+            arr : pa.Table
+            afu = ArrowFileUploader(uploader)
+
+            file1_id = afu.create_file()
+            afu.post_arrow(arr, file_id)
+
+            file2_id = afu.create_file()
+            afu.post_arrow(arr, file_id)
+
+            assert file1_id != file2_id
+    """
+
+    uploader: ArrowUploader
+
+    def __init__(self, uploader: ArrowUploader):
+        self.uploader = uploader
+
+    ###
+
+    def create_file(self, file_opts: dict = {}) -> str:
+        """
+            Creates File and returns file_id str.
+            
+            Defauls:
+              - file_type: 'arrow'
+
+            See File REST API for file_opts
+
+        """
+
+        tok = self.uploader.token
+
+        json_extended = {
+            'file_type': 'arrow',
+            **file_opts
+        }
+
+        res = requests.post(
+            self.uploader.server_base_path + '/api/v2/files/',
+            verify=self.uploader.certificate_validation,
+            headers={'Authorization': f'Bearer {tok}'},
+            json=json_extended)
+
+        try:            
+            out = res.json()
+            logger.debug('Server create file response: %s', out)
+            if not out['success']:
+                raise Exception(out)
+        except Exception as e:
+            logger.error('Failed creating file: %s', res.text, exc_info=True)
+            raise e
+        
+        self.dataset_id = out['data']['file_id']
+
+        return out
+
+    def post_arrow(self, arr: pa.Table, file_id: str, url_opts: str = 'erase=true') -> dict:
+        """
+            Upload new data to existing file id
+
+            Default url_opts='erase=true' throws exceptions on parse errors and deletes upload.
+
+            See File REST API for url_opts (file upload)
+        """
+
+        buf = self.uploader.arrow_to_buffer(arr)
+
+        tok = self.uploader.token
+        base_path = self.uploader.server_base_path
+
+        url = f'{base_path}/api/v2/upload/files/{file_id}'
+        if len(url_opts) > 0:
+            url = f'{url}?{url_opts}'
+
+        out = requests.post(
+            url,
+            verify=self.uploader.certificate_validation,
+            headers={'Authorization': f'Bearer {tok}'},
+            data=buf).json()
+        
+        if not out['success']:
+            raise Exception(out)
+            
+        return out
+
+    ###
+
+    def create_and_post_file(self, arr: pa.Table, file_id: str = None, file_opts: dict = {}, upload_url_opts: str = 'erase=true', memoize: bool = True) -> (str, dict):
+        """
+            Create file and upload data for it.
+
+            Default upload_url_opts='erase=true' throws exceptions on parse errors and deletes upload.
+
+            Default memoize=True skips uploading 'arr' when previously uploaded in current session
+
+            See File REST API for file_opts (file create) and upload_url_opts (file upload)
+        """
+
+        logger.warning('@create_and_post_file')
+        logger.warning('items: %s', [x for x in DF_TO_FILE_ID_CACHE.items()])
+
+        if memoize:
+            #FIXME if pa.Table was hashable, could do direct set/get map
+            for wrapped_table, val in DF_TO_FILE_ID_CACHE.items():
+                logger.warning('Checking: %s', wrapped_table)
+                if wrapped_table.arr is arr:
+                    return val.file_id, val.output
+
+        if file_id is None:
+            file_id = self.create_file(file_opts)
+        
+        resp = self.post_arrow(arr, file_id, upload_url_opts)
+        out = MemoizedFileUpload(file_id, resp)
+
+        if memoize:
+            wrapped = WrappedTable(out)
+            cache_arr(wrapped)
+            DF_TO_FILE_ID_CACHE[wrapped] = MemoizedFileUpload(file_id, out)
+            logger.debug('Memoized file %s', file_id)
+        
+        return out.file_id, out.output
+
+@lru_cache(maxsize=100)
+def cache_arr(arr):
+    """
+        Hack until RAPIDS supports Arrow 2.0, when pa.Table becomes weakly referenceable
+    """
+    return arr
+
+class WrappedTable():
+    arr : pa.Table
+    def __init__(self, arr: pa.Table):
+        self.arr = arr
+
+class MemoizedFileUpload():    
+    file_id: str
+    output: dict
+    def __init__(self, file_id: str, output: dict):
+        self.file_id = file_id
+        self.output = output

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -22,6 +22,10 @@ class ArrowFileUploader():
     """
         Implement file API with focus on Arrow support
 
+        Memoization in this class is based on reference equality, while plotter is based on hash.
+        That means the plotter resolves different-identity value matches, so by the time ArrowFileUploader compares,
+        identities are unified for faster reference-based checks.
+
         Example: Upload files with per-session memoization
             uploader : ArrowUploader
             arr : pa.Table
@@ -44,6 +48,7 @@ class ArrowFileUploader():
             afu.post_arrow(arr, file_id)
 
             assert file1_id != file2_id
+
     """
 
     uploader: ArrowUploader
@@ -159,6 +164,7 @@ class ArrowFileUploader():
 @lru_cache(maxsize=100)
 def cache_arr(arr):
     """
+        Hold reference to most recent memoization entries
         Hack until RAPIDS supports Arrow 2.0, when pa.Table becomes weakly referenceable
     """
     return arr

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -83,7 +83,7 @@ class ArrowFileUploader():
         try:            
             out = res.json()
             logger.debug('Server create file response: %s', out)
-            if not out['success']:
+            if (not 'success' in out) or (not out['success']):
                 raise Exception(out)
         except Exception as e:
             logger.error('Failed creating file: %s', res.text, exc_info=True)

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -136,10 +136,10 @@ class ArrowFileUploader():
         if memoize:
             #FIXME if pa.Table was hashable, could do direct set/get map
             for wrapped_table, val in DF_TO_FILE_ID_CACHE.items():
-                logger.warning('Checking: %s', wrapped_table)
                 if wrapped_table.arr is arr:
-                    logger.debug('Memoization hit: %s', val.file_id)
+                    logger.debug('arrow->file_id memoization hit: %s', val.file_id)
                     return val.file_id, val.output
+            logger.debug('arrow->file_id memoization miss (of %s)', len(DF_TO_FILE_ID_CACHE.items()))
 
         if file_id is None:
             file_id = self.create_file(file_opts)
@@ -151,7 +151,7 @@ class ArrowFileUploader():
             wrapped = WrappedTable(out)
             cache_arr(wrapped)
             DF_TO_FILE_ID_CACHE[wrapped] = MemoizedFileUpload(file_id, out)
-            logger.debug('Memoized file %s', file_id)
+            logger.debug('Memoized arrow->file_id %s', file_id)
         
         return out.file_id, out.output
 

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -84,16 +84,19 @@ class ArrowFileUploader():
 
         try:            
             out = res.json()
+            if res.status_code != requests.codes.ok:
+                res.raise_for_status()
+            if not out['is_valid']:
+                if out['is_uploaded']:
+                    raise RuntimeError("Uploaded file but cannot parse, see errors", out['errors'])
+                else:
+                    raise RuntimeError("Erased file upon failure, see errors", out['errors'])
             logger.debug('Server create file response: %s', out)
-            if (not 'success' in out) or (not out['success']):
-                raise Exception(out)
         except Exception as e:
             logger.error('Failed creating file: %s', res.text, exc_info=True)
             raise e
         
-        self.dataset_id = out['data']['file_id']
-
-        return out
+        return out['file_id']
 
     def post_arrow(self, arr: pa.Table, file_id: str, url_opts: str = 'erase=true') -> dict:
         """

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -139,7 +139,7 @@ class ArrowFileUploader():
                 if wrapped_table.arr is arr:
                     logger.debug('arrow->file_id memoization hit: %s', val.file_id)
                     return val.file_id, val.output
-            logger.debug('arrow->file_id memoization miss (of %s)', len(DF_TO_FILE_ID_CACHE.items()))
+            logger.debug('arrow->file_id memoization miss (of %s)', len(DF_TO_FILE_ID_CACHE))
 
         if file_id is None:
             file_id = self.create_file(file_opts)

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    import pyarrow as pa
     from .arrow_uploader import ArrowUploader
 
-import logging, requests
+import logging, pyarrow as pa, requests
 from functools import lru_cache
 from weakref import WeakKeyDictionary
 
@@ -51,9 +49,9 @@ class ArrowFileUploader():
 
     """
 
-    uploader: ArrowUploader
+    uploader: 'ArrowUploader'
 
-    def __init__(self, uploader: ArrowUploader):
+    def __init__(self, uploader: 'ArrowUploader'):
         self.uploader = uploader
 
     ###

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -148,7 +148,7 @@ class ArrowFileUploader():
         out = MemoizedFileUpload(file_id, resp)
 
         if memoize:
-            wrapped = WrappedTable(out)
+            wrapped = WrappedTable(arr)
             cache_arr(wrapped)
             DF_TO_FILE_ID_CACHE[wrapped] = MemoizedFileUpload(file_id, out)
             logger.debug('Memoized arrow->file_id %s', file_id)

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -128,7 +128,7 @@ class ArrowFileUploader():
                 else:
                     raise RuntimeError("Erased uploaded file contents upon failure (file_id still valid), see errors", out['errors'])
         except Exception as e:
-            logger.error('Failed creating file: %s', res.text, exc_info=True)
+            logger.error('Failed uploading file: %s', res.text, exc_info=True)
             raise e
 
         return out

--- a/graphistry/ArrowFileUploader.py
+++ b/graphistry/ArrowFileUploader.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .arrow_uploader import ArrowUploader
 
-import logging, pyarrow as pa, requests
+import logging, pyarrow as pa, requests, sys
 from functools import lru_cache
 from weakref import WeakKeyDictionary
 
@@ -71,6 +71,8 @@ class ArrowFileUploader():
 
         json_extended = {
             'file_type': 'arrow',
+            'agent_name': 'pygraphistry',
+            'agent_version': sys.modules['graphistry'].__version__,
             **file_opts
         }
 

--- a/graphistry/__init__.py
+++ b/graphistry/__init__.py
@@ -16,5 +16,6 @@ bolt, cypher,
 tigergraph, gsql, gsql_endpoint,
 nodexl,
 ArrowUploader,
+ArrowFileUploader,
 PyGraphistry
 )

--- a/graphistry/arrow_uploader.py
+++ b/graphistry/arrow_uploader.py
@@ -304,7 +304,7 @@ class ArrowUploader:
         return encodings
 
 
-    def post(self, as_files=True):
+    def post(self, as_files: bool = True, memoize: bool = True):
         """
             as_files deprecation plan:
                 Graphistry 2.34: Introduced

--- a/graphistry/arrow_uploader.py
+++ b/graphistry/arrow_uploader.py
@@ -316,10 +316,10 @@ class ArrowUploader:
 
             file_uploader = ArrowFileUploader(self)
 
-            e_file_id, _ = file_uploader.create_and_post_file(self.edges)
+            e_file_id, _ = file_uploader.create_and_post_file(self.edges, file_opts={'name': self.name + ' edges'})
 
             if not (self.nodes is None):
-                n_file_id, _ = file_uploader.create_and_post_file(self.nodes)
+                n_file_id, _ = file_uploader.create_and_post_file(self.nodes, file_opts={'name': self.name + ' nodes'})
 
             self.create_dataset({
                 "node_encodings": self.node_encodings,

--- a/graphistry/arrow_uploader.py
+++ b/graphistry/arrow_uploader.py
@@ -328,7 +328,7 @@ class ArrowUploader:
                 "name": self.name,
                 "description": self.description,
                 "edge_files": [ e_file_id ],
-                **({"node_files": [ n_file_id ] if not (self.nodes is None) else {}})
+                **({"node_files": [ n_file_id ] if not (self.nodes is None) else []})
             })
 
         else:

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1337,16 +1337,14 @@ class Plotter(object):
             if memoize:
                 #https://stackoverflow.com/questions/31567401/get-the-same-hash-value-for-a-pandas-dataframe-each-time
                 hashed = hashlib.sha256(pd.util.hash_pandas_object(table, index=True).values).hexdigest()
-                logger.warning('hash: %s', hashed)
                 
                 try:
-                    logger.warning('available: %s', [x for x in Plotter._pd_hash_to_arrow])
                     if hashed in Plotter._pd_hash_to_arrow:
                         return Plotter._pd_hash_to_arrow[hashed].v
                     else:
-                        logger.warning('pd->arrow memoization miss for id: %s', hashed)
+                        logger.debug('pd->arrow memoization miss for id: %s', hashed)
                 except:
-                    logger.warning('Failed to hash pdf', exc_info=True)
+                    logger.debug('Failed to hash pdf', exc_info=True)
                     1
 
             out = pa.Table.from_pandas(table, preserve_index=False).replace_schema_metadata({})
@@ -1355,7 +1353,6 @@ class Plotter(object):
                 w = WeakValueWrapper(out)
                 cache_coercion(hashed, w)
                 Plotter._pd_hash_to_arrow[hashed] = w
-                logger.warning('cached: %s', [x for x in Plotter._pd_hash_to_arrow])
 
             return out
 
@@ -1363,6 +1360,7 @@ class Plotter(object):
 
             hashed = None
             if memoize:
+                #https://stackoverflow.com/questions/31567401/get-the-same-hash-value-for-a-pandas-dataframe-each-time
                 hashed = hashlib.sha256(table.hash_columns().tobytes()).hexdigest()
                 try:
                     if hashed in Plotter._cudf_hash_to_arrow:

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1,4 +1,7 @@
-import copy, numpy, pandas, pyarrow as pa, sys, uuid
+import copy, hashlib, logging, numpy, pandas as pd, pyarrow as pa, sys, uuid
+from functools import lru_cache
+from weakref import WeakValueDictionary
+logger = logging.getLogger('Plotter')
 
 from .util import (error, in_ipython, make_iframe, random_string, warn)
 
@@ -21,6 +24,28 @@ try:
 except ImportError:
     1
 
+CACHE_COERCION_SIZE = 100
+
+
+_cache_coercion_val = None
+@lru_cache(maxsize=CACHE_COERCION_SIZE)
+def cache_coercion_helper(k):
+    return _cache_coercion_val
+
+def cache_coercion(k, v):
+    """
+        Holds references to last 100 used coercions
+        Use with weak key/value dictionaries for actual lookups
+    """
+    global _cache_coercion_val
+    _cache_coercion_val = v
+
+    return cache_coercion_helper(k)
+
+class WeakValueWrapper:
+    def __init__(self, v):
+        self.v = v
+
 class Plotter(object):
     """Graph plotting class.
 
@@ -30,12 +55,14 @@ class Plotter(object):
 
     To streamline reuse and replayable notebooks, Plotter manipulations are immutable. Each chained call returns a new instance that derives from the previous one. The old plotter or the new one can then be used to create different graphs.
 
+    When using memoization, for .register(api=3) sessions with .plot(memoize=True), Pandas/cudf arrow coercions are memoized, and file uploads are skipped on same-hash dataframes.
+
     The class supports convenience methods for mixing calls across Pandas, NetworkX, and IGraph.
     """
 
-
     _defaultNodeId = '__nodeid__'
-
+    _pd_hash_to_arrow = WeakValueDictionary()
+    _cudf_hash_to_arrow = WeakValueDictionary()
 
     def __init__(self):
         # Bindings
@@ -896,7 +923,7 @@ class Plotter(object):
         return res
 
 
-    def plot(self, graph=None, nodes=None, name=None, description=None, render=None, skip_upload=False, as_files=False):
+    def plot(self, graph=None, nodes=None, name=None, description=None, render=None, skip_upload=False, as_files=False, memoize=True):
         """Upload data to the Graphistry server and show as an iframe of it.
 
         Uses the currently bound schema structure and visual encodings.
@@ -922,8 +949,11 @@ class Plotter(object):
         :param skip_upload: Return node/edge/bindings that would have been uploaded. By default, upload happens.
         :type skip_upload: Boolean.
 
-        :param files: Upload distinct node/edge files and reuse them across different visualizations. Default off, will switch to default-on when stable.
+        :param as_files: Upload distinct node/edge files under the managed Files PI. Default off, will switch to default-on when stable.
         :type as_files: Boolean.
+
+        :param memoize: Tries to memoize pandas/cudf->arrow conversion, including skipping upload. Default on.
+        :type memoize: Boolean.
 
         **Example: Simple**
             ::
@@ -961,18 +991,18 @@ class Plotter(object):
         from .pygraphistry import PyGraphistry
         api_version = PyGraphistry.api_version()
         if api_version == 1:
-            dataset = self._plot_dispatch(g, n, name, description, 'json', self._style)
+            dataset = self._plot_dispatch(g, n, name, description, 'json', self._style, memoize)
             if skip_upload:
                 return dataset
             info = PyGraphistry._etl1(dataset)
         elif api_version == 2:
-            dataset = self._plot_dispatch(g, n, name, description, 'vgraph', self._style)
+            dataset = self._plot_dispatch(g, n, name, description, 'vgraph', self._style, memoize)
             if skip_upload:
                 return dataset
             info = PyGraphistry._etl2(dataset)
         elif api_version == 3:
             PyGraphistry.refresh()
-            dataset = self._plot_dispatch(g, n, name, description, 'arrow', self._style)
+            dataset = self._plot_dispatch(g, n, name, description, 'arrow', self._style, memoize)
             if skip_upload:
                 return dataset
             dataset.token = PyGraphistry.api_token()
@@ -1067,9 +1097,9 @@ class Plotter(object):
 
         edata = get_edgelist(ig)
         ndata = [v.attributes() for v in ig.vs]
-        nodes = pandas.DataFrame(ndata, columns=ig.vs.attributes())
+        nodes = pd.DataFrame(ndata, columns=ig.vs.attributes())
         cols = [self._source, self._destination] + ig.es.attributes()
-        edges = pandas.DataFrame(edata, columns=cols)
+        edges = pd.DataFrame(edata, columns=cols)
         return (edges, nodes)
 
 
@@ -1099,8 +1129,8 @@ class Plotter(object):
         self.networkx_checkoverlap(g)
         
         self._node = self._node or Plotter._defaultNodeId
-        nodes = pandas.DataFrame(get_nodelist(g))
-        edges = pandas.DataFrame(get_edgelist(g))
+        nodes = pd.DataFrame(get_nodelist(g))
+        edges = pd.DataFrame(get_edgelist(g))
         return (edges, nodes)
 
 
@@ -1119,18 +1149,18 @@ class Plotter(object):
                 error('%s attribute "%s" bound to "%s" does not exist.' % (typ, a, b))
 
 
-    def _plot_dispatch(self, graph, nodes, name, description, mode='json', metadata=None):
+    def _plot_dispatch(self, graph, nodes, name, description, mode='json', metadata=None, memoize=True):
 
-        if isinstance(graph, pandas.core.frame.DataFrame) \
+        if isinstance(graph, pd.core.frame.DataFrame) \
             or isinstance(graph, pa.Table) \
             or ( not (maybe_cudf is None) and isinstance(graph, maybe_cudf.DataFrame) ):
-            return self._make_dataset(graph, nodes, name, description, mode, metadata)
+            return self._make_dataset(graph, nodes, name, description, mode, metadata, memoize)
 
         try:
             import igraph
             if isinstance(graph, igraph.Graph):
                 (e, n) = self.igraph2pandas(graph)
-                return self._make_dataset(e, n, name, description, mode, metadata)
+                return self._make_dataset(e, n, name, description, mode, metadata. memoize)
         except ImportError:
             pass
 
@@ -1141,7 +1171,7 @@ class Plotter(object):
                isinstance(graph, networkx.classes.multigraph.MultiGraph) or \
                isinstance(graph, networkx.classes.multidigraph.MultiDiGraph):
                 (e, n) = self.networkx2pandas(graph)
-                return self._make_dataset(e, n, name, description, mode, metadata)
+                return self._make_dataset(e, n, name, description, mode, metadata, memoize)
         except ImportError:
             pass
 
@@ -1160,11 +1190,11 @@ class Plotter(object):
                      .dropna(subset=[self._source, self._destination])
 
         obj_df = elist.select_dtypes(include=[numpy.object_])
-        elist[obj_df.columns] = obj_df.apply(pandas.to_numeric, errors='ignore')
+        elist[obj_df.columns] = obj_df.apply(pd.to_numeric, errors='ignore')
 
         if nodes is None:
-            nodes = pandas.DataFrame()
-            nodes[nodeid] = pandas.concat([edges[self._source], edges[self._destination]],
+            nodes = pd.DataFrame()
+            nodes[nodeid] = pd.concat([edges[self._source], edges[self._destination]],
                                            ignore_index=True).drop_duplicates()
         else:
             self._check_bound_attribs(nodes, ['node'], 'Vertex')
@@ -1174,7 +1204,7 @@ class Plotter(object):
                      .drop_duplicates(subset=[nodeid])
 
         obj_df = nlist.select_dtypes(include=[numpy.object_])
-        nlist[obj_df.columns] = obj_df.apply(pandas.to_numeric, errors='ignore')
+        nlist[obj_df.columns] = obj_df.apply(pd.to_numeric, errors='ignore')
 
         return (elist, nlist)
 
@@ -1277,12 +1307,12 @@ class Plotter(object):
         }
         return (elist, nlist, encodings)
 
-    def _table_to_pandas(self, table) -> pandas.DataFrame:
+    def _table_to_pandas(self, table) -> pd.DataFrame:
 
         if table is None:
             return table
 
-        if isinstance(table, pandas.DataFrame):
+        if isinstance(table, pd.DataFrame):
             return table
 
         if isinstance(table, pa.Table):
@@ -1293,24 +1323,69 @@ class Plotter(object):
         
         raise Exception('Unknown type %s: Could not convert data to Pandas dataframe' % str(type(table)))
 
-    def _table_to_arrow(self, table) -> pa.Table:
+    def _table_to_arrow(self, table, memoize = True) -> pa.Table:
 
         if table is None:
             return table
 
         if isinstance(table, pa.Table):
+            #TODO: should we hash just in case there's an older-identity hash match?
             return table
         
-        if isinstance(table, pandas.DataFrame):
-            return pa.Table.from_pandas(table, preserve_index=False).replace_schema_metadata({})
+        if isinstance(table, pd.DataFrame):
+            hashed = None
+            if memoize:
+                #https://stackoverflow.com/questions/31567401/get-the-same-hash-value-for-a-pandas-dataframe-each-time
+                hashed = hashlib.sha256(pd.util.hash_pandas_object(table, index=True).values).hexdigest()
+                logger.warning('hash: %s', hashed)
+                
+                try:
+                    logger.warning('available: %s', [x for x in Plotter._pd_hash_to_arrow])
+                    if hashed in Plotter._pd_hash_to_arrow:
+                        return Plotter._pd_hash_to_arrow[hashed].v
+                    else:
+                        logger.warning('pd->arrow memoization miss for id: %s', hashed)
+                except:
+                    logger.warning('Failed to hash pdf', exc_info=True)
+                    1
+
+            out = pa.Table.from_pandas(table, preserve_index=False).replace_schema_metadata({})
+
+            if memoize:
+                w = WeakValueWrapper(out)
+                cache_coercion(hashed, w)
+                Plotter._pd_hash_to_arrow[hashed] = w
+                logger.warning('cached: %s', [x for x in Plotter._pd_hash_to_arrow])
+
+            return out
 
         if not (maybe_cudf is None) and isinstance(table, maybe_cudf.DataFrame):
-            return table.to_arrow()
+
+            hashed = None
+            if memoize:
+                hashed = hashlib.sha256(table.hash_columns().tobytes()).hexdigest()
+                try:
+                    if hashed in Plotter._cudf_hash_to_arrow:
+                        return Plotter._cudf_hash_to_arrow[hashed].v
+                    else:
+                        logger.debug('cudf->arrow memoization miss for id: %s', hashed)
+                except:
+                    logger.debug('Failed to hash cudf', exc_info=True)
+                    1
+
+            out = table.to_arrow()
+
+            if memoize:
+                w = WeakValueWrapper(out)
+                cache_coercion(hashed, w)
+                Plotter._cudf_hash_to_arrow[hashed] = w
+
+            return out
         
         raise Exception('Unknown type %s: Could not convert data to Arrow' % str(type(table)))
 
 
-    def _make_dataset(self, edges, nodes, name, description, mode, metadata=None):
+    def _make_dataset(self, edges, nodes, name, description, mode, metadata=None, memoize=True):
         try:
             if len(edges) == 0:
                 warn('Graph has no edges, may have rendering issues')
@@ -1338,8 +1413,8 @@ class Plotter(object):
             nodes_df = self._table_to_pandas(nodes)
             return self._make_vgraph_dataset(edges_df, nodes_df, name)
         elif mode == 'arrow':
-            edges_arr = self._table_to_arrow(edges)
-            nodes_arr = self._table_to_arrow(nodes)
+            edges_arr = self._table_to_arrow(edges, memoize)
+            nodes_arr = self._table_to_arrow(nodes, memoize)
             return self._make_arrow_dataset(edges=edges_arr, nodes=nodes_arr, name=name, description=description, metadata=metadata)
             #token=None, dataset_id=None, url_params = None)
         else:
@@ -1352,7 +1427,7 @@ class Plotter(object):
         from .pygraphistry import PyGraphistry
 
         (elist, nlist) = self._bind_attributes_v1(edges, nodes)
-        edict = elist.where((pandas.notnull(elist)), None).to_dict(orient='records')
+        edict = elist.where((pd.notnull(elist)), None).to_dict(orient='records')
 
         bindings = {'idField': self._node or Plotter._defaultNodeId,
                     'destinationField': self._destination, 'sourceField': self._source}
@@ -1360,7 +1435,7 @@ class Plotter(object):
                    'bindings': bindings, 'type': 'edgelist', 'graph': edict}
 
         if nlist is not None:
-            ndict = nlist.where((pandas.notnull(nlist)), None).to_dict(orient='records')
+            ndict = nlist.where((pd.notnull(nlist)), None).to_dict(orient='records')
             dataset['labels'] = ndict
         return dataset
 
@@ -1377,9 +1452,9 @@ class Plotter(object):
         elist.drop([self._source, self._destination], axis=1, inplace=True)
 
         # Filter out nodes which have no edges
-        lnodes = pandas.concat([sources, dests], ignore_index=True).unique()
-        lnodes_df = pandas.DataFrame(lnodes, columns=[nodeid])
-        filtered_nlist = pandas.merge(lnodes_df, nlist, on=nodeid, how='left')
+        lnodes = pd.concat([sources, dests], ignore_index=True).unique()
+        lnodes_df = pd.DataFrame(lnodes, columns=[nodeid])
+        filtered_nlist = pd.merge(lnodes_df, nlist, on=nodeid, how='left')
 
         # Create a map from nodeId to a continuous range of integer [0, #nodes-1].
         # The vgraph protobuf format uses the continous integer ranger as internal nodeIds.
@@ -1393,7 +1468,7 @@ class Plotter(object):
 
         from .pygraphistry import PyGraphistry
 
-        au = ArrowUploader(
+        au : ArrowUploader = ArrowUploader(
             server_base_path=PyGraphistry.protocol() + '://' + PyGraphistry.server(),
             edges=edges, nodes=nodes,
             name=name, description=description,

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1340,6 +1340,7 @@ class Plotter(object):
                 
                 try:
                     if hashed in Plotter._pd_hash_to_arrow:
+                        logger.debug('pd->arrow memoization hit: %s', hashed)
                         return Plotter._pd_hash_to_arrow[hashed].v
                     else:
                         logger.debug('pd->arrow memoization miss for id: %s', hashed)
@@ -1364,6 +1365,7 @@ class Plotter(object):
                 hashed = hashlib.sha256(table.hash_columns().tobytes()).hexdigest()
                 try:
                     if hashed in Plotter._cudf_hash_to_arrow:
+                        logger.debug('cudf->arrow memoization hit: %s', hashed)
                         return Plotter._cudf_hash_to_arrow[hashed].v
                     else:
                         logger.debug('cudf->arrow memoization miss for id: %s', hashed)

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -896,7 +896,7 @@ class Plotter(object):
         return res
 
 
-    def plot(self, graph=None, nodes=None, name=None, description=None, render=None, skip_upload=False):
+    def plot(self, graph=None, nodes=None, name=None, description=None, render=None, skip_upload=False, as_files=False):
         """Upload data to the Graphistry server and show as an iframe of it.
 
         Uses the currently bound schema structure and visual encodings.
@@ -920,7 +920,10 @@ class Plotter(object):
         :type render: Boolean
 
         :param skip_upload: Return node/edge/bindings that would have been uploaded. By default, upload happens.
-        :type skip_upload: Boolean. 
+        :type skip_upload: Boolean.
+
+        :param files: Upload distinct node/edge files and reuse them across different visualizations. Default off, will switch to default-on when stable.
+        :type as_files: Boolean.
 
         **Example: Simple**
             ::
@@ -972,9 +975,8 @@ class Plotter(object):
             dataset = self._plot_dispatch(g, n, name, description, 'arrow', self._style)
             if skip_upload:
                 return dataset
-            #fresh
             dataset.token = PyGraphistry.api_token()
-            dataset.post()
+            dataset.post(as_files=as_files)
             info = {
                 'name': dataset.dataset_id,
                 'type': 'arrow',

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1343,7 +1343,7 @@ class Plotter(object):
                         logger.debug('pd->arrow memoization hit: %s', hashed)
                         return Plotter._pd_hash_to_arrow[hashed].v
                     else:
-                        logger.debug('pd->arrow memoization miss for id: %s', hashed)
+                        logger.debug('pd->arrow memoization miss for id (of %s): %s', len(Plotter._pd_hash_to_arrow), hashed)
                 except:
                     logger.debug('Failed to hash pdf', exc_info=True)
                     1
@@ -1368,7 +1368,7 @@ class Plotter(object):
                         logger.debug('cudf->arrow memoization hit: %s', hashed)
                         return Plotter._cudf_hash_to_arrow[hashed].v
                     else:
-                        logger.debug('cudf->arrow memoization miss for id: %s', hashed)
+                        logger.debug('cudf->arrow memoization miss for id (of %s): %s', len(Plotter._cudf_hash_to_arrow), hashed)
                 except:
                     logger.debug('Failed to hash cudf', exc_info=True)
                     1

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1006,7 +1006,7 @@ class Plotter(object):
             if skip_upload:
                 return dataset
             dataset.token = PyGraphistry.api_token()
-            dataset.post(as_files=as_files)
+            dataset.post(as_files=as_files, memoize=memoize)
             info = {
                 'name': dataset.dataset_id,
                 'type': 'arrow',
@@ -1323,7 +1323,9 @@ class Plotter(object):
         
         raise Exception('Unknown type %s: Could not convert data to Pandas dataframe' % str(type(table)))
 
-    def _table_to_arrow(self, table, memoize = True) -> pa.Table:
+    def _table_to_arrow(self, table: any, memoize: bool = True) -> pa.Table:
+
+        logger.debug('_table_to_arrow of %s (memoize: %s)', type(table), memoize)
 
         if table is None:
             return table
@@ -1385,7 +1387,11 @@ class Plotter(object):
         raise Exception('Unknown type %s: Could not convert data to Arrow' % str(type(table)))
 
 
-    def _make_dataset(self, edges, nodes, name, description, mode, metadata=None, memoize=True):
+    def _make_dataset(self, edges, nodes, name, description, mode, metadata=None, memoize: bool = True):
+
+        logger.debug('_make_dataset (mode %s, memoize %s) name:[%s] des:[%s] (e::%s, n::%s) ',
+            mode, memoize, name, description, type(edges), type(nodes))
+
         try:
             if len(edges) == 0:
                 warn('Graph has no edges, may have rendering issues')

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from distutils.util import strtobool
 
 from .arrow_uploader import ArrowUploader
+from .ArrowFileUploader import ArrowFileUploader
 
 from . import util
 from . import bolt_util

--- a/graphistry/tests/test_ArrowFileUploader.py
+++ b/graphistry/tests/test_ArrowFileUploader.py
@@ -1,0 +1,21 @@
+
+import mock, pandas as pd, pyarrow as pa, pytest, unittest
+
+import graphistry
+from common import NoAuthTestCase
+from graphistry.arrow_uploader import ArrowUploader
+from graphistry.ArrowFileUploader import ArrowFileUploader, DF_TO_FILE_ID_CACHE, MemoizedFileUpload, WrappedTable, cache_arr
+
+#TODO mock requests for testing actual effectful code
+
+class TestArrowFileUploader_Core(unittest.TestCase):
+    def test_memoization(self):
+
+        afu = ArrowFileUploader(ArrowUploader(token='xx'))
+
+        arr = pa.Table.from_pandas(pd.DataFrame({'x': [1,2,3]}))
+        wa = WrappedTable(arr)
+        cache_arr(wa)
+        DF_TO_FILE_ID_CACHE[ wa ] = MemoizedFileUpload('a', 'b')
+
+        assert afu.create_and_post_file(arr) == ('a', 'b')

--- a/graphistry/tests/test_ArrowFileUploader.py
+++ b/graphistry/tests/test_ArrowFileUploader.py
@@ -14,8 +14,8 @@ class TestArrowFileUploader_Core(unittest.TestCase):
         afu = ArrowFileUploader(ArrowUploader(token='xx'))
 
         arr = pa.Table.from_pandas(pd.DataFrame({'x': [1,2,3]}))
-        wa = WrappedTable(arr)
-        cache_arr(wa)
-        DF_TO_FILE_ID_CACHE[ wa ] = MemoizedFileUpload('a', 'b')
+
+        #avoid directly holding references
+        DF_TO_FILE_ID_CACHE[ cache_arr(WrappedTable(arr)) ] = MemoizedFileUpload('a', 'b')
 
         assert afu.create_and_post_file(arr) == ('a', 'b')

--- a/graphistry/tests/test_plotter.py
+++ b/graphistry/tests/test_plotter.py
@@ -414,6 +414,9 @@ class TestPlotterArrowConversions(NoAuthTestCase):
         assert isinstance(arr1, pa.Table)
         assert arr1 is arr2
 
+        arr3 = plotter._table_to_arrow(pd.DataFrame({'x': [1]}))
+        assert arr1 is arr3
+
     def test_api3_pdf_to_arrow_memoization_forgets(self):
         plotter = graphistry.bind()
         df = pd.DataFrame({'x': [0]})
@@ -441,6 +444,9 @@ class TestPlotterArrowConversions(NoAuthTestCase):
         arr2 = plotter._table_to_arrow(df)
         assert isinstance(arr1, pa.Table)
         assert arr1 is arr2
+
+        arr3 = plotter._table_to_arrow(maybe_cudf.DataFrame({'x': [1]}))
+        assert arr1 is arr3
 
     @pytest.mark.skipif(maybe_cudf is None, reason="requires cudf")
     def test_api3_cudf_to_arrow_memoization_forgets(self):


### PR DESCRIPTION
Starts using new file upload API for `api=3` plots, including memoization to skip file reuploads from the same session.

Partially addresses https://github.com/graphistry/pygraphistry/issues/188 .

Current testing shows:
-- Best case: ~9X speedup (100% hits for a bunch of 100K-row uploads: `50s` -> `6s`)
-- Pathological worst case (hashing cost for 100% misses on same): 1% slower


## Usage

### Friendly API

```python
graphistry.register(api=3)
g.name('mygraph').edges(arr2, source='x', destination='y').plot(as_files=True)
```

This will:

* upload edges.arrow (and optional nodes.arrow) as new managed Files with name `"mygraph edges"` (`"mygraph nodes"`)
* upon reupload of same arr (by ref) in a session, reuse the file_id
* provide metadata similar to dataset metadata

### Automatic memoization

Defaults to on via `.plot(memoize=True)`. 

For plots using the File API, memoization turns on tracking of whether a table was previously uploaded as a File in the session and then avoids reuploading it, instead using a reference to its file ID.  This can save significant time, network transfers, & storage. Comparison does require a hash computation: if problematic, disable via `memoize=False`.

Example: 

```python
g = graphistry.edges(df, 'user', 'ip').bind(point_color='col1').name('mygraph')
g.plot(as_files=True)
# uploads file `"mygraph edges"` and creates + shows viz

graphistry.edges(df, 'user', 'address').plot(as_files=True) 
# detects reuse of df then skips reuploading it in favor of pointing to uploaded file `"mygraph edges"`
```

Equality comparison in `.plot()` happens via:

* `pa.Table`: By identity (`arr1 is arr2`)
* `pd.DataFrame` / `cudf.DataFrame`: By value hash

When using the underlying APIs like `ArrowFileUploader`, comparison is by reference.

### Low-level API

Upload files with per-session memoization
```python
    uploader : ArrowUploader
    arr : pa.Table
    afu = ArrowFileUploader(uploader)

    file1_id = afu.create_and_post_file(arr)[0]
    file2_id = afu.create_and_post_file(arr)[0]

    assert file1_id == file2_id # memoizes by default (memory-safe: weak refs)
```

Explicitly create a file and upload data for it
```python
    uploader : ArrowUploader
    arr : pa.Table
    afu = ArrowFileUploader(uploader)

    file1_id = afu.create_file()
    afu.post_arrow(arr, file_id)

    file2_id = afu.create_file()
    afu.post_arrow(arr, file_id)

    assert file1_id != file2_id
```

## Defaults

* Usage of is currently default-off (`plot(as_files=False)`)
* Memoization is default-on (`plot(memoize=True)`), and only acts when `as_files` is triggered

When considered stable, both settings will switch to default on, and most likely, always-on.


## Not done

* RAPIDS is on pyarrow 1.7, while only pyarrow 2.0 makes pa.Table weakly referenceable. So this  uses `lru_cache(maxsize=100)` and hash checks, vs. being entirely identity-based