### PR TITLE
Dev/fix lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
-## [0.19.34- 2021-07-22]
+## [0.19.35 - 2021-08-15]
+
+### Fixed
+
+* Fix: igraph `.plot()` arrow coercion syntax error (https://github.com/graphistry/pygraphistry/issues/257)
+* Fix: Lint duplicate import warning
+
+### Changed
+
+* CI: Treat lint warnings as CI failures
+
+
+## [0.19.34 - 2021-07-22]
 
 ### Added
 * Infra: Add CI stage that installs and tests with minimal core deps (https://github.com/graphistry/pygraphistry/issues/254)

--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -9,7 +9,6 @@ flake8 --version
 # Quick syntax errors
 flake8 \
     graphistry \
-    --exit-zero \
     --count \
     --select=E9,F63,F7,F82 \
     --show-source \
@@ -18,7 +17,6 @@ flake8 \
 # Deeper check
 flake8 \
   graphistry \
-  --exit-zero \
   --exclude graphistry/graph_vector_pb2.py,graphistry/_version.py \
   --count \
   --ignore=C901,E121,E123,E125,E128,E131,E144,E201,E202,E203,E231,E251,E265,E301,E302,E303,E401,E501,E722,F401,W291,W293 \

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -1272,7 +1272,7 @@ class PlotterBase(Plottable):
             import igraph
             if isinstance(graph, igraph.Graph):
                 (e, n) = g.igraph2pandas(graph)
-                return g._make_dataset(e, n, name, description, mode, metadata. memoize)
+                return g._make_dataset(e, n, name, description, mode, metadata, memoize)
         except ImportError:
             pass
 

--- a/graphistry/tests/test_ipython.py
+++ b/graphistry/tests/test_ipython.py
@@ -1,7 +1,7 @@
 import graphistry, IPython
 from common import NoAuthTestCase
 from mock import patch
-from graphistry.tests.test_plotter import Fake_Response, NoAuthTestCase, triangleEdges
+from graphistry.tests.test_plotter import Fake_Response, triangleEdges
 
 
 @patch('webbrowser.open')

--- a/graphistry/tests/test_plotter.py
+++ b/graphistry/tests/test_plotter.py
@@ -505,6 +505,16 @@ class TestPlotterArrowConversions(NoAuthTestCase):
         ds = g.plot(skip_upload=True)
         assert isinstance(ds.edges, pa.Table)
 
+    @pytest.mark.xfail(raises=ModuleNotFoundError)
+    def test_api3_plot_from_igraph(self):
+        g = graphistry.bind(source='src', destination='dst', node='id')
+        ig = g.pandas2igraph(triangleEdges)
+        (e, n) = g.igraph2pandas(ig)
+        g = g.edges(e).nodes(n)
+        ds = g.plot(skip_upload=True)
+        assert isinstance(ds.edges, pa.Table)
+        assert isinstance(ds.nodes, pa.Table)
+
     def test_api3_plot_from_arrow(self):
         g = graphistry.edges(pa.Table.from_pandas(pd.DataFrame({'s': [0], 'd': [0]}))).bind(source='s', destination='d')
         ds = g.plot(skip_upload=True)


### PR DESCRIPTION
Fix:
*  igraph `.plot()` arrow coercion syntax error (https://github.com/graphistry/pygraphistry/issues/257)
*  Lint duplicate import warning

Infra:
* Treat lint warnings as CI failures