### PR TITLE
feat(hypergraph): vectorize pandas and add cudf impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Hypergraph: cudf/dask/dask_cudf
 
 ### Added
-* CI: mypy type checking
-* CI: GPU test harness
+
+* Infra: Engine class for picking dataframe engine - pandas/cudf/dask/dask_cudf
+* Feature: cudf mode for hypergraph
+* Feature: pandas mode for hypergraph uses all-vectorized operations
+* CI: mypy type checking (https://github.com/graphistry/pygraphistry/pull/222)
+* CI: GPU test harness (https://github.com/graphistry/pygraphistry/pull/223)
+
+### Changed
+
+* Hypergraph: Uses new pandas/cudf implementations
 
 ## [0.17.0 - 2021-02-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Improved error message: Include response body on failed arrow.post()
 * Hypergraph: cudf/dask/dask_cudf
 
+## [0.18.0 - 2021-03-21]
+
 ### Added
 
-* Infra: Engine class for picking dataframe engine - pandas/cudf/dask/dask_cudf
-* Feature: cudf mode for hypergraph
-* Feature: pandas mode for hypergraph uses all-vectorized operations
+* Feature: cudf mode for hypergraph (https://github.com/graphistry/pygraphistry/pull/224)
+* Feature: pandas mode for hypergraph uses all-vectorized operations (https://github.com/graphistry/pygraphistry/pull/224)
+* Infra: Engine class for picking dataframe engine - pandas/cudf/dask/dask_cudf (https://github.com/graphistry/pygraphistry/pull/224)
 * CI: mypy type checking (https://github.com/graphistry/pygraphistry/pull/222)
 * CI: GPU test harness (https://github.com/graphistry/pygraphistry/pull/223)
 
 ### Changed
 
-* Hypergraph: Uses new pandas/cudf implementations
+* Hypergraph: Uses new pandas/cudf implementations (https://github.com/graphistry/pygraphistry/pull/224)
 
 ## [0.17.0 - 2021-02-08]
 

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from enum import Enum
+
+
+class Engine(Enum):
+    PANDAS : str = 'pandas'
+    CUDF : str = 'cudf'
+    DASK : str = 'dask'
+    DASK_CUDF : str = 'dask_cudf'
+
+
+DataframeLike = Any  # pdf, cudf, ddf, dgdf
+DataframeLocalLike = Any  # pdf, cudf
+GraphistryLke = Any

--- a/graphistry/hyper.py
+++ b/graphistry/hyper.py
@@ -1,230 +1,30 @@
-import logging, pandas as pd, sys
+import logging
+from typing import List, Optional
+from graphistry.hyper_dask import hypergraph as hypergraph_new
 logger = logging.getLogger(__name__)
 
-# COMMON TO HYPERGRAPH AND SIMPLE GRAPH
-def makeDefs(DEFS, opts={}):
-    defs = {key: opts[key] if key in opts else DEFS[key] for key in DEFS}    
-    base_skip = opts['SKIP'] if 'SKIP' in opts else defs['SKIP']
-    skip = [x for x in base_skip]  # copy
-    defs['SKIP'] = skip
-    for key in DEFS:
-        if not defs[key] in skip:
-            skip.append(defs[key])
-    return defs
 
-def screen_entities(events, entity_types, defs):
-    base = entity_types if entity_types is not None else events.columns
-    return [x for x in base if x not in defs['SKIP']]
-
-
-def col2cat(cat_lookup, col):
-    return cat_lookup[col] if col in cat_lookup else col
-
-def make_reverse_lookup(categories):
-    lookup = {}
-    for category in categories:
-        for col in categories[category]:
-            lookup[col] = category
-    return lookup
-
-
-def valToSafeStr(v):
-    if sys.version_info < (3,0):
-        t = type(v)
-        if t is unicode:  # noqa: F821
-            return v
-        elif t is str:
-            return v
-        else:
-            return repr(v)
-    else:
-        t = type(v)
-        if t is str:
-            return v
-        else:
-            return repr(v)
-
-
-#ex output: pd.DataFrame([{'val::state': 'CA', 'nodeType': 'state', 'nodeID': 'state::CA'}])
-def format_entities(events, entity_types, defs, drop_na):
-    cat_lookup = make_reverse_lookup(defs['CATEGORIES'])
-    lst = sum([[
-        {
-            col: v,
-            defs['TITLE']: valToSafeStr(v),
-            defs['NODETYPE']: col,
-            defs['NODEID']: col2cat(cat_lookup, col) + defs['DELIM'] + valToSafeStr(v)
-        }
-        for v in events[col].unique() if not drop_na or (not (v is None) and valToSafeStr(v) != 'nan')] for col in entity_types], [])
-    df = pd.DataFrame(lst).drop_duplicates([defs['NODEID']])
-    df[defs['CATEGORY']] = df[defs['NODETYPE']].apply(lambda col: col2cat(cat_lookup, col))
-    return df
-
-
-DEFS_HYPER = {
-    'TITLE': 'nodeTitle',
-    'DELIM': '::',
-    'NODEID': 'nodeID',
-    'ATTRIBID': 'attribID',
-    'EVENTID': 'EventID',
-    'SOURCE': 'src',
-    'DESTINATION': 'dst',
-    'CATEGORY': 'category',
-    'NODETYPE': 'type',
-    'EDGETYPE': 'edgeType',
-    'SKIP': [],
-    'CATEGORIES': {}  # { 'categoryName': ['colName', ...], ... }
-}
-
-
-#ex output: pd.DataFrame([{'edgeType': 'state', 'attribID': 'state::CA', 'eventID': 'eventID::0'}])
-def format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs):
-    is_using_categories = len(defs['CATEGORIES'].keys()) > 0
-    cat_lookup = make_reverse_lookup(defs['CATEGORIES'])
-
-    subframes = []
-    for col in sorted(entity_types):
-        fields = list(set([defs['EVENTID']] + ([x for x in events.columns] if not drop_edge_attrs else [col])))
-        raw = events[ fields ]
-        if drop_na:
-            raw = raw.dropna(axis=0, subset=[col])            
-        raw = raw.copy()
-        if len(raw):            
-            if is_using_categories:
-                raw[defs['EDGETYPE']] = raw.apply(lambda r: col2cat(cat_lookup, col), axis=1)
-                raw[defs['CATEGORY']] = raw.apply(lambda r: col, axis=1)
-            else:
-                raw[defs['EDGETYPE']] = raw.apply(lambda r: col, axis=1)
-            raw[defs['ATTRIBID']] = raw.apply(lambda r: col2cat(cat_lookup, col) + defs['DELIM'] + valToSafeStr(r[col]), axis=1)
-            subframes.append(raw)
-
-    if len(subframes):
-        result_cols = list(set(
-            ([x for x in events.columns.tolist() if not x == defs['NODETYPE']] 
-                if not drop_edge_attrs 
-                else [])
-            + [defs['EDGETYPE'], defs['ATTRIBID'], defs['EVENTID']]  # noqa: W503
-            + ([defs['CATEGORY']] if is_using_categories else []) ))  # noqa: W503
-        out = pd.concat(subframes, ignore_index=True, sort=False).reset_index(drop=True)[ result_cols ]
-        return out
-    else:
-        return pd.DataFrame([])
-
-
-# [ str ] * {?'EDGES' : ?{str: [ str ] }} -> {str: [ str ]}
-def direct_edgelist_shape(entity_types, defs):  
-    if 'EDGES' in defs and defs['EDGES'] is not None:
-        return defs['EDGES']
-    else:
-        out = {}
-        for entity_i in range(len(entity_types)):
-            out[ entity_types[entity_i] ] = entity_types[(entity_i + 1):]
-        return out
-  
-      
-#ex output: pd.DataFrame([{'edgeType': 'state', 'attribID': 'state::CA', 'eventID': 'eventID::0'}])
-def format_direct_edges(events, entity_types, defs, edge_shape, drop_na, drop_edge_attrs):
-    is_using_categories = len(defs['CATEGORIES'].keys()) > 0
-    cat_lookup = make_reverse_lookup(defs['CATEGORIES'])
-
-    subframes = []
-    for col1 in sorted(edge_shape.keys()):
-        for col2 in sorted(edge_shape[col1]):
-            fields = list(set([defs['EVENTID']] + ([x for x in events.columns] if not drop_edge_attrs else [col1, col2])))
-            raw = events[ fields ]
-            if drop_na:
-                raw = raw.dropna(axis=0, subset=[col1, col2])
-            raw = raw.copy()
-            if len(raw):
-                if is_using_categories:
-                    raw[defs['EDGETYPE']] = raw.apply(lambda r: col2cat(cat_lookup, col1) + defs['DELIM'] + col2cat(cat_lookup, col2), axis=1)
-                    raw[defs['CATEGORY']] = raw.apply(lambda r: col1 + defs['DELIM'] + col2, axis=1)
-                else:
-                    raw[defs['EDGETYPE']] = raw.apply(lambda r: col1 + defs['DELIM'] + col2, axis=1)
-                raw[defs['SOURCE']] = raw.apply(lambda r: col2cat(cat_lookup, col1) + defs['DELIM'] + valToSafeStr(r[col1]), axis=1)
-                raw[defs['DESTINATION']] = raw.apply(lambda r: col2cat(cat_lookup, col2) + defs['DELIM'] + valToSafeStr(r[col2]), axis=1)
-                subframes.append(raw)
-
-    if len(subframes):
-        result_cols = list(set(
-            ([x for x in events.columns.tolist() if not x == defs['NODETYPE']] 
-                if not drop_edge_attrs 
-                else [])
-            + [defs['EDGETYPE'], defs['SOURCE'], defs['DESTINATION'], defs['EVENTID']]  # noqa: W503
-            + ([defs['CATEGORY']] if is_using_categories else []) ))  # noqa: W503
-        out = pd.concat(subframes, ignore_index=True).reset_index(drop=True)[ result_cols ]
-        return out
-    else:
-        return pd.DataFrame([])
-
-
-def format_hypernodes(events, defs, drop_na):
-    event_nodes = events.copy()
-    event_nodes[defs['NODETYPE']] = defs['EVENTID']
-    event_nodes[defs['CATEGORY']] = 'event'
-    event_nodes[defs['NODEID']] = event_nodes[defs['EVENTID']]
-    event_nodes[defs['TITLE']] = event_nodes[defs['EVENTID']]
-    return event_nodes
-
-def hyperbinding(g, defs, entities, event_entities, edges, source, destination):
-    nodes = pd.concat([entities, event_entities], ignore_index=True, sort=False).reset_index(drop=True)
-    return {
-        'entities': entities,
-        'events': event_entities,
-        'edges': edges,
-        'nodes': nodes,
-        'graph':
-            g
-            .bind(source=source, destination=destination).edges(edges)
-            .bind(node=defs['NODEID'], point_title=defs['TITLE']).nodes(nodes)
-    }     
-
-#turn lists etc to strs, and preserve nulls
-def flatten_objs_inplace(df, cols):
-    for c in cols:
-        name = df[c].dtype.name
-        if name == 'category':
-            #Avoid warning
-            df[c] = df[c].astype(str).where(~df[c].isnull(), df[c])
-        elif name == 'object':
-            df[c] = df[c].where(df[c].isnull(), df[c].astype(str))
- 
-#
-
-class Hypergraph(object):        
+class Hypergraph(object):
 
     @staticmethod
-    def hypergraph(g, raw_events, entity_types=None, opts={}, drop_na=True, drop_edge_attrs=False, verbose=True, direct=False):
-        defs = makeDefs(DEFS_HYPER, opts)
-        entity_types = screen_entities(raw_events, entity_types, defs)
-        events = raw_events.copy().reset_index(drop=True)
-        flatten_objs_inplace(events, entity_types)
+    def hypergraph(
+        g, raw_events, entity_types: Optional[List[str]] = None, opts: dict = {},
+        drop_na: bool = True, drop_edge_attrs: bool = False, verbose: bool = True, direct: bool = False,
+        engine: str = 'pandas'
+    ) -> dict:
+        """
+            raw_events can be pd.DataFrame or cudf.DataFrame
+        """
 
-        if defs['EVENTID'] in events.columns:
-            events[defs['EVENTID']] = events.apply(
-                lambda r: defs['EVENTID'] + defs['DELIM'] + valToSafeStr(r[defs['EVENTID']]), 
-                axis=1)
-        else:
-            events[defs['EVENTID']] = events.reset_index().apply(
-                lambda r: defs['EVENTID'] + defs['DELIM'] + valToSafeStr(r['index']),
-                axis=1)
-        events[defs['NODETYPE']] = 'event'
-        
-        entities = format_entities(events, entity_types, defs, drop_na)
-        event_entities = None
-        edges = None
-        if direct:
-            edge_shape = direct_edgelist_shape(entity_types, opts)
-            event_entities = pd.DataFrame()
-            edges = format_direct_edges(events, entity_types, defs, edge_shape, drop_na, drop_edge_attrs)
-        else:        
-            event_entities = format_hypernodes(events, defs, drop_na)
-            edges = format_hyperedges(events, entity_types, defs, drop_na, drop_edge_attrs)
-        if verbose:
-            print('# links', len(edges))
-            print('# events', len(events))
-            print('# attrib entities', len(entities))
-        return hyperbinding(
-            g, defs, entities, event_entities, edges,
-            defs['SOURCE'] if direct else defs['ATTRIBID'],
-            defs['DESTINATION'] if direct else defs['EVENTID'])
+        out = hypergraph_new(
+            g, raw_events, entity_types, opts,
+            drop_na, drop_edge_attrs, verbose, direct,
+            engine=engine)
+
+        return {
+            'entities': out.entities,
+            'events': out.events,
+            'edges': out.edges,
+            'nodes': out.nodes,
+            'graph': out.graph
+        }

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -1,0 +1,473 @@
+#
+# Like hypergraph(); adds engine = 'pandas' | 'cudf' | 'dask' | 'dask-cudf'
+#
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from .Engine import Engine, DataframeLike, DataframeLocalLike
+import logging, pandas as pd, pyarrow as pa, sys
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# TODO: When Python 3.8+, switch to TypedDict
+class HyperBindings():
+    def __init__(
+        self,
+        TITLE: str = 'nodeTitle',
+        DELIM: str = '::',
+        NODEID: str = 'nodeID',
+        ATTRIBID: str = 'attribID',
+        EVENTID: str = 'EventID',
+        SOURCE: str = 'src',
+        DESTINATION: str = 'dst',
+        CATEGORY: str = 'category',
+        NODETYPE: str = 'type',
+        EDGETYPE: str = 'edgeType',
+        NULLVAL: str = 'null',
+        SKIP: List[str] = [],
+        CATEGORIES: Dict[str, List[str]] = {},
+        EDGES: Optional[Dict[str, List[str]]] = None
+    ):
+        self.title = TITLE
+        self.delim = DELIM
+        self.node_id = NODEID
+        self.attrib_id = ATTRIBID
+        self.event_id = EVENTID
+        self.source = SOURCE
+        self.destination = DESTINATION
+        self.category = CATEGORY
+        self.node_type = NODETYPE
+        self.edge_type = EDGETYPE
+        self.categories = CATEGORIES
+        self.edges = EDGES
+        self.null_val = NULLVAL
+
+        self.skip = SKIP.copy()
+        # Prevent metadata fields from turning into nodes 
+        # bindings = vars(self)
+        # for key in bindings.keys():
+        #     if (key != 'SKIP') and (bindings[key] not in self.skip):
+        #         self.skip.append(bindings[key])
+
+def screen_entities(events: DataframeLike, entity_types: Optional[List[str]], defs: HyperBindings) -> List[str]:
+    """
+    List entity columns: Unskipped user-specified entities when provided, else unskipped cols
+    """
+    base = entity_types if entity_types is not None else [x for x in events.columns]
+    return [x for x in base if x not in defs.skip]
+
+def col2cat(cat_lookup: Dict[str, str], col: str):
+    return cat_lookup[col] if col in cat_lookup else col
+
+def make_reverse_lookup(categories):
+    lookup = {}
+    for category in categories:
+        for col in categories[category]:
+            lookup[col] = str(category)
+    return lookup
+
+
+
+def format_entities_from_col(
+    defs: HyperBindings,
+    cat_lookup: Dict[str, str],
+    drop_na: bool,
+    engine: Engine,
+    df_hd: DataframeLocalLike,
+    col_name: str,
+    df_with_col: DataframeLike
+) -> DataframeLocalLike:
+    """
+    For unique v in column col, create [{col: str(v), title: str(v), nodetype: col, nodeid: `<cat><delim><v>`}]
+        - respect drop_na
+        - respect colname overrides
+        - receive+return pd.DataFrame / cudf.DataFrame depending on engine
+    """
+    logger.debug('@format_entities: [drop: %s], %s / %s', drop_na, col_name, [c for c in df_with_col])
+
+    try:
+        df_with_col_pre = df_with_col[col_name].dropna() if drop_na else df_with_col[col_name]
+        try:
+            unique_vals = df_with_col_pre.drop_duplicates()
+        except:
+            unique_vals = df_with_col_pre.astype(str).drop_duplicates()
+            logger.warning('Coerced col %s to string type for entity names', col_name)
+        unique_safe_val_strs = unique_vals.astype(str).fillna(defs.null_val)
+    except NotImplementedError:
+        logger.warning('Dropped col %s from entity list due to errors')
+        unique_vals = df_with_col[[]].reset_index()['index'][:0]
+        unique_safe_val_strs = unique_vals.astype(str).fillna(defs.null_val)
+
+    if engine in [Engine.PANDAS, Engine.DASK]:
+        cons = pd.DataFrame
+    else:
+        import cudf
+        cons = cudf.DataFrame
+    
+    return cons({
+        col_name: unique_vals,
+        defs.title: unique_safe_val_strs,
+        defs.node_type: col_name,
+        defs.category: col2cat(cat_lookup, col_name),
+        defs.node_id: (col2cat(cat_lookup, col_name) + defs.delim) + unique_safe_val_strs
+    })
+
+def concat(dfs: List[DataframeLike], engine: Engine):
+
+    if engine == Engine.PANDAS:
+        return pd.concat(dfs, ignore_index=True, sort=False)
+
+    if engine == Engine.DASK:
+        import dask.dataframe
+        return dask.dataframe.concat(dfs).reset_index(drop=True)
+    
+    if engine == Engine.CUDF:
+        import cudf
+        try:
+            return cudf.concat(dfs)
+        except TypeError as e:
+            logger.warning('Failed to concat, likely due to column type issue, try converting to a string; columns')
+            for df in dfs:
+                logger.warning('df types :: %s', df.dtypes)
+            raise e
+
+    if engine == Engine.DASK_CUDF:
+        import dask_cudf
+        return dask_cudf.concat(dfs)
+
+def mt_df(engine: Engine):
+    if engine == Engine.PANDAS:
+        return pd.DataFrame()
+
+    if engine == Engine.DASK:
+        import dask.dataframe
+        return dask.dataframe.DataFrame()
+
+    if engine == Engine.CUDF:
+        import cudf
+        return cudf.DataFrame()
+
+    if engine == Engine.DASK_CUDF:
+        import dask_cudf
+        return dask_cudf.DataFrame()
+
+#ex output: DataFrameLike([{'val::state': 'CA', 'nodeType': 'state', 'nodeID': 'state::CA'}])
+def format_entities(
+    events: DataframeLike,
+    entity_types: List[str],
+    defs: HyperBindings,
+    drop_na: bool,
+    engine: Engine,
+    npartitions: Optional[int],
+    chunksize: Optional[int]) -> DataframeLike:
+
+    logger.debug('@format_entities :: %s', entity_types)
+
+
+    if engine in [Engine.PANDAS, Engine.DASK]:
+        df_cons = pd.DataFrame
+        series_cons = pd.Series
+    else:
+        import cudf
+        df_cons = cudf.DataFrame
+        series_cons = cudf.Series
+
+    # handle mt + dask meta
+    df_hd = df_cons({
+        defs.title: series_cons([], dtype='object'),
+        defs.node_type: series_cons([], dtype='object'),
+        defs.category: series_cons([], dtype='object'),
+        defs.node_id: series_cons([], dtype='object'),
+        **{
+            col_name: series_cons([], dtype=events[col_name].dtype)
+            for col_name in entity_types
+        }
+    })
+
+    cat_lookup = make_reverse_lookup(defs.categories)
+    logger.debug('@format_entities cat_lookup [ %s ] => [ %s ]', defs.categories, cat_lookup)
+
+    entity_dfs = [
+        format_entities_from_col(
+            defs, cat_lookup, drop_na, engine, df_hd,
+            col_name, events[[col_name]])
+        for col_name in entity_types
+    ]
+    for df in entity_dfs:
+        logger.debug('sub df: %s', df)
+
+    df = concat(entity_dfs, engine).drop_duplicates([defs.node_id])
+
+    return df
+
+
+#ex output: pd.DataFrame([{'edgeType': 'state', 'attribID': 'state::CA', 'eventID': 'eventID::0'}])
+def format_hyperedges(engine, events, entity_types, defs, drop_na, drop_edge_attrs):
+    is_using_categories = len(defs.categories.keys()) > 0
+    cat_lookup = make_reverse_lookup(defs.categories)
+
+    subframes = []
+    for col in sorted(entity_types):
+        fields = list(set([defs.event_id] + ([x for x in events.columns] if not drop_edge_attrs else [col])))
+        raw = events[ fields ]
+        if drop_na:
+            raw = raw.dropna(axis=0, subset=[col])            
+        raw = raw.copy()
+        if len(raw):            
+            if is_using_categories:
+                raw[defs.edge_type] = col2cat(cat_lookup, col)
+                raw[defs.category] = col
+            else:
+                raw[defs.edge_type] = col
+            try:
+                raw[defs.attrib_id] = (col2cat(cat_lookup, col) + defs.delim) + raw[col].astype(str).fillna(defs.null_val)
+            except NotImplementedError:
+                logger.warning('Did not create hyperedges for column %s as does not support astype(str)', col)
+                continue
+            subframes.append(raw)
+
+    if len(subframes):
+        result_cols = list(set(
+            ([x for x in events.columns.tolist() if not x == defs.node_type] 
+                if not drop_edge_attrs 
+                else [])
+            + [defs.edge_type, defs.attrib_id, defs.event_id]  # noqa: W503
+            + ([defs.category] if is_using_categories else []) ))  # noqa: W503
+        out = concat(subframes, engine).reset_index(drop=True)[ result_cols ]
+        return out
+    else:
+        return pd.DataFrame([])
+
+
+def direct_edgelist_shape(entity_types: List[str], defs: HyperBindings) -> Dict[str, List[str]]:
+    """
+        Edges take format {src_col: [dest_col1, dest_col2], ....}
+        If None, create connect all to all, leaving up to algorithm in which direction
+    """
+    if defs.edges is not None:
+        return defs.edges
+    else:
+        out = {}
+        for entity_i in range(len(entity_types)):
+            out[ entity_types[entity_i] ] = entity_types[(entity_i + 1):]
+        return out
+  
+      
+#ex output: DataFrameLike([{'edgeType': 'state', 'attribID': 'state::CA', 'eventID': 'eventID::0'}])
+def format_direct_edges(
+    engine: Engine, events: DataframeLike, entity_types, defs: HyperBindings, edge_shape, drop_na: bool, drop_edge_attrs: bool
+) -> DataframeLike:
+    is_using_categories = len(defs.categories.keys()) > 0
+    cat_lookup = make_reverse_lookup(defs.categories)
+
+    subframes = []
+    for col1 in sorted(edge_shape.keys()):
+        for col2 in sorted(edge_shape[col1]):
+            fields = list(set([defs.event_id] + ([x for x in events.columns] if not drop_edge_attrs else [col1, col2])))
+            raw = events[ fields ]
+            if drop_na:
+                raw = raw.dropna(axis=0, subset=[col1, col2])
+            raw = raw.copy()
+            if len(raw):
+                if is_using_categories:
+                    raw[defs.edge_type] = col2cat(cat_lookup, col1) + defs.delim + col2cat(cat_lookup, col2)
+                    raw[defs.category] = col1 + defs.delim + col2
+                else:
+                    raw[defs.edge_type] = col1 + defs.delim + col2
+                raw[defs.source] = (col2cat(cat_lookup, col1) + defs.delim) + raw[col1].astype(str).fillna(defs.null_val)
+                raw[defs.destination] = (col2cat(cat_lookup, col2) + defs.delim) + raw[col2].astype(str).fillna(defs.null_val)
+                subframes.append(raw)
+
+    if len(subframes):
+        result_cols = list(set(
+            ([x for x in events.columns.tolist() if not x == defs.node_type] 
+                if not drop_edge_attrs 
+                else [])
+            + [defs.edge_type, defs.source, defs.destination, defs.event_id]  # noqa: W503
+            + ([defs.category] if is_using_categories else []) ))  # noqa: W503
+        out = concat(subframes, engine=engine)[ result_cols ]
+        return out
+    else:
+        return events[:0][[]]
+
+
+def format_hypernodes(events, defs, drop_na):
+    event_nodes = events.copy()
+    event_nodes[defs.node_type] = defs.event_id
+    event_nodes[defs.category] = 'event'
+    event_nodes[defs.node_id] = event_nodes[defs.event_id]
+    event_nodes[defs.title] = event_nodes[defs.event_id]
+    return event_nodes
+
+def hyperbinding(g, defs, entities, event_entities, edges, source, destination):
+    nodes = pd.concat([entities, event_entities], ignore_index=True, sort=False).reset_index(drop=True)
+    return {
+        'entities': entities,
+        'events': event_entities,
+        'edges': edges,
+        'nodes': nodes,
+        'graph':
+            g
+            .bind(source=source, destination=destination).edges(edges)
+            .bind(node=defs.node_id, point_title=defs.title).nodes(nodes)
+    }     
+
+#turn lists etc to strs, and preserve nulls
+def flatten_objs_inplace(df, cols):
+    for c in cols:
+        name = df[c].dtype.name
+        if name == 'category':
+            #Avoid warning
+            df[c] = df[c].astype(str).where(~df[c].isnull(), df[c])
+        elif name == 'object':
+            df[c] = df[c].where(df[c].isnull(), df[c].astype(str))
+ 
+#
+
+def shallow_copy(df: DataframeLike, engine: Engine) -> DataframeLike:
+    if engine in [Engine.DASK, Engine.DASK_CUDF]:
+        df2 = df.copy()
+    else:
+        df2 = df.copy(deep=False)
+    return df2
+
+
+def df_coercion(  # noqa: C901
+    df: DataframeLike,
+    engine: Engine,
+    npartitions: Optional[int] = None,
+    chunksize: Optional[int] = None
+) -> DataframeLike:
+    """
+    Supported coercions:
+        pd <- pd
+        cudf <- pd, cudf
+        ddf <- pd, ddf
+        dgdf <- pd, cudf, dgdf
+    """
+    if engine == Engine.PANDAS:
+        if isinstance(df, pd.DataFrame):
+            return df
+        raise ValueError('pandas engine mode requires pd.DataFrame input, received: %s' % str(type(df)))
+
+    if engine == Engine.CUDF:
+        import cudf
+        if isinstance(df, pd.DataFrame):
+            return cudf.from_pandas(df)
+        if isinstance(df, cudf.DataFrame):
+            return df
+        raise ValueError('cudf engine mode requires pd.DataFrame/cudf.DataFrame input, received: %s' % str(type(df)))
+
+    if engine == Engine.DASK:
+        import dask
+        if isinstance(df, pd.DataFrame):
+            return dask.dataframe.from_pandas(df, npartitions=npartitions, chunksize=chunksize)
+        if isinstance(df, dask.dataframe.DataFrame):
+            return df
+        raise ValueError('dask engine mode requires pd.DataFrame/dask.dataframe.DataFrame input, received: %s' % str(type(df)))
+
+    if engine == Engine.DASK_CUDF:
+        import cudf, dask_cudf, dask.dataframe
+        if isinstance(df, pd.DataFrame):
+            ddf = df_coercion(df, Engine.DASK, npartitions, chunksize)
+            return df_coercion(ddf, Engine.DASK_CUDF, npartitions, chunksize)
+        if isinstance(df, cudf.DataFrame):
+            return dask_cudf.from_cudf(df, npartitions=npartitions, chunksize=chunksize)
+        if isinstance(df, dask_cudf.DataFrame):
+            return df
+        if isinstance(df, dask.dataframe.DataFrame):
+            return df.map_partitions(cudf.from_pandas)  # FIXME How does this get the right type?
+        raise ValueError('dask_cudf engine mode requires pd.DataFrame/cudf.DataFrame/dask.dataframe.DataFrame/dask_cudf.DataFrame input, received: %s' % str(type(df)))
+
+    return ValueError('Did not get a value Engine type: %s' % engine)
+
+
+def clean_events(
+    events: DataframeLike,
+    engine: Engine,
+    npartitions: Optional[int] = None,
+    chunksize: Optional[int] = None
+) -> DataframeLike:
+    """
+    Copy with reset index and in the target engine format
+    """
+    logger.debug('@clean: %s', [c for c in events.columns])
+    out_events = df_coercion(events, engine, npartitions, chunksize)
+    out_events = shallow_copy(out_events, engine)
+    out_events = out_events.reset_index(drop=True)
+    return out_events
+
+
+class Hypergraph():
+    def __init__(
+        self, g,
+        defs, entities: DataframeLike, event_entities: DataframeLike, edges: DataframeLike,
+        source: str, destination: str,
+        engine: Engine = Engine.PANDAS
+    ):
+        self.engine = engine
+        self.entities = entities
+        self.events = event_entities
+        self.edges = edges
+        self.nodes = concat([entities, event_entities], engine=engine)
+        self.graph = (g
+            .edges(edges, source, destination)
+            .nodes(self.nodes, defs.node_id)
+            .bind(point_title=defs.title))
+
+
+def hypergraph(
+    g,
+    raw_events: DataframeLike, 
+    entity_types: Optional[List[str]] = None,
+    opts: dict = {},
+    drop_na: bool = True,
+    drop_edge_attrs: bool = False,
+    verbose: bool = True,
+    direct: bool = False,
+    engine: str = 'pandas',  # see Engine for valid values
+    npartitions: Optional[int] = None,
+    chunksize: Optional[int] = None
+):
+    """
+    Internal details:
+        - IDs currently strings: `${namespace(col)}${delim}${str(val)}`
+    """
+    # TODO: String -> categorical
+    # TODO: col_name column can be prohibitively wide & sparse: drop / warning?
+
+    engine_resolved : Engine
+    if not isinstance(engine, Engine):
+        engine_resolved = getattr(Engine, str(engine).upper())  # type: ignore
+    else:
+        engine_resolved = engine
+    defs = HyperBindings(**opts)
+    entity_types = screen_entities(raw_events, entity_types, defs)
+    events = clean_events(raw_events, engine_resolved, npartitions, chunksize)  # type: ignore
+
+    if defs.event_id in events.columns:
+        events[defs.event_id] = (defs.event_id + defs.delim) + events[defs.event_id].astype(str).fillna(defs.null_val) 
+    else:
+        events[defs.event_id] = (defs.event_id + defs.delim) + events[[]].reset_index()['index'].astype(str)
+    events[defs.node_type] = 'event'
+    
+    entities = format_entities(events, entity_types, defs, drop_na, engine_resolved, npartitions, chunksize)  # type: ignore
+
+    event_entities = None
+    edges = None
+    if direct:
+        edge_shape = direct_edgelist_shape(entity_types, defs)
+        event_entities = mt_df(engine_resolved)
+        edges = format_direct_edges(engine_resolved, events, entity_types, defs, edge_shape, drop_na, drop_edge_attrs)
+    else:        
+        event_entities = format_hypernodes(events, defs, drop_na)
+        edges = format_hyperedges(engine_resolved, events, entity_types, defs, drop_na, drop_edge_attrs)
+    if verbose:
+        print('# links', len(edges))
+        print('# events', len(events))
+        print('# attrib entities', len(entities))
+    return Hypergraph(
+        g,
+        defs, entities, event_entities, edges,
+        defs.source if direct else defs.attrib_id,
+        defs.destination if direct else defs.event_id,
+        engine_resolved)

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -431,7 +431,7 @@ class PyGraphistry(object):
 
         """
         from . import hyper
-        return hyper.Hypergraph().hypergraph(PyGraphistry, raw_events, entity_types, opts, drop_na, drop_edge_attrs, verbose, direct)
+        return hyper.Hypergraph().hypergraph(PyGraphistry, raw_events, entity_types, opts, drop_na, drop_edge_attrs, verbose, direct, engine=engine)
 
 
     @staticmethod

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List, Optional
 
 """Top-level import of class PyGraphistry as "Graphistry". Used to connect to the Graphistry server and then create a base plotter."""
 import calendar, gzip, io, json, os, numpy, pandas as pd, requests, sys, time, warnings
@@ -369,26 +369,35 @@ class PyGraphistry(object):
 
 
     @staticmethod
-    def hypergraph(raw_events, entity_types=None, opts={}, drop_na=True, drop_edge_attrs=False, verbose=True, direct=False):
+    def hypergraph(
+        raw_events, entity_types: Optional[List[str]] = None, opts: dict = {},
+        drop_na: bool = True, drop_edge_attrs: bool = False, verbose: bool = True, direct: bool = False,
+        engine: str = 'pandas'
+    ):
         """Transform a dataframe into a hypergraph.
 
-        :param raw_events: Dataframe to transform
+        :param raw_events: Dataframe to transform (pandas or cudf). 
         :type raw_events: pandas.DataFrame
         :param list entity_types: Optional list of columns (strings) to turn into nodes, None signifies all
         :param dict opts: See below
         :param bool drop_edge_attrs: Whether to include each row's attributes on its edges, defaults to False (include)
         :param bool verbose: Whether to print size information
         :param bool direct: Omit hypernode and instead strongly connect nodes in an event
+        :param bool engine: String (pandas, cudf, ...) for engine to use. Should match raw_events type.
+
+        Specify engine mode by passing `engine='pandas'` or `engine='cudf'` (default: 'pandas').
 
         Create a graph out of the dataframe, and return the graph components as dataframes, 
         and the renderable result Plotter. It reveals relationships between the rows and between column values.
         This transform is useful for lists of events, samples, relationships, and other structured high-dimensional data.
 
-        The transform creates a node for every row, and turns a row's column entries into node attributes. 
-        If direct=False (default), every unique value within a column is also turned into a node. 
-        Edges are added to connect a row's nodes to each of its column nodes, or if direct=True, to one another.
+        The transform creates a node for every unique value in the entity_types columns (default: all columns). 
+        If direct=False (default), every row is also turned into a node. 
+        Edges are added to connect every table cell to its originating row's node, or if direct=True, to the other nodes from the same row.
         Nodes are given the attribute 'type' corresponding to the originating column name, or in the case of a row, 'EventID'.
-
+        Options further control the transform, such column category definitions for controlling whether values
+        reocurring in different columns should be treated as one node,
+        or whether to only draw edges between certain column type pairs. 
 
         Consider a list of events. Each row represents a distinct event, and each column some metadata about an event. 
         If multiple events have common metadata, they will be transitively connected through those metadata values. 

--- a/graphistry/tests/test_hyper_dask.py
+++ b/graphistry/tests/test_hyper_dask.py
@@ -1,0 +1,517 @@
+# -*- coding: utf-8 -*-
+
+import datetime as dt, logging, os, pandas as pd, pyarrow as pa, pytest
+from common import NoAuthTestCase
+
+from graphistry.pygraphistry import PyGraphistry 
+from graphistry.Engine import Engine
+from graphistry.hyper_dask import HyperBindings, hypergraph
+from graphistry.tests.test_hypergraph import triangleNodes, assertFrameEqual, hyper_df, squareEvil
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+# ###
+
+
+def assertFrameEqualCudf(df1, df2):
+    return assertFrameEqual(df2.to_pandas(), df2.to_pandas())
+
+
+squareEvil_gdf_friendly = pd.DataFrame({
+    'src': [0,1,2,3],
+    'dst': [1,2,3,0],
+    'colors': [1, 1, 2, 2],
+    #'list_int': [ [1], [2, 3], [4], []],
+    #'list_str': [ ['x'], ['1', '2'], ['y'], []],
+    #'list_bool': [ [True], [True, False], [False], []],
+    #'list_date_str': [ ['2018-01-01 00:00:00'], ['2018-01-02 00:00:00', '2018-01-03 00:00:00'], ['2018-01-05 00:00:00'], []],
+    #'list_date': [ [pd.Timestamp('2018-01-05')], [pd.Timestamp('2018-01-05'), pd.Timestamp('2018-01-05')], [], []],
+    #'list_mixed': [ [1], ['1', '2'], [False, None], []],
+    'bool': [True, False, True, True],
+    'char': ['a', 'b', 'c', 'd'],
+    'str': ['a', 'b', 'c', 'd'],
+    'ustr': [u'a', u'b', u'c', u'd'],
+    'emoji': ['😋', '😋😋', '😋', '😋'],
+    'int': [0, 1, 2, 3],
+    'num': [0.5, 1.5, 2.5, 3.5],
+    'date_str': ['2018-01-01 00:00:00', '2018-01-02 00:00:00', '2018-01-03 00:00:00', '2018-01-05 00:00:00'],
+    
+    # API 1 BUG: Try with https://github.com/graphistry/pygraphistry/pull/126
+    'date': [dt.datetime(2018, 1, 1), dt.datetime(2018, 1, 1), dt.datetime(2018, 1, 1), dt.datetime(2018, 1, 1)],
+    'time': [pd.Timestamp('2018-01-05'), pd.Timestamp('2018-01-05'), pd.Timestamp('2018-01-05'), pd.Timestamp('2018-01-05')],
+    
+    # API 2 BUG: Need timedelta in https://github.com/graphistry/pygraphistry/blob/master/graphistry/vgraph.py#L108
+    'delta': [pd.Timedelta('1 day'), pd.Timedelta('1 day'), pd.Timedelta('1 day'), pd.Timedelta('1 day')]
+})
+
+
+def hyper_gdf():
+    try:
+        import cudf
+        hyper2_df = hyper_df.assign(cc=hyper_df['cc'].astype(str))
+        hyper2_gdf = cudf.DataFrame.from_pandas(hyper2_df)
+        logger.debug('hyper2_gdf :: %s', hyper2_gdf.dtypes)
+        return hyper2_gdf
+    except Exception as e:
+        logger.error('Failed to make hyper_gdf fixture..', exc_info=True)
+        raise e
+
+
+# ###
+
+
+def test_HyperBindings_mt():
+    hb = HyperBindings()
+    assert hb.title == 'nodeTitle'
+    assert hb.skip == []
+
+def test_HyperBindings_override():
+    hb = HyperBindings(NODETYPE='abc')
+    assert hb.node_type == 'abc'
+
+
+# ###
+
+
+@pytest.mark.skipif(
+    not ('TEST_PANDAS' in os.environ and os.environ['TEST_PANDAS'] == '1'),
+    reason='pandas tests need TEST_PANDAS=1')
+class TestHypergraphPandas(NoAuthTestCase):
+
+  
+    def test_hyperedges(self):
+
+        h = hypergraph(PyGraphistry.bind(), triangleNodes, verbose=False)
+        
+        edges = pd.DataFrame({
+            'a1': [1, 2, 3] * 4,
+            'a2': ['red', 'blue', 'green'] * 4,
+            'id': ['a', 'b', 'c'] * 4,
+            '🙈': ['æski ēˈmōjē', '😋', 's'] * 4,
+            'edgeType': ['a1', 'a1', 'a1', 'a2', 'a2', 'a2', 'id', 'id', 'id', '🙈', '🙈', '🙈'],
+            'attribID': [
+                'a1::1', 'a1::2', 'a1::3', 
+                'a2::red', 'a2::blue', 'a2::green',                 
+                'id::a', 'id::b', 'id::c',
+                '🙈::æski ēˈmōjē', '🙈::😋', '🙈::s'],
+            'EventID': ['EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2']})
+
+        assertFrameEqual(h.edges, edges)
+        for (k, v) in [('entities', 12), ('nodes', 15), ('edges', 12), ('events', 3)]:
+            self.assertEqual(len(getattr(h, k)), v)
+
+    def test_hyperedges_direct(self):
+
+        h = hypergraph(PyGraphistry.bind(), hyper_df, verbose=False, direct=True)
+        
+        self.assertEqual(len(h.edges), 9)
+        self.assertEqual(len(h.nodes), 9)
+
+    def test_hyperedges_direct_categories(self):
+
+        h = hypergraph(PyGraphistry.bind(), hyper_df, verbose=False, direct=True, opts={'CATEGORIES': {'n': ['aa', 'bb', 'cc']}})
+        
+        self.assertEqual(len(h.edges), 9)
+        self.assertEqual(len(h.nodes), 6)
+
+    def test_hyperedges_direct_manual_shaping(self):
+
+        h1 = hypergraph(PyGraphistry.bind(), hyper_df, verbose=False, direct=True, opts={'EDGES': {'aa': ['cc'], 'cc': ['cc']}})
+        self.assertEqual(len(h1.edges), 6)
+
+        h2 = hypergraph(PyGraphistry.bind(), hyper_df, verbose=False, direct=True, opts={'EDGES': {'aa': ['cc', 'bb', 'aa'], 'cc': ['cc']}})
+        self.assertEqual(len(h2.edges), 12)
+
+
+    def test_drop_edge_attrs(self):
+    
+        h = hypergraph(PyGraphistry.bind(), triangleNodes, ['id', 'a1', '🙈'], verbose=False, drop_edge_attrs=True)
+
+        edges = pd.DataFrame({
+            'edgeType': ['a1', 'a1', 'a1', 'id', 'id', 'id', '🙈', '🙈', '🙈'],
+            'attribID': [
+                'a1::1', 'a1::2', 'a1::3', 
+                'id::a', 'id::b', 'id::c',
+                '🙈::æski ēˈmōjē', '🙈::😋', '🙈::s'],
+            'EventID': ['EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2']})
+
+
+        assertFrameEqual(h.edges, edges)
+        for (k, v) in [('entities', 9), ('nodes', 12), ('edges', 9), ('events', 3)]:
+            logger.debug('testing: %s = %s', k, getattr(h, k))
+            self.assertEqual(len(getattr(h, k)), v)
+
+    def test_drop_edge_attrs_direct(self):
+        
+        h = hypergraph(PyGraphistry.bind(), triangleNodes,
+            ['id', 'a1', '🙈'],
+            verbose=False, direct=True, drop_edge_attrs=True,
+            opts = {
+                'EDGES': {
+                    'id': ['a1'],
+                    'a1': ['🙈']
+                }
+            })
+
+        logger.debug('h.nodes: %s', h.graph._nodes)
+        logger.debug('h.edges: %s', h.graph._edges)
+
+        edges = pd.DataFrame({
+            'edgeType': ['a1::🙈', 'a1::🙈', 'a1::🙈', 'id::a1', 'id::a1', 'id::a1'],
+            'src': [
+                'a1::1', 'a1::2', 'a1::3',
+                'id::a', 'id::b', 'id::c'],
+            'dst': [
+                '🙈::æski ēˈmōjē', '🙈::😋', '🙈::s',
+                'a1::1', 'a1::2', 'a1::3'],
+            'EventID': [
+                'EventID::0', 'EventID::1', 'EventID::2',
+                'EventID::0', 'EventID::1', 'EventID::2']})
+
+        assertFrameEqual(h.edges, edges)
+        for (k, v) in [('entities', 9), ('nodes', 9), ('edges', 6), ('events', 0)]:
+            logger.error('testing: %s', k)
+            logger.error('actual: %s', getattr(h,k))
+            self.assertEqual(len(getattr(h,k)), v)
+
+
+    def test_drop_na_hyper(self):
+
+        df = pd.DataFrame({
+            'a': ['a', None, 'c'],
+            'i': [1, 2, None]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, drop_na=True)
+
+        assert len(hg.graph._nodes) == 7
+        assert len(hg.graph._edges) == 4
+
+    def test_drop_na_direct(self):
+
+        df = pd.DataFrame({
+            'a': ['a', None, 'a'],
+            'i': [1, 1, None]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, drop_na=True, direct=True)
+
+        assert len(hg.graph._nodes) == 2
+        assert len(hg.graph._edges) == 1
+
+    def test_skip_na_hyperedge(self):
+    
+        nans_df = pd.DataFrame({
+          'x': ['a', 'b', 'c'],
+          'y': ['aa', None, 'cc']
+        })
+        expected_hits = ['a', 'b', 'c', 'aa', 'cc']
+
+        skip_attr_h_edges = hypergraph(PyGraphistry.bind(), nans_df, drop_edge_attrs=True).edges
+        self.assertEqual(len(skip_attr_h_edges), len(expected_hits))
+
+        default_h_edges = hypergraph(PyGraphistry.bind(), nans_df).edges
+        self.assertEqual(len(default_h_edges), len(expected_hits))
+
+    def test_hyper_evil(self):
+        hypergraph(PyGraphistry.bind(), squareEvil)
+
+    def test_hyper_to_pa_vanilla(self):
+
+        df = pd.DataFrame({
+            'x': ['a', 'b', 'c'],
+            'y': ['d', 'e', 'f']
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df)
+        nodes_arr = pa.Table.from_pandas(hg.graph._nodes)
+        assert len(nodes_arr) == 9
+        edges_err = pa.Table.from_pandas(hg.graph._edges)
+        assert len(edges_err) == 6
+
+    def test_hyper_to_pa_mixed(self):
+
+        df = pd.DataFrame({
+            'x': ['a', 'b', 'c'],
+            'y': [1, 2, 3]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df)
+        nodes_arr = pa.Table.from_pandas(hg.graph._nodes)
+        assert len(nodes_arr) == 9
+        edges_err = pa.Table.from_pandas(hg.graph._edges)
+        assert len(edges_err) == 6
+
+    def test_hyper_to_pa_na(self):
+
+        df = pd.DataFrame({
+            'x': ['a', None, 'c'],
+            'y': [1, 2, None]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, drop_na=False)
+        logger.debug('nodes :: %s => %s', hg.graph._nodes.dtypes, hg.graph._nodes)
+        nodes_arr = pa.Table.from_pandas(hg.graph._nodes)
+        assert len(hg.graph._nodes) == 9
+        assert len(nodes_arr) == 9
+        edges_err = pa.Table.from_pandas(hg.graph._edges)
+        assert len(hg.graph._edges) == 6
+        assert len(edges_err) == 6
+
+    def test_hyper_to_pa_all(self):
+        hg = hypergraph(PyGraphistry.bind(), triangleNodes, ['id', 'a1', '🙈'])
+        nodes_arr = pa.Table.from_pandas(hg.graph._nodes)
+        assert len(hg.graph._nodes) == 12
+        assert len(nodes_arr) == 12
+        edges_err = pa.Table.from_pandas(hg.graph._edges)
+        assert len(hg.graph._edges) == 9
+        assert len(edges_err) == 9
+
+    def test_hyper_to_pa_all_direct(self):
+        hg = hypergraph(PyGraphistry.bind(), triangleNodes, ['id', 'a1', '🙈'], direct=True)
+        nodes_arr = pa.Table.from_pandas(hg.graph._nodes)
+        assert len(hg.graph._nodes) == 9
+        assert len(nodes_arr) == 9
+        edges_err = pa.Table.from_pandas(hg.graph._edges)
+        assert len(hg.graph._edges) == 9
+        assert len(edges_err) == 9
+
+
+@pytest.mark.skipif(
+    not ('TEST_CUDF' in os.environ and os.environ['TEST_CUDF'] == '1'),
+    reason='cudf tests need TEST_CUDF=1')
+class TestHypergraphCudf(NoAuthTestCase):
+
+  
+    def test_hyperedges(self):
+        import cudf
+
+        h = hypergraph(PyGraphistry.bind(), cudf.DataFrame.from_pandas(triangleNodes), verbose=False, engine=Engine.CUDF)
+        
+        edges = cudf.DataFrame({
+            'a1': [1, 2, 3] * 4,
+            'a2': ['red', 'blue', 'green'] * 4,
+            'id': ['a', 'b', 'c'] * 4,
+            '🙈': ['æski ēˈmōjē', '😋', 's'] * 4,
+            'edgeType': ['a1', 'a1', 'a1', 'a2', 'a2', 'a2', 'id', 'id', 'id', '🙈', '🙈', '🙈'],
+            'attribID': [
+                'a1::1', 'a1::2', 'a1::3', 
+                'a2::red', 'a2::blue', 'a2::green',                 
+                'id::a', 'id::b', 'id::c',
+                '🙈::æski ēˈmōjē', '🙈::😋', '🙈::s'],
+            'EventID': ['EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2']})
+
+        assertFrameEqualCudf(h.edges, edges)
+        for (k, v) in [('entities', 12), ('nodes', 15), ('edges', 12), ('events', 3)]:
+            self.assertEqual(len(getattr(h, k)), v)
+
+    def test_hyperedges_direct(self):
+        import cudf
+
+        h = hypergraph(PyGraphistry.bind(), hyper_gdf(), verbose=False, direct=True, engine=Engine.CUDF)
+        
+        self.assertEqual(len(h.edges), 9)
+        self.assertEqual(len(h.nodes), 9)
+
+    def test_hyperedges_direct_categories(self):
+        import cudf
+
+        h = hypergraph(
+            PyGraphistry.bind(), hyper_gdf(),
+            verbose=False, direct=True, opts={'CATEGORIES': {'n': ['aa', 'bb', 'cc']}}, engine=Engine.CUDF)
+        
+        self.assertEqual(len(h.edges), 9)
+        self.assertEqual(len(h.nodes), 6)
+
+    def test_hyperedges_direct_manual_shaping(self):
+        import cudf
+
+        h1 = hypergraph(
+            PyGraphistry.bind(), hyper_gdf(),
+            verbose=False, direct=True, opts={'EDGES': {'aa': ['cc'], 'cc': ['cc']}}, engine=Engine.CUDF)
+        self.assertEqual(len(h1.edges), 6)
+
+        h2 = hypergraph(
+            PyGraphistry.bind(), hyper_gdf(),
+            verbose=False, direct=True, opts={'EDGES': {'aa': ['cc', 'bb', 'aa'], 'cc': ['cc']}}, engine=Engine.CUDF)
+        self.assertEqual(len(h2.edges), 12)
+
+
+    def test_drop_edge_attrs(self):
+        import cudf
+    
+        h = hypergraph(
+            PyGraphistry.bind(), cudf.DataFrame.from_pandas(triangleNodes), ['id', 'a1', '🙈'],
+            verbose=False, drop_edge_attrs=True, engine=Engine.CUDF)
+
+        edges = cudf.DataFrame({
+            'edgeType': ['a1', 'a1', 'a1', 'id', 'id', 'id', '🙈', '🙈', '🙈'],
+            'attribID': [
+                'a1::1', 'a1::2', 'a1::3', 
+                'id::a', 'id::b', 'id::c',
+                '🙈::æski ēˈmōjē', '🙈::😋', '🙈::s'],
+            'EventID': ['EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2', 'EventID::0', 'EventID::1', 'EventID::2']})
+
+
+        assertFrameEqualCudf(h.edges, edges)
+        for (k, v) in [('entities', 9), ('nodes', 12), ('edges', 9), ('events', 3)]:
+            logger.debug('testing: %s = %s', k, getattr(h, k))
+            self.assertEqual(len(getattr(h, k)), v)
+
+    def test_drop_edge_attrs_direct(self):
+        import cudf
+        
+        h = hypergraph(
+            PyGraphistry.bind(), cudf.DataFrame.from_pandas(triangleNodes),
+            ['id', 'a1', '🙈'],
+            verbose=False, direct=True, drop_edge_attrs=True,
+            opts = {
+                'EDGES': {
+                    'id': ['a1'],
+                    'a1': ['🙈']
+                }
+            },
+            engine=Engine.CUDF)
+
+        logger.debug('h.nodes: %s', h.graph._nodes)
+        logger.debug('h.edges: %s', h.graph._edges)
+
+        edges = cudf.DataFrame({
+            'edgeType': ['a1::🙈', 'a1::🙈', 'a1::🙈', 'id::a1', 'id::a1', 'id::a1'],
+            'src': [
+                'a1::1', 'a1::2', 'a1::3',
+                'id::a', 'id::b', 'id::c'],
+            'dst': [
+                '🙈::æski ēˈmōjē', '🙈::😋', '🙈::s',
+                'a1::1', 'a1::2', 'a1::3'],
+            'EventID': [
+                'EventID::0', 'EventID::1', 'EventID::2',
+                'EventID::0', 'EventID::1', 'EventID::2']})
+
+        assertFrameEqualCudf(h.edges, edges)
+        for (k, v) in [('entities', 9), ('nodes', 9), ('edges', 6), ('events', 0)]:
+            logger.error('testing: %s', k)
+            logger.error('actual: %s', getattr(h,k))
+            self.assertEqual(len(getattr(h,k)), v)
+
+
+    def test_drop_na_hyper(self):
+        import cudf
+
+        df = cudf.DataFrame({
+            'a': ['a', None, 'c'],
+            'i': [1, 2, None]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, drop_na=True, engine=Engine.CUDF)
+
+        assert len(hg.graph._nodes) == 7
+        assert len(hg.graph._edges) == 4
+
+    def test_drop_na_direct(self):
+        import cudf
+
+        df = cudf.DataFrame({
+            'a': ['a', None, 'a'],
+            'i': [1, 1, None]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, drop_na=True, direct=True, engine=Engine.CUDF)
+
+        assert len(hg.graph._nodes) == 2
+        assert len(hg.graph._edges) == 1
+
+    def test_skip_na_hyperedge(self):
+        import cudf
+    
+        nans_df = cudf.DataFrame({
+          'x': ['a', 'b', 'c'],
+          'y': ['aa', None, 'cc']
+        })
+        expected_hits = ['a', 'b', 'c', 'aa', 'cc']
+
+        skip_attr_h_edges = hypergraph(
+            PyGraphistry.bind(), nans_df, drop_edge_attrs=True,
+            engine=Engine.CUDF).edges
+        self.assertEqual(len(skip_attr_h_edges), len(expected_hits))
+
+        default_h_edges = hypergraph(
+            PyGraphistry.bind(), nans_df,
+            engine=Engine.CUDF).edges
+        self.assertEqual(len(default_h_edges), len(expected_hits))
+
+    def test_hyper_evil(self):
+        import cudf
+
+        hypergraph(
+            PyGraphistry.bind(), cudf.DataFrame.from_pandas(squareEvil_gdf_friendly),
+            engine=Engine.CUDF)
+
+    def test_hyper_to_pa_vanilla(self):
+        import cudf
+
+        df = cudf.DataFrame({
+            'x': ['a', 'b', 'c'],
+            'y': ['d', 'e', 'f']
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, engine=Engine.CUDF)
+        nodes_arr = hg.graph._nodes.to_arrow()
+        assert len(nodes_arr) == 9
+        edges_err = hg.graph._edges.to_arrow()
+        assert len(edges_err) == 6
+
+    def test_hyper_to_pa_mixed(self):
+        import cudf
+
+        df = cudf.DataFrame({
+            'x': ['a', 'b', 'c'],
+            'y': [1, 2, 3]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, engine=Engine.CUDF)
+        nodes_arr = hg.graph._nodes.to_arrow()
+        assert len(nodes_arr) == 9
+        edges_err = hg.graph._edges.to_arrow()
+        assert len(edges_err) == 6
+
+    def test_hyper_to_pa_na(self):
+        import cudf
+
+        df = cudf.DataFrame({
+            'x': ['a', None, 'c'],
+            'y': [1, 2, None]
+        })
+
+        hg = hypergraph(PyGraphistry.bind(), df, drop_na=False, engine=Engine.CUDF)
+        nodes_arr = hg.graph._nodes.to_arrow()
+        assert len(hg.graph._nodes) == 9
+        assert len(nodes_arr) == 9
+        edges_err = hg.graph._edges.to_arrow()
+        assert len(hg.graph._edges) == 6
+        assert len(edges_err) == 6
+
+    def test_hyper_to_pa_all(self):
+        import cudf
+        hg = hypergraph(
+            PyGraphistry.bind(), cudf.DataFrame.from_pandas(triangleNodes), ['id', 'a1', '🙈'],
+            engine=Engine.CUDF)
+        nodes_arr = hg.graph._nodes.to_arrow()
+        assert len(hg.graph._nodes) == 12
+        assert len(nodes_arr) == 12
+        edges_err = hg.graph._edges.to_arrow()
+        assert len(hg.graph._edges) == 9
+        assert len(edges_err) == 9
+
+    def test_hyper_to_pa_all_direct(self):
+        import cudf
+        hg = hypergraph(
+            PyGraphistry.bind(), cudf.DataFrame.from_pandas(triangleNodes), ['id', 'a1', '🙈'],
+            direct=True, engine=Engine.CUDF)
+        nodes_arr = hg.graph._nodes.to_arrow()
+        assert len(hg.graph._nodes) == 9
+        assert len(nodes_arr) == 9
+        edges_err = hg.graph._edges.to_arrow()
+        assert len(hg.graph._edges) == 9
+        assert len(edges_err) == 9

--- a/graphistry/tests/test_hyper_dask.py
+++ b/graphistry/tests/test_hyper_dask.py
@@ -515,3 +515,11 @@ class TestHypergraphCudf(NoAuthTestCase):
         edges_err = hg.graph._edges.to_arrow()
         assert len(hg.graph._edges) == 9
         assert len(edges_err) == 9
+
+    def test_hyperedges_import(self):
+        from graphistry.pygraphistry import hypergraph as hypergraph_public
+
+        h = hypergraph_public(hyper_gdf(), verbose=False, direct=True, engine='cudf')
+
+        self.assertEqual(len(h['edges']), 9)
+        self.assertEqual(len(h['nodes']), 9)


### PR DESCRIPTION
Redo hypergraph:

* Pandas: vectorize
* Cudf: pure cudf impl
* Typed output
* Engine class for picking pd/cudf/dask/dask_cudf

For now, public API input/output contract stays the same, except:
* can pass in cudf.DataFrame
* and for it to work, set optional param `engine = 'cudf'`



