### PR TITLE
fix: change python-igraph package name to igraph in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+## [0.29.3 - 2023-07=19]
+
+### Changed
+
+* igraph: Change dependency to new package name before old deprecates (https://github.com/graphistry/pygraphistry/pull/494)
+
 ## [0.29.2 - 2023-07-10]
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ dev_extras = {
 }
 
 base_extras_light = {
-    'igraph': ['python-igraph'],
+    'igraph': ['igraph'],
     'networkx': ['networkx>=2.5'],
     'gremlin': ['gremlinpython'],
     'bolt': ['neo4j', 'neotime'],


### PR DESCRIPTION
This is needed because python-igraph was renamed to igraph and the old name is just a legacy redirect to igraph itself that will be deactivated soon.