### PR TITLE
Dev/neo4j warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,7 @@ jobs:
       ##pytest
       run: |
         python -B -m pytest -vv
+
+    - name: Neo4j connector tests
+      run: |
+        cd docker && WITH_SUDO=" " ./test-cpu-local-neo4j-only.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
       run: |
         python -B -m pytest -vv
 
+
+  test-neo4j:
+
+    needs: [ authorize-collaborators ]  # Wait on test-core-python / run flake8?
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
     - name: Neo4j connector tests
       run: |
         cd docker && WITH_SUDO=" " ./test-cpu-local-neo4j-only.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+* Friendlier error message for calling .cypher(...) without setting BOLT auth/driver (https://github.com/graphistry/pygraphistry/issues/204) 
+
+### Fixed
+
+* Memoization: When memoize hashes throw exceptions, emit warning and fallback to unmemoized (b7a25c74e)
+
+## [0.16.1] - 2021-02-07
+
+### Added
+
 * Friendlier error message for api=1, 2 server non-json responses (https://github.com/graphistry/pygraphistry/pull/187)
-* CI: Moved to GitHub Actions
+* CI: Moved to GitHub Actions for CI + optional manual publish
+* CI: Added Python 3.9 to test matrix
+* Infrastructure: Upgraded Versioneer to 0.19
 * Infrastructure: Fewer warnings and enforce flake8 CI checks
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 * Friendlier error message for calling .cypher(...) without setting BOLT auth/driver (https://github.com/graphistry/pygraphistry/issues/204) 
+* CI: Run containerized neo4j connector tests
+* Infrastructure: Set Python 3.9 support metadata
 
 ### Fixed
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,6 +2,8 @@
 
 Dev is moving towards docker for easier tasks like CI automation integrations and reliable local dev
 
+You can still do native dev; inspect `docker/` or `.github/workflows/` for latest commands
+
 ## Docker
 
 ### Install
@@ -15,7 +17,7 @@ cd docker && docker-compose build && docker-compose up -d
 cd docker && ./test-cpu-local.sh
 ```
 
-Connector tests (currently neo4j-only): `cd docker && WITH_NEO4J=1 ./test-cpu-local.sh`
+Connector tests (currently neo4j-only): `cd docker && WITH_NEO4J=1 ./test-cpu-local.sh` (optional `WITH_SUDO=" "`)
 
 * Will start a local neo4j (docker) then enable+run tests against it
 
@@ -44,7 +46,7 @@ To manually build, see `docs/`.
 
 ## CI
 
-We intend to move to Github Actions / DockerHub Automated Builds for CPU and TBD for GPU
+GitHub Actions: See `.github/workflows`
 
 
 ## Debugging Tips
@@ -52,9 +54,6 @@ We intend to move to Github Actions / DockerHub Automated Builds for CPU and TBD
 * Use the unit tests
 * use the `logging` module per-file
 
-### Travis - DEPRECATED
-
-Travis CI automatically runs on every branch (with a Travis CI file). To configure, go to the [Travis CI account](https://travis-ci.org/graphistry/pygraphistry) .
 
 ### Native - Uninstall Git Checkout - DEPRECATED
 
@@ -73,7 +72,7 @@ Uninstall the local checkout (useful to rollback to packaged version) with `./se
 	git push --tags
 	```
 
-1. Automatically picked up by pypi. To do manually, run the Publish action from github on the master branch
+1. Check pypi automatically got the update. If not, manually run the Publish action from github on the master branch
 
 1. Toggle version as active at [ReadTheDocs](https://readthedocs.org/projects/pygraphistry/versions/)
 

--- a/docker/test-cpu-entrypoint.sh
+++ b/docker/test-cpu-entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -ex
 
 python -B -m pytest -vv $@

--- a/docker/test-cpu-local-neo4j-only.sh
+++ b/docker/test-cpu-local-neo4j-only.sh
@@ -1,24 +1,23 @@
 #!/bin/bash
+set -ex
 
-# Run tests using local mounts
+WITH_NEO4J=1
+WITH_SUDO=${WITH_SUDO:-sudo}
 
-WITH_NEO4J=${WITH_NEO4J:-0}
-
-if [ "$WITH_NEO4J" == "1" ]
-then
-    ( cd ../test/db/neo4j && ./launch.sh )
-fi
+( cd ../test/db/neo4j && WITH_SUDO="$WITH_SUDO" ./launch.sh )
 
 docker-compose build
 
 TEST_CPU_VERSION=${TEST_CPU_VERSION:-latest}
 
-docker run \
+${WITH_SUDO} docker run \
     -e PYTEST_CURRENT_TEST=TRUE \
-    -e WITH_NEO4J=$WITH_NEO4J \
+    -e WITH_NEO4J=1 \
     --rm -it \
     -v ${PWD}/..:/opt/pygraphistry-mounted:ro \
     -w /opt/pygraphistry-mounted \
     --net grph_net \
     graphistry/test-cpu:${TEST_CPU_VERSION} \
-        --maxfail=5 $@
+        --maxfail=5 \
+        graphistry/tests/test_bolt_util.py \
+        $@

--- a/docker/test-cpu-local-neo4j-only.sh
+++ b/docker/test-cpu-local-neo4j-only.sh
@@ -13,7 +13,7 @@ TEST_CPU_VERSION=${TEST_CPU_VERSION:-latest}
 ${WITH_SUDO} docker run \
     -e PYTEST_CURRENT_TEST=TRUE \
     -e WITH_NEO4J=1 \
-    --rm -it \
+    --rm \
     -v ${PWD}/..:/opt/pygraphistry-mounted:ro \
     -w /opt/pygraphistry-mounted \
     --net grph_net \

--- a/docker/test-cpu-local.sh
+++ b/docker/test-cpu-local.sh
@@ -16,7 +16,7 @@ TEST_CPU_VERSION=${TEST_CPU_VERSION:-latest}
 docker run \
     -e PYTEST_CURRENT_TEST=TRUE \
     -e WITH_NEO4J=$WITH_NEO4J \
-    --rm -it \
+    --rm \
     -v ${PWD}/..:/opt/pygraphistry-mounted:ro \
     -w /opt/pygraphistry-mounted \
     --net grph_net \

--- a/docker/test-cpu.Dockerfile
+++ b/docker/test-cpu.Dockerfile
@@ -19,4 +19,4 @@ COPY docker/test-cpu-entrypoint.sh /entrypoint/test-cpu-entrypoint.sh
 COPY graphistry ./graphistry
 COPY pytest.ini .
 
-ENTRYPOINT /entrypoint/test-cpu-entrypoint.sh
+ENTRYPOINT ["/entrypoint/test-cpu-entrypoint.sh"]

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1505,6 +1505,8 @@ class Plotter(object):
 
         res = copy.copy(self)
         driver = self._bolt_driver or PyGraphistry._config['bolt_driver']
+        if driver is None:
+            raise ValueError("BOLT connection information not provided. Must first call graphistry.register(bolt=...) or g.bolt(...).")
         with driver.session() as session:
             bolt_statement = session.run(query, **params)
             graph = bolt_statement.graph()

--- a/graphistry/plotter.py
+++ b/graphistry/plotter.py
@@ -1340,9 +1340,13 @@ class Plotter(object):
         if isinstance(table, pd.DataFrame):
             hashed = None
             if memoize:
-                #https://stackoverflow.com/questions/31567401/get-the-same-hash-value-for-a-pandas-dataframe-each-time
-                hashed = hashlib.sha256(pd.util.hash_pandas_object(table, index=True).values).hexdigest()
                 
+                try:
+                    #https://stackoverflow.com/questions/31567401/get-the-same-hash-value-for-a-pandas-dataframe-each-time
+                    hashed = hashlib.sha256(pd.util.hash_pandas_object(table, index=True).values).hexdigest()
+                except TypeError:
+                    logger.warn('Failed memoization speedup attempt due to Pandas internal hash function failing. Continuing without memoization speedups.', exc_info=True)
+
                 try:
                     if hashed in Plotter._pd_hash_to_arrow:
                         logger.debug('pd->arrow memoization hit: %s', hashed)
@@ -1355,7 +1359,7 @@ class Plotter(object):
 
             out = pa.Table.from_pandas(table, preserve_index=False).replace_schema_metadata({})
 
-            if memoize:
+            if memoize and (hashed is not None):
                 w = WeakValueWrapper(out)
                 cache_coercion(hashed, w)
                 Plotter._pd_hash_to_arrow[hashed] = w

--- a/graphistry/tests/test_plotter.py
+++ b/graphistry/tests/test_plotter.py
@@ -344,6 +344,10 @@ class TestPlotterConversions(NoAuthTestCase):
         assertFrameEqual(e, edges)
         assertFrameEqual(n, nodes)
 
+    def test_cypher_unconfigured(self):
+        with pytest.raises(ValueError):
+            graphistry.bind().cypher("MATCH (a)-[b]-(c) RETURN a,b,c")
+
 
 class TestPlotterNameBindings(NoAuthTestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Visualization',
         'Topic :: Scientific/Engineering :: Information Analysis',
     ],

--- a/test/db/neo4j/launch.sh
+++ b/test/db/neo4j/launch.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -ex
 
-sudo docker-compose -f neo4j4.yml down -v || exit 1
-sudo docker-compose -f neo4j4.yml up -d || exit 1
-sudo ./wait_neo4j.sh
-sudo NEO4J_PORT=10006 ./add_data.sh || exit 1
+WITH_SUDO=${WITH_SUDO:-sudo}
+
+${WITH_SUDO} docker-compose -f neo4j4.yml down -v || exit 1
+${WITH_SUDO} docker-compose -f neo4j4.yml up -d || exit 1
+${WITH_SUDO} ./wait_neo4j.sh
+NEO4J_PORT=10006 ./add_data.sh || exit 1


### PR DESCRIPTION
Add:
- Friendly error for `cypher()` without first setting bolt (https://github.com/graphistry/pygraphistry/issues/204)
- Metadata for Python 3.9 support

Fix:
- Sometimes memoization failed on df's due to pandas internally throwing an exn on hash. Instead, log a warning and handle call without memoization.

Infra:
- Run neo4j tests (https://github.com/graphistry/pygraphistry/issues/196)

Docs:
- Changelog
- Dev for GHA