### PR TITLE
fix(igraph): reindex from_igraph src/dst to id vs idx

### DIFF
--- a/graphistry/tests/test_igraph.py
+++ b/graphistry/tests/test_igraph.py
@@ -22,6 +22,17 @@ names = ["my", "list", "of", "five", "edges"]
 nodes = [0, 1, 2, 3, 4]
 names_v = ["eggs", "spam", "ham", "bacon", "yello"]
 
+edges2_df = pd.DataFrame({
+    'a': ['c', 'd', 'a', 'b', 'b'],
+    'b': ['d', 'a', 'b', 'c', 'c'],
+    'v1': ['cc', 'dd', 'aa', 'bb', 'bb2'],
+    'i': [2, 4, 6, 8, 10]
+})
+nodes2_df = pd.DataFrame({
+    'n': ['a', 'c', 'b', 'd'],
+    'v': ['aa', 'cc', 'bb', 'dd'],
+    'i': [2, 4, 6, 8]
+})
 
 @pytest.mark.skipif(not has_igraph, reason="Requires igraph")
 class Test_from_igraph(NoAuthTestCase):
@@ -158,6 +169,19 @@ class Test_from_igraph(NoAuthTestCase):
         assert g2._source == g._source
         assert g2._destination == g._destination
         assert sorted(g2._edges.columns) == sorted(['s', 'd'])
+
+    def test_edges_named(self):
+        g = graphistry.edges(edges2_df, 'a', 'b').nodes(nodes2_df, 'n')
+        ig = g.to_igraph()
+        g2 = g.from_igraph(ig)
+        assert len(g2._nodes) == len(g._nodes)
+        assert len(g2._edges) == len(g._edges)
+        g2n = g2._nodes.sort_values(by='n').reset_index(drop=True)
+        assert g2n.equals(pd.DataFrame({
+            'n': ['a', 'b', 'c', 'd'],
+            'v': ['aa', 'bb', 'cc', 'dd'],
+            'i': [2, 6, 4, 8]
+        }))
 
 
 @pytest.mark.skipif(not has_igraph, reason="Requires igraph")


### PR DESCRIPTION
`from_igraph` was not reindexing edge src/dst idx as id, giving unexpected results

This fix unblocks igraph layout flows:

```python
nodes_df = pd.DataFrame({
    'n': ['a', 'c', 'b', 'd'],
    'v': ['aa', 'cc', 'bb', 'dd']
})
edges_df = pd.DataFrame({
    'a': ['c', 'd', 'a', 'b', 'b'],
    'b': ['d', 'a', 'b', 'c', 'c'],
    'v1': ['cc', 'dd', 'aa', 'bb', 'bb2']
})
g = graphistry.edges(edges_df, 'a', 'b').nodes(nodes_df, 'n')

ig = g.to_igraph()
layout_df = pd.DataFrame([x for x in ig.layout('circle')])

g2a = g.from_igraph(ig)
g2b = (g2a
      .nodes(g2a._nodes.assign(x=layout_df[0], y=layout_df[1]))
      .bind(point_x='x', point_y='y')
      .settings(url_params={'play': 0})
)
g2b.plot()
```