### PR TITLE
Dev/gfql serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+## [0.32.0 - 2023-12-22]
+
 ### Added
 
 * GFQL `Chain` AST object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * GFQL in readme.md
 
+### Breaking 🔥
+
+* GFQL `e()` now aliases `e_undirected` instead of the base class `ASTEdge`
+
 ## [0.31.1 - 2023-12-05]
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+### Docs
+
+* GFQL in readme.md
+
 ## [0.31.1 - 2023-12-05]
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+### Added
+* GFQL predicate `is_year_end`
+
 ### Docs
 
 * GFQL in readme.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-* GFQL query serialization: `graphistry.compute.from_json(graphistry.compute.to_json([...]))`
+* GFQL `Chain` AST object
+* GFQL query serialization - `Chain`, `ASTObject`, and `ASTPredict` implement `ASTSerializable`
+  - Ex:`Chain.from_json(Chain([n(), e(), n()]).to_json())`
 * GFQL predicate `is_year_end`
 
 ### Docs
 
 * GFQL in readme.md
+
+### Changes
+
+* Refactor `ASTEdge`, `ASTNode` field naming convention to match other `ASTSerializable`s
 
 ### Breaking 🔥
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 
 ### Added
+
+* GFQL query serialization: `graphistry.compute.from_json(graphistry.compute.to_json([...]))`
 * GFQL predicate `is_year_end`
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ It is easy to turn arbitrary data into insightful graphs. PyGraphistry comes wit
     g2.plot()
     ```
 
-* Cypher-style graph pattern mining queries on dataframes ([ipynb demo](demos/more_examples/graphistry_features/hop_and_chain_graph_pattern_mining.ipynb))
+* GFQL: Cypher-style graph pattern mining queries on dataframes ([ipynb demo](demos/more_examples/graphistry_features/hop_and_chain_graph_pattern_mining.ipynb))
 
-  Run Cypher-style graph queries natively on dataframes without going to a database or Java:
+  Run Cypher-style graph queries natively on dataframes without going to a database or Java with GFQL:
 
     ```python
     from graphistry import n, e_undirected, is_in
@@ -1133,7 +1133,7 @@ g2.plot() # nodes are values from cols s, d, k1
     destination_node_match={"k2": 2},
     destination_node_query='k2 == 2 or k2 == 4',
   )
-  .chain([ # filter to subgraph
+  .chain([ # filter to subgraph with Cypher-style GFQL
     n(),
     n({'k2': 0, "m": 'ok'}), #specific values
     n({'type': is_in(["type1", "type2"])}), #multiple valid values
@@ -1156,7 +1156,7 @@ g2.plot() # nodes are values from cols s, d, k1
   .collapse(node='some_id', column='some_col', attribute='some val')
 ```
 
-Both `hop()` and `chain()` match dictionary expressions support dataframe series *predicates*. The above examples show `is_in([x, y, z, ...])`. Additional predicates include:
+Both `hop()` and `chain()` (GFQL) match dictionary expressions support dataframe series *predicates*. The above examples show `is_in([x, y, z, ...])`. Additional predicates include:
 
 * categorical: is_in, duplicated
 * temporal: is_month_start, is_month_end, is_quarter_start, is_quarter_end, is_year_start, is_year_end
@@ -1233,7 +1233,7 @@ assert 'pagerank' in g2._nodes.columns
 
 #### Graph pattern matching
 
-PyGraphistry supports a PyData-native variant of the popular Cypher graph query language, meaning you can do graph pattern matching directly from Pandas dataframes without installing a database or Java
+PyGraphistry supports GFQL, its PyData-native variant of the popular Cypher graph query language, meaning you can do graph pattern matching directly from Pandas dataframes without installing a database or Java
 
 See also [graph pattern matching tutorial](demos/more_examples/graphistry_features/hop_and_chain_graph_pattern_mining.ipynb)
 

--- a/README.md
+++ b/README.md
@@ -1319,11 +1319,11 @@ See table above for more predicates like `is_in()` and `gt()`
 Queries can be serialized and deserialized, such as for saving and remote execution:
 
 ```python
-from graphistry.compute.chain import from_json, to_json
+from graphistry.compute.chain import Chain
 
-pattern = [n(), e(), n()]
-pattern_json = to_json(pattern)
-pattern2 = from_json(pattern_json)
+pattern = Chain([n(), e(), n()])
+pattern_json = pattern.to_json()
+pattern2 = Chain.from_json(pattern_json)
 g.chain(pattern2).plot()
 ```
 

--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,17 @@ print('# end edges: ', len(g3._edges[ g3._edges.final_edge ]))
 
 See table above for more predicates like `is_in()` and `gt()`
 
+Queries can be serialized and deserialized, such as for saving and remote execution:
+
+```python
+from graphistry.compute.chain import from_json, to_json
+
+pattern = [n(), e(), n()]
+pattern_json = to_json(pattern)
+pattern2 = from_json(pattern_json)
+g.chain(pattern2).plot()
+```
+
 #### Pipelining
 
 ```python

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,7 @@ nitpick_ignore = [
     ('py:class', 'graphistry.compute.predicates.temporal.IsQuarterEnd'),
     ('py:class', 'graphistry.compute.predicates.temporal.IsQuarterStart'),
     ('py:class', 'graphistry.compute.predicates.temporal.IsYearStart'),
+    ('py:class', 'graphistry.compute.predicates.temporal.IsYearEnd'),
     ('py:class', 'graphistry.Engine.Engine'),
     ('py:class', 'graphistry.gremlin.CosmosMixin'),
     ('py:class', 'graphistry.gremlin.GremlinMixin'),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ nitpick_ignore = [
     ('py:class', 'graphistry.compute.predicates.numeric.LT'),
     ('py:class', 'graphistry.compute.predicates.numeric.NE'),
     ('py:class', 'graphistry.compute.predicates.numeric.NotNA'),
+    ('py:class', 'graphistry.compute.predicates.numeric.NumericASTPredicate'),
     ('py:class', 'graphistry.compute.predicates.str.Contains'),
     ('py:class', 'graphistry.compute.predicates.str.Endswith'),
     ('py:class', 'graphistry.compute.predicates.str.IsAlnum'),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,8 @@ nitpick_ignore = [
     ('py:class', '3'),
     ('py:class', "<class 'dict'>"),
     ('py:class', "<class 'str'>"),
+    ('py:class', "graphistry.compute.ASTSerializable.ASTSerializable"),
+    ('py:class', "graphistry.compute.chain.Chain"),
     ('py:class', "graphistry.compute.predicates.ASTPredicate.ASTPredicate"),
     ('py:class', 'graphistry.compute.predicates.categorical.Duplicated'),
     ('py:class', 'graphistry.compute.predicates.is_in.IsIn'),

--- a/graphistry/__init__.py
+++ b/graphistry/__init__.py
@@ -51,6 +51,7 @@ from graphistry.pygraphistry import (  # noqa: E402, F401
 
 from graphistry.compute import (
     n, e_forward, e_reverse, e_undirected,
+    Chain,
 
     is_in, IsIn,
 

--- a/graphistry/__init__.py
+++ b/graphistry/__init__.py
@@ -61,6 +61,7 @@ from graphistry.compute import (
     is_quarter_start, IsQuarterStart,
     is_quarter_end, IsQuarterEnd,
     is_year_start, IsYearStart,
+    is_year_end, IsYearEnd,
     is_leap_year, IsLeapYear,
 
     gt, GT,

--- a/graphistry/compute/ASTSerializable.py
+++ b/graphistry/compute/ASTSerializable.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+import pandas as pd
+
+from graphistry.utils.json import JSONVal, serialize_to_json_val
+
+
+class ASTSerializable(ABC):
+    """
+    Internal, not intended for use outside of this module.
+    Class name becomes o['type'], and all non reserved_fields become JSON-typed key
+    """
+
+    reserved_fields = ['type']
+
+    def validate(self) -> None:
+        pass
+
+    def to_json(self, validate=True) -> Dict[str, JSONVal]:
+        """
+        Returns JSON-compatible dictionry {"type": "ClassName", "arg1": val1, ...}
+        Emits all non-reserved instance fields
+        """
+        if validate:
+            self.validate()
+        data: Dict[str, JSONVal] = {'type': self.__class__.__name__}
+        for key, value in self.__dict__.items():
+            if key not in self.reserved_fields:
+                data[key] = serialize_to_json_val(value)
+        return data
+
+    @classmethod
+    def from_json(cls, d: Dict[str, JSONVal]) -> 'ASTSerializable':
+        """
+        Given c.to_json(), hydrate back c
+
+        Corresponding c.__class__.__init__ must accept all non-reserved instance fields
+        """
+        constructor_args = {k: v for k, v in d.items() if k not in cls.reserved_fields}
+        return cls(**constructor_args)

--- a/graphistry/compute/__init__.py
+++ b/graphistry/compute/__init__.py
@@ -14,6 +14,7 @@ from .predicates.temporal import (
     is_quarter_start, IsQuarterStart,
     is_quarter_end, IsQuarterEnd,
     is_year_start, IsYearStart,
+    is_year_end, IsYearEnd,
     is_leap_year, IsLeapYear
 )
 from .predicates.numeric import (

--- a/graphistry/compute/__init__.py
+++ b/graphistry/compute/__init__.py
@@ -2,6 +2,7 @@ from .ComputeMixin import ComputeMixin
 from .ast import (
     n, e_forward, e_reverse, e_undirected
 )
+from .chain import Chain
 from .predicates.is_in import (
     is_in, IsIn
 )

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -5,7 +5,8 @@ from typing_extensions import Literal
 import pandas as pd
 
 from graphistry.Plottable import Plottable
-from graphistry.util import is_json_serializable, setup_logger
+from graphistry.util import setup_logger
+from graphistry.utils.json import is_json_serializable
 from .predicates.ASTPredicate import ASTPredicate
 from .predicates.is_in import (
     is_in, IsIn

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -223,7 +223,6 @@ class ASTEdge(ASTObject):
             destination_node_query=self._source_node_query,
             edge_query=self._edge_query
         )
-e = ASTEdge  # noqa: E305
 
 class ASTEdgeForward(ASTEdge):
     """
@@ -314,3 +313,4 @@ class ASTEdgeUndirected(ASTEdge):
         )
 
 e_undirected = ASTEdgeUndirected  # noqa: E305
+e = ASTEdgeUndirected  # noqa: E305

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -121,10 +121,11 @@ n = ASTNode  # noqa: E305
 
 ###############################################################################
 
+Direction = Literal['forward', 'reverse', 'undirected']
 
 DEFAULT_HOPS = 1
 DEFAULT_FIXED_POINT = False
-DEFAULT_DIRECTION = 'forward'
+DEFAULT_DIRECTION: Direction = 'forward'
 DEFAULT_FILTER_DICT = None
 
 class ASTEdge(ASTObject):
@@ -133,7 +134,7 @@ class ASTEdge(ASTObject):
     """
     def __init__(
         self,
-        direction: Optional[str] = DEFAULT_DIRECTION,
+        direction: Optional[Direction] = DEFAULT_DIRECTION,
         edge_match: Optional[dict] = DEFAULT_FILTER_DICT,
         hops: Optional[int] = DEFAULT_HOPS,
         to_fixed_point: bool = DEFAULT_FIXED_POINT,
@@ -158,7 +159,7 @@ class ASTEdge(ASTObject):
 
         self._hops = hops
         self._to_fixed_point = to_fixed_point
-        self._direction = direction
+        self._direction : Direction = direction
         self._source_node_match = source_node_match
         self._edge_match = edge_match
         self._destination_node_match = destination_node_match
@@ -206,6 +207,7 @@ class ASTEdge(ASTObject):
 
     def reverse(self) -> 'ASTEdge':
         # updates both edges and nodes
+        direction : Direction
         if self._direction == 'reverse':
             direction = 'forward'
         elif self._direction == 'forward':

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -253,9 +253,6 @@ class ASTEdgeForward(ASTEdge):
             edge_query=edge_query
         )
 
-    def __repr__(self) -> str:
-        return f'ASTEdgeForward(edge_match={self._edge_match}, hops={self._hops}, source_node_match={self._source_node_match}, destination_node_match={self._destination_node_match}, to_fixed_point={self._to_fixed_point}, name={self._name}, source_node_query={self._source_node_query}, destination_node_query={self._destination_node_query}, edge_query={self._edge_query})'
-
 e_forward = ASTEdgeForward  # noqa: E305
 
 class ASTEdgeReverse(ASTEdge):
@@ -285,9 +282,6 @@ class ASTEdgeReverse(ASTEdge):
             destination_node_query=destination_node_query,
             edge_query=edge_query
         )
-    
-    def __repr__(self) -> str:
-        return f'ASTEdgeReverse(edge_match={self._edge_match}, hops={self._hops}, source_node_match={self._source_node_match}, destination_node_match={self._destination_node_match}, to_fixed_point={self._to_fixed_point}, name={self._name}, source_node_query={self._source_node_query}, destination_node_query={self._destination_node_query}, edge_query={self._edge_query})'
 
 e_reverse = ASTEdgeReverse  # noqa: E305
 
@@ -318,8 +312,5 @@ class ASTEdgeUndirected(ASTEdge):
             destination_node_query=destination_node_query,
             edge_query=edge_query
         )
-
-    def __repr__(self) -> str:
-        return f'ASTEdgeUndirected(edge_match={self._edge_match}, hops={self._hops}, source_node_match={self._source_node_match}, destination_node_match={self._destination_node_match}, to_fixed_point={self._to_fixed_point}, name={self._name}, source_node_query={self._source_node_query}, destination_node_query={self._destination_node_query}, edge_query={self._edge_query})'
 
 e_undirected = ASTEdgeUndirected  # noqa: E305

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -17,6 +17,7 @@ from .predicates.temporal import (
     is_quarter_start, IsQuarterStart,
     is_quarter_end, IsQuarterEnd,
     is_year_start, IsYearStart,
+    is_year_end, IsYearEnd,
     is_leap_year, IsLeapYear
 )
 from .predicates.numeric import (

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, cast
+from typing_extensions import Literal
 import pandas as pd
 
 from graphistry.Plottable import Plottable

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1,11 +1,51 @@
-from typing import Dict, cast, List, Tuple
+from typing import Dict, Union, cast, List, Tuple
 import pandas as pd
 
 from graphistry.Plottable import Plottable
+from graphistry.compute.ASTSerializable import ASTSerializable
 from graphistry.util import setup_logger
+from graphistry.utils.json import JSONVal
 from .ast import ASTObject, ASTNode, ASTEdge, from_json as ASTObject_from_json
 
 logger = setup_logger(__name__)
+
+
+###############################################################################
+
+
+class Chain(ASTSerializable):
+
+    def __init__(self, chain: List[ASTObject]) -> None:
+        self.chain = chain
+
+    def validate(self) -> None:
+        assert isinstance(self.chain, list)
+        for op in self.chain:
+            assert isinstance(op, ASTObject)
+            op.validate()
+
+    @classmethod
+    def from_json(cls, d: Dict[str, JSONVal]) -> 'Chain':
+        """
+        Convert a JSON AST into a list of ASTObjects
+        """
+        assert isinstance(d, dict)
+        assert 'chain' in d
+        assert isinstance(d['chain'], list)
+        out = cls([ASTObject_from_json(op) for op in d['chain']])
+        out.validate()
+        return out
+
+    def to_json(self, validate=True) -> Dict[str, JSONVal]:
+        """
+        Convert a list of ASTObjects into a JSON AST
+        """
+        if validate:
+            self.validate()
+        return {
+            'type': self.__class__.__name__,
+            'chain': [op.to_json() for op in self.chain]
+        }
 
 
 ###############################################################################
@@ -92,12 +132,14 @@ def combine_steps(g: Plottable, kind: str, steps: List[Tuple[ASTObject,Plottable
 #
 ###############################################################################
 
-def chain(self: Plottable, ops: List[ASTObject]) -> Plottable:
+def chain(self: Plottable, ops: Union[List[ASTObject], Chain]) -> Plottable:
     """
-    Experimental: Chain a list of operations
+    Chain a list of ASTObject (node/edge) traversal operations
 
     Return subgraph of matches according to the list of node & edge matchers
     If any matchers are named, add a correspondingly named boolean-valued column to the output
+
+    For direct calls, exposes convenience `List[ASTObject]`. Internal operational should prefer `Chain`.
 
     :param ops: List[ASTObject] Various node and edge matchers
 
@@ -161,6 +203,9 @@ def chain(self: Plottable, ops: List[ASTObject]) -> Plottable:
             print('# hits:', len(g_risky._nodes[ g_risky._nodes.hit ]))
 
     """
+
+    if isinstance(ops, Chain):
+        ops = ops.chain
 
     if len(ops) == 0:
         return self
@@ -253,18 +298,3 @@ def chain(self: Plottable, ops: List[ASTObject]) -> Plottable:
     g_out = g.nodes(final_nodes_df).edges(final_edges_df)
 
     return g_out
-
-###
-
-def from_json(d: Dict) -> List[ASTObject]:
-    """
-    Convert a JSON AST into a list of ASTObjects
-    """
-    assert isinstance(d, list)
-    return [ASTObject_from_json(op) for op in d]
-
-def to_json(ops: List[ASTObject]) -> List[Dict]:
-    """
-    Convert a list of ASTObjects into a JSON AST
-    """
-    return [op.to_json() for op in ops]

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1,9 +1,9 @@
-from typing import cast, List, Tuple
+from typing import Dict, cast, List, Tuple
 import pandas as pd
 
 from graphistry.Plottable import Plottable
 from graphistry.util import setup_logger
-from .ast import ASTObject, ASTNode, ASTEdge
+from .ast import ASTObject, ASTNode, ASTEdge, from_json as ASTObject_from_json
 
 logger = setup_logger(__name__)
 
@@ -253,3 +253,18 @@ def chain(self: Plottable, ops: List[ASTObject]) -> Plottable:
     g_out = g.nodes(final_nodes_df).edges(final_edges_df)
 
     return g_out
+
+###
+
+def from_json(d: Dict) -> List[ASTObject]:
+    """
+    Convert a JSON AST into a list of ASTObjects
+    """
+    assert isinstance(d, list)
+    return [ASTObject_from_json(op) for op in d]
+
+def to_json(ops: List[ASTObject]) -> List[Dict]:
+    """
+    Convert a list of ASTObjects into a JSON AST
+    """
+    return [op.to_json() for op in ops]

--- a/graphistry/compute/predicates/ASTPredicate.py
+++ b/graphistry/compute/predicates/ASTPredicate.py
@@ -10,4 +10,15 @@ class ASTPredicate():
 
     @abstractmethod
     def __call__(self, s: pd.Series) -> pd.Series:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def to_json(self, validate=True) -> dict:
+        raise NotImplementedError()
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'ASTPredicate':
+        raise NotImplementedError()
+
+    def validate(self) -> None:
         pass

--- a/graphistry/compute/predicates/ASTPredicate.py
+++ b/graphistry/compute/predicates/ASTPredicate.py
@@ -1,24 +1,44 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
+from typing import Any, Dict
 import pandas as pd
 
+from graphistry.utils.json import JSONVal, serialize_to_json_val
 
-class ASTPredicate():
+
+class ASTPredicate(ABC):
     """
     Internal, not intended for use outside of this module.
     These are fancy columnar predicates used in {k: v, ...} node/edge df matching when going beyond primitive equality
     """
 
+    reserved_fields = ['type']
+
     @abstractmethod
     def __call__(self, s: pd.Series) -> pd.Series:
         raise NotImplementedError()
 
-    @abstractmethod
-    def to_json(self, validate=True) -> dict:
-        raise NotImplementedError()
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'ASTPredicate':
-        raise NotImplementedError()
-
     def validate(self) -> None:
         pass
+
+    def to_json(self, validate=True) -> Dict[str, JSONVal]:
+        """
+        Returns JSON-compatible dictionry {"type": "ClassName", "arg1": val1, ...}
+        Emits all non-reserved instance fields
+        """
+        if validate:
+            self.validate()
+        data: Dict[str, JSONVal] = {'type': self.__class__.__name__}
+        for key, value in self.__dict__.items():
+            if key not in self.reserved_fields:
+                data[key] = serialize_to_json_val(value)
+        return data
+
+    @classmethod
+    def from_json(cls, d: Dict[str, JSONVal]) -> 'ASTPredicate':
+        """
+        Given c.to_json(), hydrate back c
+
+        Corresponding c.__class__.__init__ must accept all non-reserved instance fields
+        """
+        constructor_args = {k: v for k, v in d.items() if k not in cls.reserved_fields}
+        return cls(**constructor_args)

--- a/graphistry/compute/predicates/ASTPredicate.py
+++ b/graphistry/compute/predicates/ASTPredicate.py
@@ -1,44 +1,15 @@
-from abc import ABC, abstractmethod
-from typing import Any, Dict
+from abc import abstractmethod
 import pandas as pd
 
-from graphistry.utils.json import JSONVal, serialize_to_json_val
+from graphistry.compute.ASTSerializable import ASTSerializable
 
 
-class ASTPredicate(ABC):
+class ASTPredicate(ASTSerializable):
     """
     Internal, not intended for use outside of this module.
     These are fancy columnar predicates used in {k: v, ...} node/edge df matching when going beyond primitive equality
     """
 
-    reserved_fields = ['type']
-
     @abstractmethod
     def __call__(self, s: pd.Series) -> pd.Series:
         raise NotImplementedError()
-
-    def validate(self) -> None:
-        pass
-
-    def to_json(self, validate=True) -> Dict[str, JSONVal]:
-        """
-        Returns JSON-compatible dictionry {"type": "ClassName", "arg1": val1, ...}
-        Emits all non-reserved instance fields
-        """
-        if validate:
-            self.validate()
-        data: Dict[str, JSONVal] = {'type': self.__class__.__name__}
-        for key, value in self.__dict__.items():
-            if key not in self.reserved_fields:
-                data[key] = serialize_to_json_val(value)
-        return data
-
-    @classmethod
-    def from_json(cls, d: Dict[str, JSONVal]) -> 'ASTPredicate':
-        """
-        Given c.to_json(), hydrate back c
-
-        Corresponding c.__class__.__init__ must accept all non-reserved instance fields
-        """
-        constructor_args = {k: v for k, v in d.items() if k not in cls.reserved_fields}
-        return cls(**constructor_args)

--- a/graphistry/compute/predicates/categorical.py
+++ b/graphistry/compute/predicates/categorical.py
@@ -13,18 +13,6 @@ class Duplicated(ASTPredicate):
     def validate(self) -> None:
         assert self.keep in ['first', 'last', False]
 
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'Duplicated', 'keep': self.keep}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'Duplicated':
-        assert 'keep' in d
-        out = Duplicated(keep=d['keep'])
-        out.validate()
-        return out
-
 def duplicated(keep: Literal['first', 'last', False] = 'first') -> Duplicated:
     """
     Return whether a given value is duplicated

--- a/graphistry/compute/predicates/categorical.py
+++ b/graphistry/compute/predicates/categorical.py
@@ -10,6 +10,21 @@ class Duplicated(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.duplicated(keep=self.keep)
 
+    def validate(self) -> None:
+        assert self.keep in ['first', 'last', False]
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'Duplicated', 'keep': self.keep}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'Duplicated':
+        assert 'keep' in d
+        out = Duplicated(keep=d['keep'])
+        out.validate()
+        return out
+
 def duplicated(keep: Literal['first', 'last', False] = 'first') -> Duplicated:
     """
     Return whether a given value is duplicated

--- a/graphistry/compute/predicates/from_json.py
+++ b/graphistry/compute/predicates/from_json.py
@@ -37,5 +37,6 @@ def from_json(d: Dict[str, JSONVal]) -> ASTPredicate:
     assert isinstance(d['type'], str)
     pred = type_to_predicate[d['type']]
     out = pred.from_json(d)
+    assert isinstance(out, ASTPredicate)
     out.validate()
     return out

--- a/graphistry/compute/predicates/from_json.py
+++ b/graphistry/compute/predicates/from_json.py
@@ -1,0 +1,37 @@
+from typing import Dict, List, Type
+
+from graphistry.compute.predicates.ASTPredicate import ASTPredicate
+from graphistry.compute.predicates.categorical import Duplicated
+from graphistry.compute.predicates.is_in import IsIn
+from graphistry.compute.predicates.numeric import GT, LT, GE, LE, EQ, NE, Between, IsNA, NotNA
+from graphistry.compute.predicates.str import (
+    Contains, Startswith, Endswith, Match, IsNumeric, IsAlpha, IsDecimal, IsDigit, IsLower, IsUpper,
+    IsSpace, IsAlnum, IsTitle, IsNull, NotNull
+)
+from graphistry.compute.predicates.temporal import (
+    IsMonthStart, IsMonthEnd, IsQuarterStart, IsQuarterEnd,
+    IsYearStart, IsYearEnd, IsLeapYear
+)
+
+predicates : List[Type[ASTPredicate]] = [
+    Duplicated,
+    IsIn,
+    GT, LT, GE, LE, EQ, NE, Between, IsNA, NotNA,
+    Contains, Startswith, Endswith, Match, IsNumeric, IsAlpha, IsDecimal, IsDigit, IsLower, IsUpper,
+    IsSpace, IsAlnum, IsDecimal, IsTitle, IsNull, NotNull,
+    IsMonthStart, IsMonthEnd, IsQuarterStart, IsQuarterEnd,
+    IsYearStart, IsYearEnd, IsLeapYear
+]
+
+type_to_predicate: Dict[str, Type[ASTPredicate]] = {
+    cls.__name__: cls
+    for cls in predicates
+}
+
+def from_json(d: Dict) -> ASTPredicate:
+    assert isinstance(d, dict)
+    assert 'type' in d
+    assert d['type'] in type_to_predicate
+    out = type_to_predicate[d['type']].from_json(d)
+    out.validate()
+    return out

--- a/graphistry/compute/predicates/from_json.py
+++ b/graphistry/compute/predicates/from_json.py
@@ -12,6 +12,8 @@ from graphistry.compute.predicates.temporal import (
     IsMonthStart, IsMonthEnd, IsQuarterStart, IsQuarterEnd,
     IsYearStart, IsYearEnd, IsLeapYear
 )
+from graphistry.utils.json import JSONVal
+
 
 predicates : List[Type[ASTPredicate]] = [
     Duplicated,
@@ -28,10 +30,12 @@ type_to_predicate: Dict[str, Type[ASTPredicate]] = {
     for cls in predicates
 }
 
-def from_json(d: Dict) -> ASTPredicate:
+def from_json(d: Dict[str, JSONVal]) -> ASTPredicate:
     assert isinstance(d, dict)
     assert 'type' in d
     assert d['type'] in type_to_predicate
-    out = type_to_predicate[d['type']].from_json(d)
+    assert isinstance(d['type'], str)
+    pred = type_to_predicate[d['type']]
+    out = pred.from_json(d)
     out.validate()
     return out

--- a/graphistry/compute/predicates/is_in.py
+++ b/graphistry/compute/predicates/is_in.py
@@ -1,6 +1,8 @@
 from typing import Any, List
 import pandas as pd
 
+from graphistry.util import assert_json_serializable
+
 from .ASTPredicate import ASTPredicate
 
 
@@ -10,6 +12,25 @@ class IsIn(ASTPredicate):
     
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.isin(self.options)
+    
+    def validate(self) -> None:
+        assert isinstance(self.options, list)
+        assert_json_serializable(self.options)
+    
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {
+            'type': 'IsIn',
+            'options': self.options
+        }
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsIn':
+        assert 'options' in d
+        out = IsIn(options=d['options'])
+        out.validate()
+        return out
 
 def is_in(options: List[Any]) -> IsIn:
     return IsIn(options)

--- a/graphistry/compute/predicates/is_in.py
+++ b/graphistry/compute/predicates/is_in.py
@@ -16,21 +16,6 @@ class IsIn(ASTPredicate):
     def validate(self) -> None:
         assert isinstance(self.options, list)
         assert_json_serializable(self.options)
-    
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {
-            'type': 'IsIn',
-            'options': self.options
-        }
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsIn':
-        assert 'options' in d
-        out = IsIn(options=d['options'])
-        out.validate()
-        return out
 
 def is_in(options: List[Any]) -> IsIn:
     return IsIn(options)

--- a/graphistry/compute/predicates/is_in.py
+++ b/graphistry/compute/predicates/is_in.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 import pandas as pd
 
-from graphistry.util import assert_json_serializable
+from graphistry.utils.json import assert_json_serializable
 
 from .ASTPredicate import ASTPredicate
 

--- a/graphistry/compute/predicates/numeric.py
+++ b/graphistry/compute/predicates/numeric.py
@@ -20,18 +20,6 @@ class GT(NumericASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s > self.val
 
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'GT', 'val': self.val}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'GT':
-        assert 'val' in d
-        out = GT(val=d['val'])
-        out.validate()
-        return out
-
 def gt(val: float) -> GT:
     """
     Return whether a given value is greater than a threshold
@@ -44,18 +32,6 @@ class LT(NumericASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s < self.val
-
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'LT', 'val': self.val}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'LT':
-        assert 'val' in d
-        out = LT(val=d['val'])
-        out.validate()
-        return out
 
 def lt(val: float) -> LT:
     """
@@ -70,18 +46,6 @@ class GE(NumericASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s >= self.val
 
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'GE', 'val': self.val}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'GE':
-        assert 'val' in d
-        out = GE(val=d['val'])
-        out.validate()
-        return out
-
 def ge(val: float) -> GE:
     """
     Return whether a given value is greater than or equal to a threshold
@@ -94,18 +58,6 @@ class LE(NumericASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s <= self.val
-
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'LE', 'val': self.val}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'LE':
-        assert 'val' in d
-        out = LE(val=d['val'])
-        out.validate()
-        return out
 
 def le(val: float) -> LE:
     """
@@ -120,18 +72,6 @@ class EQ(NumericASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s == self.val
 
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'EQ', 'val': self.val}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'EQ':
-        assert 'val' in d
-        out = EQ(val=d['val'])
-        out.validate()
-        return out
-
 def eq(val: float) -> EQ:
     """
     Return whether a given value is equal to a threshold
@@ -144,18 +84,6 @@ class NE(NumericASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s != self.val
-
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'NE', 'val': self.val}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'NE':
-        assert 'val' in d
-        out = NE(val=d['val'])
-        out.validate()
-        return out
 
 def ne(val: float) -> NE:
     """
@@ -180,20 +108,6 @@ class Between(ASTPredicate):
         assert isinstance(self.upper, (int, float))
         assert isinstance(self.inclusive, bool)
 
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {'type': 'Between', 'lower': self.lower, 'upper': self.upper, 'inclusive': self.inclusive}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'Between':
-        assert 'lower' in d
-        assert 'upper' in d
-        assert 'inclusive' in d
-        out = Between(lower=d['lower'], upper=d['upper'], inclusive=d['inclusive'])
-        out.validate()
-        return out
-
 def between(lower: float, upper: float, inclusive: bool = True) -> Between:
     """
     Return whether a given value is between a lower and upper threshold
@@ -203,13 +117,6 @@ def between(lower: float, upper: float, inclusive: bool = True) -> Between:
 class IsNA(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.isna()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsNA'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsNA':
-        return IsNA()
 
 def isna() -> IsNA:
     """
@@ -221,13 +128,6 @@ def isna() -> IsNA:
 class NotNA(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.notna()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'NotNA'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'NotNA':
-        return NotNA()
 
 def notna() -> NotNA:
     """

--- a/graphistry/compute/predicates/numeric.py
+++ b/graphistry/compute/predicates/numeric.py
@@ -1,14 +1,36 @@
-from typing import Optional
+from typing import Union
 import pandas as pd
 
 from .ASTPredicate import ASTPredicate
 
-class GT(ASTPredicate):
+
+class NumericASTPredicate(ASTPredicate):
+    def __init__(self, val: Union[int, float]) -> None:
+        self.val = val
+
+    def validate(self) -> None:
+        assert isinstance(self.val, (int, float))
+
+###
+
+class GT(NumericASTPredicate):
     def __init__(self, val: float) -> None:
         self.val = val
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s > self.val
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'GT', 'val': self.val}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'GT':
+        assert 'val' in d
+        out = GT(val=d['val'])
+        out.validate()
+        return out
 
 def gt(val: float) -> GT:
     """
@@ -16,12 +38,24 @@ def gt(val: float) -> GT:
     """
     return GT(val)
 
-class LT(ASTPredicate):
+class LT(NumericASTPredicate):
     def __init__(self, val: float) -> None:
         self.val = val
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s < self.val
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'LT', 'val': self.val}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'LT':
+        assert 'val' in d
+        out = LT(val=d['val'])
+        out.validate()
+        return out
 
 def lt(val: float) -> LT:
     """
@@ -29,12 +63,24 @@ def lt(val: float) -> LT:
     """
     return LT(val)
 
-class GE(ASTPredicate):
+class GE(NumericASTPredicate):
     def __init__(self, val: float) -> None:
         self.val = val
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s >= self.val
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'GE', 'val': self.val}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'GE':
+        assert 'val' in d
+        out = GE(val=d['val'])
+        out.validate()
+        return out
 
 def ge(val: float) -> GE:
     """
@@ -42,12 +88,24 @@ def ge(val: float) -> GE:
     """
     return GE(val)
 
-class LE(ASTPredicate):
+class LE(NumericASTPredicate):
     def __init__(self, val: float) -> None:
         self.val = val
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s <= self.val
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'LE', 'val': self.val}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'LE':
+        assert 'val' in d
+        out = LE(val=d['val'])
+        out.validate()
+        return out
 
 def le(val: float) -> LE:
     """
@@ -55,12 +113,24 @@ def le(val: float) -> LE:
     """
     return LE(val)
 
-class EQ(ASTPredicate):
+class EQ(NumericASTPredicate):
     def __init__(self, val: float) -> None:
         self.val = val
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s == self.val
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'EQ', 'val': self.val}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'EQ':
+        assert 'val' in d
+        out = EQ(val=d['val'])
+        out.validate()
+        return out
 
 def eq(val: float) -> EQ:
     """
@@ -68,12 +138,24 @@ def eq(val: float) -> EQ:
     """
     return EQ(val)
 
-class NE(ASTPredicate):
+class NE(NumericASTPredicate):
     def __init__(self, val: float) -> None:
         self.val = val
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s != self.val
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'NE', 'val': self.val}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'NE':
+        assert 'val' in d
+        out = NE(val=d['val'])
+        out.validate()
+        return out
 
 def ne(val: float) -> NE:
     """
@@ -92,6 +174,25 @@ class Between(ASTPredicate):
             return (s >= self.lower) & (s <= self.upper)
         else:
             return (s > self.lower) & (s < self.upper)
+        
+    def validate(self) -> None:
+        assert isinstance(self.lower, (int, float))
+        assert isinstance(self.upper, (int, float))
+        assert isinstance(self.inclusive, bool)
+
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {'type': 'Between', 'lower': self.lower, 'upper': self.upper, 'inclusive': self.inclusive}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'Between':
+        assert 'lower' in d
+        assert 'upper' in d
+        assert 'inclusive' in d
+        out = Between(lower=d['lower'], upper=d['upper'], inclusive=d['inclusive'])
+        out.validate()
+        return out
 
 def between(lower: float, upper: float, inclusive: bool = True) -> Between:
     """
@@ -102,6 +203,13 @@ def between(lower: float, upper: float, inclusive: bool = True) -> Between:
 class IsNA(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.isna()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsNA'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsNA':
+        return IsNA()
 
 def isna() -> IsNA:
     """
@@ -113,6 +221,13 @@ def isna() -> IsNA:
 class NotNA(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.notna()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'NotNA'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'NotNA':
+        return NotNA()
 
 def notna() -> NotNA:
     """

--- a/graphistry/compute/predicates/str.py
+++ b/graphistry/compute/predicates/str.py
@@ -14,6 +14,41 @@ class Contains(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.contains(self.pat, self.case, self.flags, self.na, self.regex)
+    
+    def validate(self) -> None:
+        assert isinstance(self.pat, str)
+        assert isinstance(self.case, bool)
+        assert isinstance(self.flags, int)
+        assert isinstance(self.na, (bool, type(None)))
+        assert isinstance(self.regex, bool)
+    
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {
+            'type': 'Contains',
+            'pat': self.pat,
+            'case': self.case,
+            'flags': self.flags,
+            **({'na': self.na} if self.na is not None else {}),
+            'regex': self.regex
+        }
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'Contains':
+        assert 'pat' in d
+        assert 'case' in d
+        assert 'flags' in d
+        assert 'regex' in d
+        out = Contains(
+            pat=d['pat'],
+            case=d['case'],
+            flags=d['flags'],
+            na=d['na'] if 'na' in d else None,
+            regex=d['regex']
+        )
+        out.validate()
+        return out
 
 def contains(pat: str, case: bool = True, flags: int = 0, na: Optional[bool] = None, regex: bool = True) -> Contains:
     """
@@ -29,6 +64,29 @@ class Startswith(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.startswith(self.pat, self.na)
+
+    def validate(self) -> None:
+        assert isinstance(self.pat, str)
+        assert isinstance(self.na, (str, type(None)))
+    
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {
+            'type': 'Startswith',
+            'pat': self.pat,
+            **({'na': self.na} if self.na is not None else {})
+        }
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'Startswith':
+        assert 'pat' in d
+        out = Startswith(
+            pat=d['pat'],
+            na=d['na'] if 'na' in d else None
+        )
+        out.validate()
+        return out
 
 def startswith(pat: str, na: Optional[str] = None) -> Startswith:
     """
@@ -47,6 +105,29 @@ class Endswith(ASTPredicate):
         """
         return s.str.endswith(self.pat, self.na)
 
+    def validate(self) -> None:
+        assert isinstance(self.pat, str)
+        assert isinstance(self.na, (str, type(None)))
+    
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {
+            'type': 'Endswith',
+            'pat': self.pat,
+            **({'na': self.na} if self.na is not None else {})
+        }
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'Endswith':
+        assert 'pat' in d
+        out = Endswith(
+            pat=d['pat'],
+            na=d['na'] if 'na' in d else None
+        )
+        out.validate()
+        return out
+
 def endswith(pat: str, na: Optional[str] = None) -> Endswith:
     return Endswith(pat, na)
 
@@ -59,6 +140,37 @@ class Match(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.match(self.pat, self.case, self.flags, self.na)
+    
+    def validate(self) -> None:
+        assert isinstance(self.pat, str)
+        assert isinstance(self.case, bool)
+        assert isinstance(self.flags, int)
+        assert isinstance(self.na, (bool, type(None)))
+    
+    def to_json(self, validate=True) -> dict:
+        if validate:
+            self.validate()
+        return {
+            'type': 'Match',
+            'pat': self.pat,
+            'case': self.case,
+            'flags': self.flags,
+            **({'na': self.na} if self.na is not None else {})
+        }
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'Match':
+        assert 'pat' in d
+        assert 'case' in d
+        assert 'flags' in d
+        out = Match(
+            pat=d['pat'],
+            case=d['case'],
+            flags=d['flags'],
+            na=d['na'] if 'na' in d else None
+        )
+        out.validate()
+        return out
 
 def match(pat: str, case: bool = True, flags: int = 0, na: Optional[bool] = None) -> Match:
     """
@@ -72,7 +184,14 @@ class IsNumeric(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isnumeric()
-
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsNumeric'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsNumeric':
+        return IsNumeric()
+    
 def isnumeric() -> IsNumeric:
     """
     Return whether a given string is numeric
@@ -85,6 +204,13 @@ class IsAlpha(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isalpha()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsAlpha'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsAlpha':
+        return IsAlpha()
 
 def isalpha() -> IsAlpha:
     """
@@ -98,6 +224,13 @@ class IsDigit(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isdigit()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsDigit'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsDigit':
+        return IsDigit()
 
 def isdigit() -> IsDigit:
     """
@@ -111,6 +244,13 @@ class IsLower(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.islower()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsLower'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsLower':
+        return IsLower()
 
 def islower() -> IsLower:
     """
@@ -124,6 +264,13 @@ class IsUpper(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isupper()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsUpper'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsUpper':
+        return IsUpper()
 
 def isupper() -> IsUpper:
     """
@@ -138,6 +285,13 @@ class IsSpace(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isspace()
     
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsSpace'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsSpace':
+        return IsSpace()
+    
 def isspace() -> IsSpace:
     """
     Return whether a given string is whitespace
@@ -151,6 +305,13 @@ class IsAlnum(ASTPredicate):
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isalnum()
     
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsAlnum'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsAlnum':
+        return IsAlnum()
+    
 def isalnum() -> IsAlnum:
     """
     Return whether a given string is alphanumeric
@@ -163,6 +324,13 @@ class IsDecimal(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isdecimal()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsDecimal'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsDecimal':
+        return IsDecimal()
 
 def isdecimal() -> IsDecimal:
     """
@@ -176,6 +344,13 @@ class IsTitle(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.istitle()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsTitle'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsTitle':
+        return IsTitle()
 
 def istitle() -> IsTitle:
     """
@@ -189,6 +364,13 @@ class IsNull(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series: 
         return s.isnull()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsNull'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsNull':
+        return IsNull()
 
 def isnull() -> IsNull:
     """
@@ -202,6 +384,13 @@ class NotNull(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series: 
         return s.notnull()
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'NotNull'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'NotNull':
+        return NotNull()
 
 def notnull() -> NotNull:
     """

--- a/graphistry/compute/predicates/str.py
+++ b/graphistry/compute/predicates/str.py
@@ -21,34 +21,6 @@ class Contains(ASTPredicate):
         assert isinstance(self.flags, int)
         assert isinstance(self.na, (bool, type(None)))
         assert isinstance(self.regex, bool)
-    
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {
-            'type': 'Contains',
-            'pat': self.pat,
-            'case': self.case,
-            'flags': self.flags,
-            **({'na': self.na} if self.na is not None else {}),
-            'regex': self.regex
-        }
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'Contains':
-        assert 'pat' in d
-        assert 'case' in d
-        assert 'flags' in d
-        assert 'regex' in d
-        out = Contains(
-            pat=d['pat'],
-            case=d['case'],
-            flags=d['flags'],
-            na=d['na'] if 'na' in d else None,
-            regex=d['regex']
-        )
-        out.validate()
-        return out
 
 def contains(pat: str, case: bool = True, flags: int = 0, na: Optional[bool] = None, regex: bool = True) -> Contains:
     """
@@ -68,25 +40,6 @@ class Startswith(ASTPredicate):
     def validate(self) -> None:
         assert isinstance(self.pat, str)
         assert isinstance(self.na, (str, type(None)))
-    
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {
-            'type': 'Startswith',
-            'pat': self.pat,
-            **({'na': self.na} if self.na is not None else {})
-        }
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'Startswith':
-        assert 'pat' in d
-        out = Startswith(
-            pat=d['pat'],
-            na=d['na'] if 'na' in d else None
-        )
-        out.validate()
-        return out
 
 def startswith(pat: str, na: Optional[str] = None) -> Startswith:
     """
@@ -108,25 +61,6 @@ class Endswith(ASTPredicate):
     def validate(self) -> None:
         assert isinstance(self.pat, str)
         assert isinstance(self.na, (str, type(None)))
-    
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {
-            'type': 'Endswith',
-            'pat': self.pat,
-            **({'na': self.na} if self.na is not None else {})
-        }
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'Endswith':
-        assert 'pat' in d
-        out = Endswith(
-            pat=d['pat'],
-            na=d['na'] if 'na' in d else None
-        )
-        out.validate()
-        return out
 
 def endswith(pat: str, na: Optional[str] = None) -> Endswith:
     return Endswith(pat, na)
@@ -146,31 +80,6 @@ class Match(ASTPredicate):
         assert isinstance(self.case, bool)
         assert isinstance(self.flags, int)
         assert isinstance(self.na, (bool, type(None)))
-    
-    def to_json(self, validate=True) -> dict:
-        if validate:
-            self.validate()
-        return {
-            'type': 'Match',
-            'pat': self.pat,
-            'case': self.case,
-            'flags': self.flags,
-            **({'na': self.na} if self.na is not None else {})
-        }
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'Match':
-        assert 'pat' in d
-        assert 'case' in d
-        assert 'flags' in d
-        out = Match(
-            pat=d['pat'],
-            case=d['case'],
-            flags=d['flags'],
-            na=d['na'] if 'na' in d else None
-        )
-        out.validate()
-        return out
 
 def match(pat: str, case: bool = True, flags: int = 0, na: Optional[bool] = None) -> Match:
     """
@@ -179,18 +88,9 @@ def match(pat: str, case: bool = True, flags: int = 0, na: Optional[bool] = None
     return Match(pat, case, flags, na)
 
 class IsNumeric(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isnumeric()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsNumeric'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsNumeric':
-        return IsNumeric()
     
 def isnumeric() -> IsNumeric:
     """
@@ -199,18 +99,9 @@ def isnumeric() -> IsNumeric:
     return IsNumeric()
 
 class IsAlpha(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isalpha()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsAlpha'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsAlpha':
-        return IsAlpha()
 
 def isalpha() -> IsAlpha:
     """
@@ -219,18 +110,9 @@ def isalpha() -> IsAlpha:
     return IsAlpha()
 
 class IsDigit(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isdigit()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsDigit'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsDigit':
-        return IsDigit()
 
 def isdigit() -> IsDigit:
     """
@@ -239,18 +121,9 @@ def isdigit() -> IsDigit:
     return IsDigit()
 
 class IsLower(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.islower()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsLower'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsLower':
-        return IsLower()
 
 def islower() -> IsLower:
     """
@@ -259,18 +132,9 @@ def islower() -> IsLower:
     return IsLower()
 
 class IsUpper(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isupper()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsUpper'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsUpper':
-        return IsUpper()
 
 def isupper() -> IsUpper:
     """
@@ -279,18 +143,9 @@ def isupper() -> IsUpper:
     return IsUpper()
 
 class IsSpace(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isspace()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsSpace'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsSpace':
-        return IsSpace()
     
 def isspace() -> IsSpace:
     """
@@ -299,18 +154,9 @@ def isspace() -> IsSpace:
     return IsSpace()
 
 class IsAlnum(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isalnum()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsAlnum'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsAlnum':
-        return IsAlnum()
     
 def isalnum() -> IsAlnum:
     """
@@ -319,18 +165,9 @@ def isalnum() -> IsAlnum:
     return IsAlnum()
 
 class IsDecimal(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.isdecimal()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsDecimal'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsDecimal':
-        return IsDecimal()
 
 def isdecimal() -> IsDecimal:
     """
@@ -339,18 +176,9 @@ def isdecimal() -> IsDecimal:
     return IsDecimal()
 
 class IsTitle(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.str.istitle()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsTitle'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsTitle':
-        return IsTitle()
 
 def istitle() -> IsTitle:
     """
@@ -359,18 +187,9 @@ def istitle() -> IsTitle:
     return IsTitle()
 
 class IsNull(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series: 
         return s.isnull()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsNull'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsNull':
-        return IsNull()
 
 def isnull() -> IsNull:
     """
@@ -379,18 +198,9 @@ def isnull() -> IsNull:
     return IsNull()
 
 class NotNull(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series: 
         return s.notnull()
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'NotNull'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'NotNull':
-        return NotNull()
 
 def notnull() -> NotNull:
     """

--- a/graphistry/compute/predicates/temporal.py
+++ b/graphistry/compute/predicates/temporal.py
@@ -9,6 +9,13 @@ class IsMonthStart(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_month_start
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsMonthStart'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsMonthStart':
+        return IsMonthStart()
 
 def is_month_start() -> IsMonthStart:
     """
@@ -22,6 +29,13 @@ class IsMonthEnd(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_month_end
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsMonthEnd'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsMonthEnd':
+        return IsMonthEnd()
 
 def is_month_end() -> IsMonthEnd:
     """
@@ -35,6 +49,13 @@ class IsQuarterStart(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_quarter_start
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsQuarterStart'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsQuarterStart':
+        return IsQuarterStart()
 
 def is_quarter_start() -> IsQuarterStart:
     """
@@ -48,6 +69,13 @@ class IsQuarterEnd(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_quarter_end
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsQuarterEnd'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsQuarterEnd':
+        return IsQuarterEnd()
 
 def is_quarter_end() -> IsQuarterEnd:
     """
@@ -61,6 +89,13 @@ class IsYearStart(ASTPredicate):
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_year_start
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsYearStart'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsYearStart':
+        return IsYearStart()
 
 def is_year_start() -> IsYearStart:
     """
@@ -68,12 +103,39 @@ def is_year_start() -> IsYearStart:
     """
     return IsYearStart()
 
+class IsYearEnd(ASTPredicate):
+    def __init__(self) -> None:
+        pass
+
+    def __call__(self, s: pd.Series) -> pd.Series:
+        return s.dt.is_year_end
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsYearEnd'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsYearEnd':
+        return IsYearEnd()
+
+def is_year_end() -> IsYearEnd:
+    """
+    Return whether a given value is a year end
+    """
+    return IsYearEnd()
+
 class IsLeapYear(ASTPredicate):
     def __init__(self) -> None:
         pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_leap_year
+    
+    def to_json(self, validate=True) -> dict:
+        return {'type': 'IsLeapYear'}
+    
+    @classmethod
+    def from_json(cls, d: dict) -> 'IsLeapYear':
+        return IsLeapYear()
 
 def is_leap_year() -> IsLeapYear:
     """

--- a/graphistry/compute/predicates/temporal.py
+++ b/graphistry/compute/predicates/temporal.py
@@ -4,18 +4,9 @@ import pandas as pd
 from .ASTPredicate import ASTPredicate
 
 class IsMonthStart(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_month_start
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsMonthStart'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsMonthStart':
-        return IsMonthStart()
 
 def is_month_start() -> IsMonthStart:
     """
@@ -24,18 +15,9 @@ def is_month_start() -> IsMonthStart:
     return IsMonthStart()
 
 class IsMonthEnd(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_month_end
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsMonthEnd'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsMonthEnd':
-        return IsMonthEnd()
 
 def is_month_end() -> IsMonthEnd:
     """
@@ -44,18 +26,9 @@ def is_month_end() -> IsMonthEnd:
     return IsMonthEnd()
 
 class IsQuarterStart(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_quarter_start
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsQuarterStart'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsQuarterStart':
-        return IsQuarterStart()
 
 def is_quarter_start() -> IsQuarterStart:
     """
@@ -64,18 +37,9 @@ def is_quarter_start() -> IsQuarterStart:
     return IsQuarterStart()
 
 class IsQuarterEnd(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_quarter_end
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsQuarterEnd'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsQuarterEnd':
-        return IsQuarterEnd()
 
 def is_quarter_end() -> IsQuarterEnd:
     """
@@ -84,18 +48,9 @@ def is_quarter_end() -> IsQuarterEnd:
     return IsQuarterEnd()
 
 class IsYearStart(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_year_start
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsYearStart'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsYearStart':
-        return IsYearStart()
 
 def is_year_start() -> IsYearStart:
     """
@@ -104,18 +59,9 @@ def is_year_start() -> IsYearStart:
     return IsYearStart()
 
 class IsYearEnd(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_year_end
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsYearEnd'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsYearEnd':
-        return IsYearEnd()
 
 def is_year_end() -> IsYearEnd:
     """
@@ -124,18 +70,9 @@ def is_year_end() -> IsYearEnd:
     return IsYearEnd()
 
 class IsLeapYear(ASTPredicate):
-    def __init__(self) -> None:
-        pass
 
     def __call__(self, s: pd.Series) -> pd.Series:
         return s.dt.is_leap_year
-    
-    def to_json(self, validate=True) -> dict:
-        return {'type': 'IsLeapYear'}
-    
-    @classmethod
-    def from_json(cls, d: dict) -> 'IsLeapYear':
-        return IsLeapYear()
 
 def is_leap_year() -> IsLeapYear:
     """

--- a/graphistry/tests/compute/predicates/test_categorical.py
+++ b/graphistry/tests/compute/predicates/test_categorical.py
@@ -1,0 +1,15 @@
+from graphistry.compute.predicates.categorical import Duplicated, duplicated
+
+def test_duplicated():
+
+    d = duplicated('last')
+    assert isinstance(d, Duplicated)
+    assert d.keep == 'last'
+
+    o = d.to_json()
+    assert isinstance(o, dict)
+    assert o['type'] == 'Duplicated'
+
+    d2 = Duplicated.from_json(o)
+    assert isinstance(d2, Duplicated)
+    assert d2.keep == 'last'

--- a/graphistry/tests/compute/predicates/test_from_json.py
+++ b/graphistry/tests/compute/predicates/test_from_json.py
@@ -1,0 +1,27 @@
+from graphistry.compute.predicates.categorical import Duplicated
+from graphistry.compute.predicates.from_json import from_json
+
+
+def test_from_json_good():
+    d = from_json({'type': 'Duplicated', 'keep': 'last'})
+    assert isinstance(d, Duplicated)
+    assert d.keep == 'last'
+
+def test_from_json_bad():
+    try:
+        from_json({'type': 'zzz'})
+        assert False
+    except AssertionError:
+        assert True
+
+    try:
+        from_json({'type': 'Duplicated', 'keep': 'zzz'})
+        assert False
+    except AssertionError:
+        assert True
+
+    try:
+        from_json({'type': 'Duplicated'})
+        assert False
+    except AssertionError:
+        assert True

--- a/graphistry/tests/compute/predicates/test_is_in.py
+++ b/graphistry/tests/compute/predicates/test_is_in.py
@@ -1,0 +1,16 @@
+from graphistry.compute.predicates.is_in import IsIn, is_in
+
+
+def test_is_in():
+
+    d = is_in([1, 2, 3])
+    assert isinstance(d, IsIn)
+    assert d.options == [1, 2, 3]
+
+    o = d.to_json()
+    assert isinstance(o, dict)
+    assert o['type'] == 'IsIn'
+
+    d2 = IsIn.from_json(o)
+    assert isinstance(d2, IsIn)
+    assert d2.options == [1, 2, 3]

--- a/graphistry/tests/compute/predicates/test_numeric.py
+++ b/graphistry/tests/compute/predicates/test_numeric.py
@@ -1,0 +1,16 @@
+from graphistry.compute.predicates.numeric import GT, gt
+
+def test_gt():
+
+    d = gt(1)
+    assert isinstance(d, GT)
+    assert d.val == 1
+
+    o = d.to_json()
+    assert isinstance(o, dict)
+    assert o['type'] == 'GT'
+    assert o['val'] == 1
+
+    d2 = GT.from_json(o)
+    assert isinstance(d2, GT)
+    assert d2.val == 1

--- a/graphistry/tests/compute/predicates/test_str.py
+++ b/graphistry/tests/compute/predicates/test_str.py
@@ -1,0 +1,14 @@
+from graphistry.compute.predicates.str import IsUpper, isupper
+
+
+def test_is_upper():
+    
+    d = isupper()
+    assert isinstance(d, IsUpper)
+
+    o = d.to_json()
+    assert isinstance(o, dict)
+    assert o['type'] == 'IsUpper'
+
+    d2 = IsUpper.from_json(o)
+    assert isinstance(d2, IsUpper)

--- a/graphistry/tests/compute/predicates/test_temporal.py
+++ b/graphistry/tests/compute/predicates/test_temporal.py
@@ -1,0 +1,13 @@
+from graphistry.compute.predicates.temporal import IsLeapYear, is_leap_year
+
+def test_is_leap_year():
+    
+    d = is_leap_year()
+    assert isinstance(d, IsLeapYear)
+
+    o = d.to_json()
+    assert isinstance(o, dict)
+    assert o['type'] == 'IsLeapYear'
+
+    d2 = IsLeapYear.from_json(o)
+    assert isinstance(d2, IsLeapYear)

--- a/graphistry/tests/compute/test_ast.py
+++ b/graphistry/tests/compute/test_ast.py
@@ -6,7 +6,7 @@ def test_serialization_node():
     o = node.to_json()
     node2 = from_json(o)
     assert isinstance(node2, ASTNode)
-    assert node2._query == 'zzz'
+    assert node2.query == 'zzz'
     assert node2._name == 'abc'
     o2 = node2.to_json()
     assert o == o2
@@ -17,7 +17,7 @@ def test_serialization_edge():
     o = edge.to_json()
     edge2 = from_json(o)
     assert isinstance(edge2, ASTEdge)
-    assert edge2._edge_query == 'zzz'
+    assert edge2.edge_query == 'zzz'
     assert edge2._name == 'abc'
     o2 = edge2.to_json()
     assert o == o2

--- a/graphistry/tests/compute/test_ast.py
+++ b/graphistry/tests/compute/test_ast.py
@@ -1,0 +1,23 @@
+from graphistry.compute.ast import from_json, ASTNode, ASTEdge, n, e, e_forward, e_reverse, e_undirected
+
+def test_serialization_node():
+
+    node = n(query='zzz', name='abc')
+    o = node.to_json()
+    node2 = from_json(o)
+    assert isinstance(node2, ASTNode)
+    assert node2._query == 'zzz'
+    assert node2._name == 'abc'
+    o2 = node2.to_json()
+    assert o == o2
+
+def test_serialization_edge():
+
+    edge = e(edge_query='zzz', name='abc')
+    o = edge.to_json()
+    edge2 = from_json(o)
+    assert isinstance(edge2, ASTEdge)
+    assert edge2._edge_query == 'zzz'
+    assert edge2._name == 'abc'
+    o2 = edge2.to_json()
+    assert o == o2

--- a/graphistry/tests/compute/test_chain.py
+++ b/graphistry/tests/compute/test_chain.py
@@ -1,0 +1,38 @@
+from graphistry.compute.ast import ASTNode, ASTEdge, n, e
+from graphistry.compute.chain import to_json as chain_to_json, from_json as chain_from_json
+
+def test_chain_serialization_mt():
+    o = chain_to_json([])
+    d = chain_from_json(o)
+    assert d == []
+    assert o == []
+
+def test_chain_serialization_node():
+    o = chain_to_json([n(query='zzz', name='abc')])
+    d = chain_from_json(o)
+    assert isinstance(d[0], ASTNode)
+    assert d[0]._query == 'zzz'
+    assert d[0]._name == 'abc'
+    o2 = chain_to_json(d)
+    assert o == o2
+
+def test_chain_serialization_edge():
+    o = chain_to_json([e(edge_query='zzz', name='abc')])
+    d = chain_from_json(o)
+    assert isinstance(d[0], ASTEdge)
+    assert d[0]._edge_query == 'zzz'
+    assert d[0]._name == 'abc'
+    o2 = chain_to_json(d)
+    assert o == o2
+
+def test_chain_serialization_multi():
+    o = chain_to_json([n(query='zzz', name='abc'), e(edge_query='zzz', name='abc')])
+    d = chain_from_json(o)
+    assert isinstance(d[0], ASTNode)
+    assert d[0]._query == 'zzz'
+    assert d[0]._name == 'abc'
+    assert isinstance(d[1], ASTEdge)
+    assert d[1]._edge_query == 'zzz'
+    assert d[1]._name == 'abc'
+    o2 = chain_to_json(d)
+    assert o == o2

--- a/graphistry/tests/compute/test_chain.py
+++ b/graphistry/tests/compute/test_chain.py
@@ -1,38 +1,38 @@
 from graphistry.compute.ast import ASTNode, ASTEdge, n, e
-from graphistry.compute.chain import to_json as chain_to_json, from_json as chain_from_json
+from graphistry.compute.chain import Chain
 
 def test_chain_serialization_mt():
-    o = chain_to_json([])
-    d = chain_from_json(o)
-    assert d == []
-    assert o == []
+    o = Chain([]).to_json()
+    d = Chain.from_json(o)
+    assert d.chain == []
+    assert o['chain'] == []
 
 def test_chain_serialization_node():
-    o = chain_to_json([n(query='zzz', name='abc')])
-    d = chain_from_json(o)
-    assert isinstance(d[0], ASTNode)
-    assert d[0]._query == 'zzz'
-    assert d[0]._name == 'abc'
-    o2 = chain_to_json(d)
+    o = Chain([n(query='zzz', name='abc')]).to_json()
+    d = Chain.from_json(o)
+    assert isinstance(d.chain[0], ASTNode)
+    assert d.chain[0].query == 'zzz'
+    assert d.chain[0]._name == 'abc'
+    o2 = d.to_json()
     assert o == o2
 
 def test_chain_serialization_edge():
-    o = chain_to_json([e(edge_query='zzz', name='abc')])
-    d = chain_from_json(o)
-    assert isinstance(d[0], ASTEdge)
-    assert d[0]._edge_query == 'zzz'
-    assert d[0]._name == 'abc'
-    o2 = chain_to_json(d)
+    o = Chain([e(edge_query='zzz', name='abc')]).to_json()
+    d = Chain.from_json(o)
+    assert isinstance(d.chain[0], ASTEdge)
+    assert d.chain[0].edge_query == 'zzz'
+    assert d.chain[0]._name == 'abc'
+    o2 = d.to_json()
     assert o == o2
 
 def test_chain_serialization_multi():
-    o = chain_to_json([n(query='zzz', name='abc'), e(edge_query='zzz', name='abc')])
-    d = chain_from_json(o)
-    assert isinstance(d[0], ASTNode)
-    assert d[0]._query == 'zzz'
-    assert d[0]._name == 'abc'
-    assert isinstance(d[1], ASTEdge)
-    assert d[1]._edge_query == 'zzz'
-    assert d[1]._name == 'abc'
-    o2 = chain_to_json(d)
+    o = Chain([n(query='zzz', name='abc'), e(edge_query='zzz', name='abc')]).to_json()
+    d = Chain.from_json(o)
+    assert isinstance(d.chain[0], ASTNode)
+    assert d.chain[0].query == 'zzz'
+    assert d.chain[0]._name == 'abc'
+    assert isinstance(d.chain[1], ASTEdge)
+    assert d.chain[1].edge_query == 'zzz'
+    assert d.chain[1]._name == 'abc'
+    o2 = d.to_json()
     assert o == o2

--- a/graphistry/tests/test_util.py
+++ b/graphistry/tests/test_util.py
@@ -1,0 +1,63 @@
+from graphistry.util import assert_json_serializable
+
+class TestAssertJsonSerializable():
+
+    def test_primitives(self):
+        assert_json_serializable(1)
+        assert_json_serializable(1.0)
+        assert_json_serializable('a')
+        assert_json_serializable(True)
+        assert_json_serializable(None)
+    
+    def test_list(self):
+        assert_json_serializable([])
+        assert_json_serializable([1])
+        assert_json_serializable([1, 2])
+        assert_json_serializable([1, 'a', True, None])
+    
+    def test_dict(self):
+        assert_json_serializable({})
+        assert_json_serializable({'a': 1})
+        assert_json_serializable({'a': 1, 'b': 2})
+        assert_json_serializable({'a': 1, 'b': 'b', 'c': True, 'd': None})
+    
+    def test_nested(self):
+        assert_json_serializable({'a': [1]})
+        assert_json_serializable({'a': {'b': 1}})
+        assert_json_serializable({'a': [{'b': 1}]})
+        assert_json_serializable({'a': [{'b': 1}, {'c': 2}]})
+    
+    def test_unserializable(self):
+
+        try:
+            assert_json_serializable(set())
+            assert False, 'Expected exception on set'
+        except AssertionError:
+            pass
+
+        try:
+            assert_json_serializable({'a': set()})
+            assert False, 'Expected exception on nested set'
+        except AssertionError:
+            pass
+
+        try:
+            assert_json_serializable({'a': [set()]})
+            assert False, 'Expected exception on nested set'
+        except AssertionError:
+            pass
+
+        try:
+            assert_json_serializable({'a': [{'b': set()}]})
+            assert False, 'Expected exception on nested set'
+        except AssertionError:
+            pass
+
+        class Unserializable:
+            pass
+
+        try:
+            assert_json_serializable(Unserializable())
+            assert False, 'Expected exception on class'
+        except AssertionError:
+            pass

--- a/graphistry/tests/utils/test_json.py
+++ b/graphistry/tests/utils/test_json.py
@@ -1,4 +1,4 @@
-from graphistry.util import assert_json_serializable
+from graphistry.utils.json import assert_json_serializable
 
 class TestAssertJsonSerializable():
 

--- a/graphistry/util.py
+++ b/graphistry/util.py
@@ -419,13 +419,3 @@ def printmd(string, color=None, size=20):
 #
 #     # matches name of inner function
 #     return wrapper
-
-def is_json_serializable(data):
-    try:
-        json.dumps(data)
-        return True
-    except TypeError:
-        return False
-
-def assert_json_serializable(data):
-    assert is_json_serializable(data), f"Data is not JSON-serializable: {data}"

--- a/graphistry/util.py
+++ b/graphistry/util.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import os
 import pandas as pd
@@ -418,3 +419,13 @@ def printmd(string, color=None, size=20):
 #
 #     # matches name of inner function
 #     return wrapper
+
+def is_json_serializable(data):
+    try:
+        json.dumps(data)
+        return True
+    except TypeError:
+        return False
+
+def assert_json_serializable(data):
+    assert is_json_serializable(data), f"Data is not JSON-serializable: {data}"

--- a/graphistry/utils/json.py
+++ b/graphistry/utils/json.py
@@ -1,0 +1,27 @@
+
+import json
+from typing import Any, Dict, List, Union
+
+
+JSONVal = Union[None, bool, str, float, int, List['JSONVal'], Dict[str, 'JSONVal']]
+
+
+def is_json_serializable(data):
+    try:
+        json.dumps(data)
+        return True
+    except TypeError:
+        return False
+
+def assert_json_serializable(data):
+    assert is_json_serializable(data), f"Data is not JSON-serializable: {data}"
+
+def serialize_to_json_val(obj: Any) -> JSONVal:
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    elif isinstance(obj, list):
+        return [serialize_to_json_val(item) for item in obj]
+    elif isinstance(obj, dict):
+        return {key: serialize_to_json_val(value) for key, value in obj.items()}
+    else:
+        raise TypeError(f"Unsupported type for to_json: {type(obj)}")


### PR DESCRIPTION
Adding serialization of GFQL queries in preparation for exposing as a public FEP endpoint on datasets

```python
pattern = [n(), e(), n()]
o = graphistry.compute.chain.to_json(pattern)
pattern2 = graphistry.compute.chain.from_json(o)
g.chain(pattern2).plot()
```

---

### Added

* GFQL `Chain` AST object
* GFQL query serialization - `Chain`, `ASTObject`, and `ASTPredict` implement `ASTSerializable`
  - Ex:`Chain.from_json(Chain([n(), e(), n()]).to_json())`
* GFQL predicate `is_year_end`

### Docs

* GFQL in readme.md

### Changes

* Refactor `ASTEdge`, `ASTNode` field naming convention to match other `ASTSerializable`s (`e.edge_query` vs `e._edge_query`)

### Breaking 🔥

* GFQL `e()` now aliases `e_undirected` instead of the base class `ASTEdge`
