### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,14 @@ on:
 
 jobs:
 
-  authorize-collaborators:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: octokit/request-action@v2.1.0
-      id: auth_check
-      with:
-        route: GET /repos/graphistry/pygraphistry/collaborators/${{ github.actor }}
-        mediaType: application/vnd.github.v3+json
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
   test-minimal-python:
 
-    needs: [ authorize-collaborators ]
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7]
 
     steps:
 
@@ -64,7 +51,7 @@ jobs:
 
   test-core-python:
 
-    needs: [ authorize-collaborators ]
+    needs: [ test-minimal-python ]
     runs-on: ubuntu-latest
 
     strategy:
@@ -106,7 +93,7 @@ jobs:
 
   test-neo4j:
 
-    needs: [ authorize-collaborators ]  # Wait on test-core-python / run flake8?
+    needs: [ test-minimal-python ]
     runs-on: ubuntu-latest
 
     steps:
@@ -119,7 +106,7 @@ jobs:
 
   test-build:
 
-    needs: [ authorize-collaborators ]  # Wait on test-core-python / run flake8?
+    needs: [ test-minimal-python ]
     runs-on: ubuntu-latest
 
     steps:
@@ -142,7 +129,7 @@ jobs:
   
   test-docs:
 
-    needs: [ authorize-collaborators ]  # Wait on test-core-python / run flake8?
+    needs: [ test-minimal-python ]
     runs-on: ubuntu-latest
 
     steps:
@@ -155,7 +142,7 @@ jobs:
   
   test-readme:
 
-    needs: [ authorize-collaborators ]  # Wait on test-core-python / run flake8?
+    needs: [ test-minimal-python ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
     - uses: octokit/request-action@v2.1.0
       with:
-        route: GET /repos/${{ github.repository }}/collaborators/${{ github.actor }}
+        route: GET /repos/{owner}/{repo}/collaborators/${{ github.actor }}
+        owner: graphistry
+        repo: pygraphistry
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,9 @@ jobs:
 
     steps:
     - uses: octokit/request-action@v2.1.0
+      id: auth_check
       with:
-        route: GET /repos/{owner}/{repo}/collaborators/${{ github.actor }}
-        owner: graphistry
-        repo: pygraphistry
+        route: GET /repos/graphistry/pygraphistry/collaborators/${{ github.actor }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: octokit/request-action@v2.0.0
+    - uses: octokit/request-action@v2.1.0
       with:
         route: GET /repos/:repository/collaborators/${{ github.actor }}
         repository: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       id: auth_check
       with:
         route: GET /repos/graphistry/pygraphistry/collaborators/${{ github.actor }}
+        mediaType: application/vnd.github.v3+json
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
     steps:
     - uses: octokit/request-action@v2.1.0
       with:
-        route: GET /repos/:repository/collaborators/${{ github.actor }}
-        repository: ${{ github.repository }}
+        route: GET /repos/${{ github.repository }}/collaborators/${{ github.actor }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Handle auth action failure in https://github.com/graphistry/pygraphistry/runs/3706003779?check_suite_focus=true :

```
Warning: Unexpected input(s) 'repository', valid inputs are ['route']
Run octokit/request-action@v2.0.0
  with:
    route: GET /repos/:repository/collaborators/lmeyerov
    repository: graphistry/pygraphistry
  env:
    GITHUB_TOKEN: ***
GET /repos/:repository/collaborators/lmeyerov
> repository: graphistry/pygraphistry
Error: Not Found
```

This appears to be a spurious 404 -- manual CLI-level works --  but not the first time it's happened with GHA (see action's issues history).

Changed repo to only run actions for internal collaborators, so could just delete here.

