### PR TITLE
Dev/sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
-## [0.19.36 - 2021-08-15]
+## [0.19.6 - 2021-08-15]
 
 ### Fixed
 
 * Fix: NetworkX 2.5+ support - accept minor version tags
 
-## [0.19.35 - 2021-08-15]
+## [0.19.5 - 2021-08-15]
 
 ### Fixed
 
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * CI: Treat lint warnings as CI failures
 
 
-## [0.19.34 - 2021-07-22]
+## [0.19.4 - 2021-07-22]
 
 ### Added
 * Infra: Add CI stage that installs and tests with minimal core deps (https://github.com/graphistry/pygraphistry/issues/254)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+### Added
+* Feature: global `graphistry.privacy()` and compositional `Plotter.privacy()`
+* Docs: How to use `privacy()`
+
+### Changed
+
+* Docs: Start removing deprecated 1.0 API docs
+
 ## [0.19.6 - 2021-08-15]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+## [0.19.36 - 2021-08-15]
+
+### Fixed
+
+* Fix: NetworkX 2.5+ support - accept minor version tags
+
 ## [0.19.35 - 2021-08-15]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can use PyGraphistry with traditional Python data sources like CSVs, SQL, Ne
 
 * **Configurable:** In-tool or via the declarative APIs, use the powerful encodings systems for tasks like coloring by time, sizing by score, clustering by weight, show icons by type, and more.
 
+* **Shareable:** Share live links, configure who has access, and more! 
+
 ### Explore any data as a graph
 
 It is easy to turn arbitrary data into insightful graphs. PyGraphistry comes with many built-in connectors, and by supporting Python dataframes (Pandas, Arrow, RAPIDS), it's easy to bring standard Python data libraries. If the data comes as a table instead of a graph, PyGraphistry will help you extract and explore the relationships.
@@ -252,6 +254,7 @@ Set visual attributes through [quick data bindings](https://hub.graphistry.com/d
 
   ```python
     g
+      .privacy(mode='private', invited_users=[{'email': 'friend1@site.ngo', 'action': '10'}], notify=False)
       .edges(df, 'col_a', 'col_b')
       .edges(my_transform1(g._edges))
       .nodes(df, 'col_c')
@@ -340,7 +343,7 @@ Non-Python users may want to explore the underlying language-neutral [authentica
 
 ```python
 import graphistry
-graphistry.register(api=3, username='username', password='your password') # 2.0 API
+graphistry.register(api=3, username='username', password='your password')
 ```
 
 * **For code**: Long-running services may prefer to use 1-hour JWT tokens:
@@ -358,16 +361,6 @@ assert initial_one_hour_token != fresh_token
 ```
 
 Alternatively, you can rerun `graphistry.register(api=3, username='username', password='your password')`, which will also fetch a fresh token.
-
-* **Legacy: 1.0 API (WARNING: DEPRECATED)**
-
-```python
-#graphistry.register(api=1, key='Your key') # 1.0 API; note parameter name/value 'key' is different from `token`
-```
-
-Optionally, for convenience in the 1.0 API, you may set your API key in your system environment and thereby skip the register step in all your notebooks. In your `.profile` or `.bash_profile`, add the following and reload your environment:
-
-```export GRAPHISTRY_API_KEY="Your key"```
 
 #### Advanced: Private servers
 
@@ -400,6 +393,51 @@ graphistry.register(
 ```
 
 Prebuilt Graphistry servers are already setup to do this out-of-the-box.
+
+#### Advanced: Sharing controls
+
+Graphistry supports flexible sharing permissions that are similar to Google documents
+
+By default, visualizations are publicly viewable by anyone with the (unguessable) URL, and only editable by their owner.
+
+* Private-only: You can default uploads to private:
+
+```python
+graphistry.privacy()
+# or graphistry.privacy(mode='private')
+```
+
+* Invitees: You can share access to specify users, and optionally, even email them invites
+
+```python
+VIEW = "10"
+EDIT = "20"
+graphistry.privacy(
+  mode='private',
+  invited_users=[ 
+    {"email": "friend1@site1.com", "action": VIEW},
+    {"email": "friend2@site2.com", "action": EDIT}
+  ],
+  notify=True)
+```
+
+* Per-visualization: You can choose different rules for global defaults vs. for specific visualizations
+
+```python
+VIEW = "10"
+EDIT = "20"
+graphistry.privacy(
+  mode='private',
+  invited_users=[ 
+    {"email": "friend1@site1.com", "action": VIEW},
+    {"email": "friend2@site2.com", "action": EDIT}
+  ],
+  notify=False)
+
+g = graphistry.hypergraph(pd.read_csv('...'))['graph']
+g = g.privacy(notify=True)  # Override global default just for g
+g.plot()
+```
 
 ## Tutorial: Les Misérables
 

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -112,6 +112,7 @@ class PlotterBase(Plottable):
         self._height : int = 500
         self._render : bool = True
         self._url_params : dict = {'info': 'true'}
+        self._privacy = None
         # Metadata
         self._name : Optional[str] = None
         self._description : Optional[str] = None
@@ -1021,6 +1022,116 @@ class PlotterBase(Plottable):
         res._height = height or self._height
         res._url_params = dict(self._url_params, **url_params)
         res._render = self._render if render is None else render
+        return res
+
+
+    def privacy(self, mode: Optional[str] = None, notify: Optional[bool] = None, invited_users: Optional[List] = None, message: Optional[str] = None):
+        """Set local sharing mode
+
+        :param mode: Either "private", "public", or inherit from global privacy()
+        :type mode: Optional[str]
+        :param notify: Whether to email the recipient(s) upon upload, defaults to global privacy()
+        :type notify: Optional[bool]
+        :param invited_users: List of recipients, where each is {"email": str, "action": str} and action is "10" (view) or "20" (edit), defaults to global privacy()
+        :type invited_users: Optional[List]
+        :param message: Email to send when notify=True
+        :type message': Optioanl[str]
+
+        Requires an account with sharing capabilities.
+
+        Shared datasets will appear in recipients' galleries.
+
+        If mode is set to "private", only accounts in invited_users list can access. Mode "public" permits viewing by any user with the URL.
+
+        Action "10" (view) gives read access, while action "20" (edit) gives edit access, like changing the sharing mode.
+
+        When notify is true, uploads will trigger notification emails to invitees. Email will use visualization's ".name()"
+
+        When settings are not specified, they are inherited from the global graphistry.privacy() defaults
+
+        **Example: Limit visualizations to current user**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph']
+                g = g.privacy()  # default uploads to mode="private"
+                g.plot()
+
+
+        **Example: Default to publicly viewable visualizations**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph']
+                #g = g.privacy(mode="public")  # can skip calling .privacy() for this default
+                g.plot()
+
+
+        **Example: Default to sharing with select teammates, and keep notifications opt-in**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph']
+                g = g.privacy(
+                    mode="private",
+                    invited_users=[
+                        {"email": "friend1@acme.org", "action": "10"}, # view
+                        {"email": "friend2@acme.org", "action": "20"}, # edit
+                    ],
+                    notify=False)
+                g.plot()
+
+
+        **Example: Keep visualizations public and email notifications upon upload**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph']
+                g = g.name('my cool viz')  # For friendlier invitations
+                g = g.privacy(
+                    mode="public",
+                    invited_users=[
+                        {"email": "friend1@acme.org", "action": "10"}, # view
+                        {"email": "friend2@acme.org", "action": "20"}, # edit
+                    ],
+                    notify=True)
+                g.plot()
+        """
+
+        res = copy.copy(self)
+        res._privacy = copy.copy(self._privacy or {})
+        if mode is not None:
+            res._privacy['mode'] = mode
+        if notify is not None:
+            res._privacy['notify'] = notify
+        if invited_users is not None:
+            res._privacy['invited_users'] = invited_users
+        if message is not None:
+            res._privacy['message'] = message
         return res
 
 

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -1219,6 +1219,7 @@ class PlotterBase(Plottable):
                 return dataset
             dataset.token = PyGraphistry.api_token()
             dataset.post(as_files=as_files, memoize=memoize)
+            dataset.maybe_post_share_link(self)
             info = {
                 'name': dataset.dataset_id,
                 'type': 'arrow',

--- a/graphistry/__init__.py
+++ b/graphistry/__init__.py
@@ -1,6 +1,6 @@
 from graphistry.pygraphistry import (  # noqa: E402, F401
     client_protocol_hostname, protocol, server,
-    register, login, refresh, api_token, verify_token,
+    register, privacy, login, refresh, api_token, verify_token,
     store_token_creds_in_memory,
     name, description,
     bind, style, addStyle, edges, nodes, graph, settings,

--- a/graphistry/arrow_uploader.py
+++ b/graphistry/arrow_uploader.py
@@ -438,6 +438,8 @@ class ArrowUploader:
         except Exception as e:
             logger.error('Unexpected error setting sharing settings: %s', res.text, exc_info=True)
             raise e
+
+        logger.debug('Set privacy: mode %s, notify %s, users %s, message: %s', mode, notify, invited_users, message)
         
         return out
 
@@ -513,6 +515,7 @@ class ArrowUploader:
         out = self.post()
 
         from .pygraphistry import PyGraphistry
+        logger.debug('Privacy: global (%s), local (%s)', PyGraphistry._config['privacy'] or 'None', g._privacy or 'None')
         if PyGraphistry._config['privacy'] is not None or g._privacy is not None:
             self.post_share_link(self.dataset_id, 'dataset', g._privacy)
 

--- a/graphistry/arrow_uploader.py
+++ b/graphistry/arrow_uploader.py
@@ -1,5 +1,6 @@
 #Enable when we drop 3.6
 #from __future__ import annotations
+from typing import List, Optional
 
 import io, logging, pyarrow as pa, requests, sys
 from .ArrowFileUploader import ArrowFileUploader
@@ -351,6 +352,96 @@ class ArrowUploader:
         
         return self
 
+
+    ###########################################
+
+
+    def cascade_privacy_settings(
+        self,
+        mode: Optional[str] = None,
+        notify: Optional[bool] = None,
+        invited_users: Optional[List] = None,
+        message: Optional[str] = None
+    ):
+        """
+        Cascade:
+            - local (passed in)
+            - global
+            - hard-coded
+        """
+
+        from .pygraphistry import PyGraphistry
+        global_privacy = PyGraphistry._config['privacy']
+        if global_privacy is not None:
+            if mode is None:
+                mode = global_privacy['mode']
+            if notify is None:
+                notify = global_privacy['notify']
+            if invited_users is None:
+                invited_users = global_privacy['invited_users']
+            if message is None:
+                message = global_privacy['message']
+
+        if mode is None:
+            mode = 'private'
+        if notify is None:
+            notify = False
+        if invited_users is None:
+            invited_users = []
+        if message is None:
+            message = ''
+
+        return mode, notify, invited_users, message
+
+
+    def post_share_link(
+        self,
+        obj_pk: str,
+        obj_type: str = 'dataset',
+        privacy: Optional[dict] = None
+    ):
+        """
+        Set sharing settings. Any settings not passed here will cascade from PyGraphistry or defaults
+        """
+
+        mode, notify, invited_users, message = self.cascade_privacy_settings(**(privacy or {}))
+
+        path = self.server_base_path + '/api/v2/share/link/'
+        tok = self.token
+        res = requests.post(
+            path,
+            verify=self.certificate_validation,
+            headers={'Authorization': f'Bearer {tok}'},
+            json={
+                'obj_pk': obj_pk,
+                'obj_type': obj_type,
+                'mode': mode,
+                'notify': notify,
+                'invited_users': invited_users,
+                'message': message
+            })
+
+        if res.status_code != requests.codes.ok:
+            logger.error('Failed setting sharing status (code %s): %s', res.status_code, res.text, exc_info=True)
+
+        if res.status_code == 404:
+            raise Exception(f'Code not find resource {path}; is your server location correct and does it support sharing?')
+
+        if res.status_code == 403:
+            raise Exception(f'Permission denied ({path}); do you have edit access and does your account having sharing enabled?')
+
+        try:
+            out = res.json()
+            logger.debug('Server create file response: %s', out)
+            if res.status_code != requests.codes.ok:
+                res.raise_for_status()
+        except Exception as e:
+            logger.error('Unexpected error setting sharing settings: %s', res.text, exc_info=True)
+            raise e
+        
+        return out
+
+
     ###########################################
 
 
@@ -419,7 +510,13 @@ class ArrowUploader:
         if not (g._nodes is None):
             self.nodes = pa.Table.from_pandas(g._nodes, preserve_index=False).replace_schema_metadata({})
 
-        return self.post()
+        out = self.post()
+
+        from .pygraphistry import PyGraphistry
+        if PyGraphistry._config['privacy'] is not None or g._privacy is not None:
+            self.post_share_link(self.dataset_id, 'dataset', g._privacy)
+
+        return out
     
     def post_edges_file(self, file_path, file_type='csv'):
         return self.post_file(file_path, 'edges', file_type)

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -48,7 +48,10 @@ default_config = {
     'protocol': 'https',
     'client_protocol_hostname': None,
     'certificate_validation': True,
-    'store_token_creds_in_memory': True
+    'store_token_creds_in_memory': True,
+
+    #Do not call API when all None
+    'privacy': None
 }
 
 
@@ -367,6 +370,104 @@ class PyGraphistry(object):
         PyGraphistry.authenticate()
 
         PyGraphistry.set_bolt_driver(bolt)
+
+    @staticmethod
+    def privacy(mode: Optional[str] = None, notify: Optional[bool] = None, invited_users: Optional[List] = None, message: Optional[str] = None):
+        """Set global default sharing mode
+
+        :param mode: Either "private" or "public"
+        :type mode: str
+        :param notify: Whether to email the recipient(s) upon upload
+        :type notify: bool
+        :param invited_users: List of recipients, where each is {"email": str, "action": str} and action is "10" (view) or "20" (edit)
+        :type invited_users: List
+
+        Requires an account with sharing capabilities.
+
+        Shared datasets will appear in recipients' galleries.
+
+        If mode is set to "private", only accounts in invited_users list can access. Mode "public" permits viewing by any user with the URL.
+
+        Action "10" (view) gives read access, while action "20" (edit) gives edit access, like changing the sharing mode.
+
+        When notify is true, uploads will trigger notification emails to invitees. Email will use visualization's ".name()"
+
+        **Example: Limit visualizations to current user**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                graphistry.privacy()  # default uploads to mode="private"
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph'].plot()
+
+
+        **Example: Default to publicly viewable visualizations**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                #graphistry.privacy(mode="public")  # can skip calling .privacy() for this default
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph'].plot()
+
+
+        **Example: Default to sharing with select teammates, and keep notifications opt-in**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                graphistry.privacy(
+                    mode="private",
+                    invited_users=[
+                        {"email": "friend1@acme.org", "action": "10"}, # view
+                        {"email": "friend2@acme.org", "action": "20"}, # edit
+                    ],
+                    notify=False)
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph'].plot()
+
+
+        **Example: Keep visualizations public and email notifications upon upload**
+
+            ::
+
+                import graphistry
+                graphistry.register(api=3, username='myuser', password='mypassword')
+                graphistry.privacy(
+                    mode="public",
+                    invited_users=[
+                        {"email": "friend1@acme.org", "action": "10"}, # view
+                        {"email": "friend2@acme.org", "action": "20"}, # edit
+                    ],
+                    notify=True)
+                
+                #Subsequent uploads default to using .privacy() settings
+                users_df = pd.DataFrame({'user': ['a','b','x'], 'boss': ['x', 'x', 'y']})
+                h = graphistry.hypergraph(users_df, direct=True)
+                g = h['graph']
+                g = g.name('my cool viz')  # For friendlier invitations
+                g.plot()
+        """
+
+        PyGraphistry._config['privacy'] = {
+            'mode': mode,
+            'notify': notify,
+            'invited_users': invited_users,
+            'message': message
+        }
 
 
     @staticmethod
@@ -1675,6 +1776,7 @@ store_token_creds_in_memory = PyGraphistry.store_token_creds_in_memory
 server = PyGraphistry.server
 protocol = PyGraphistry.protocol
 register = PyGraphistry.register
+privacy = PyGraphistry.privacy
 login = PyGraphistry.login
 refresh = PyGraphistry.refresh
 api_token = PyGraphistry.api_token

--- a/graphistry/tests/test_arrow_uploader.py
+++ b/graphistry/tests/test_arrow_uploader.py
@@ -3,6 +3,7 @@
 import graphistry, mock, pandas as pd, pytest, unittest
 
 from graphistry import ArrowUploader
+from graphistry.pygraphistry import PyGraphistry
 
 #TODO mock requests for testing actual effectful code
 
@@ -127,6 +128,31 @@ class TestArrowUploader_Core(unittest.TestCase):
                 }
             }
         }
+
+    def test_cascade_privacy_settings_default_global(self):
+        PyGraphistry._config['privacy'] = None
+        PyGraphistry.privacy()
+        au = ArrowUploader()
+        assert au.cascade_privacy_settings() == ('private', False, [], '')
+
+    def test_cascade_privacy_settings_global_override(self):
+        PyGraphistry._config['privacy'] = None
+        PyGraphistry.privacy(mode='public', notify=True)
+        au = ArrowUploader()
+        assert au.cascade_privacy_settings() == ('public', True, [], '')
+
+    def test_cascade_privacy_settings_local_override(self):
+        PyGraphistry._config['privacy'] = None
+        g = graphistry.bind().privacy(mode='public', notify=True)
+        au = ArrowUploader()
+        assert au.cascade_privacy_settings(**g._privacy) == ('public', True, [], '')
+
+    def test_cascade_privacy_settings_local_override_cascade(self):
+        PyGraphistry._config['privacy'] = None
+        PyGraphistry.privacy()
+        g = graphistry.bind().privacy(mode='public', notify=True)
+        au = ArrowUploader()
+        assert au.cascade_privacy_settings(**g._privacy) == ('public', True, [], '')
 
 
 class TestArrowUploader_Comms(unittest.TestCase):


### PR DESCRIPTION
Docs: Start removing deprecated api=1
Feat: Sharing api

Global default:

```python
#Set global
graphistry.privacy()

#same as above
graphistry.privacy(mode='private', invited_users=[], notify=False)

#public, except email an invite
graphistry.privacy(mode='public', invited_users=[{"email": "user1@site1.com", "action": "10"], notify=True, message="hello")
```

Local override:

```
g = graphistry.edges(...)
g = g.privacy(mode='private')  # local override
g.plot()
```