### PR TITLE
Fixes exception thrown for networkx recent version stamps

### DIFF
--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -1208,10 +1208,10 @@ class PlotterBase(Plottable):
     def networkx_checkoverlap(self, g):
 
         import networkx as nx
-        [x, y] = [int(x) for x in nx.__version__.split('.')]
+        [_major, _minor] = nx.__version__.split('.', 1)
 
         vattribs = None
-        if x == 1:
+        if _major == '1':
             vattribs = g.nodes(data=True)[0][1] if g.number_of_nodes() > 0 else []
         else:
             vattribs = g.nodes(data=True) if g.number_of_nodes() > 0 else []


### PR DESCRIPTION
Parsing of the version string for Networkx relies on the assumption that there are only 2 parts (eg. 1.2 or 2.3). Releases which include subversions (2.5.1) fail to be parsed and raise an exception.

Since only the major part of the version number is needed, I have modified the method to split only this component. Additionally, I have removed the integer conversion, since there is no need for making the subsequent decesion on API usage.