### PR TITLE
Dev/more gfql fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 * GFQL: Export shorter alias `e` for `e_undirected`
+* Featurize: More auto-dropping of non-numerics when no `dirty_cat`
 
 ### Fixed
 
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Infra
 
 * Pin test env to work around test fails: `'test': ['flake8>=5.0', 'mock', 'mypy', 'pytest'] + stubs + test_workarounds,` +  `test_workarounds = ['scikit-learn<=1.3.2']`
+* Skip dbscan tests that require umap when it is not available
 
 ## [0.33.0 - 2023-12-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * GFQL: `hop()` defaults to `debugging_hop=False`
 * GFQL: Edge cases around shortest-path multi-hop queries failing to enrich against target nodes during backwards pass
 
+### Infra
+
+* Pin test env to work around test fails: `'test': ['flake8>=5.0', 'mock', 'mypy', 'pytest'] + stubs + test_workarounds,` +  `test_workarounds = ['scikit-learn<=1.3.2']`
+
 ## [0.33.0 - 2023-12-26]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 * GFQL: `hop()` defaults to `debugging_hop=False`
+* GFQL: Edge cases around shortest-path multi-hop queries failing to enrich against target nodes during backwards pass
 
 ## [0.33.0 - 2023-12-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * GFQL: Export shorter alias `e` for `e_undirected`
 
+### Fixed
+
+* GFQL: `hop()` defaults to `debugging_hop=False`
+
 ## [0.33.0 - 2023-12-26]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
-## [0.33.1 - 2024-02-24]
+## [0.33.2 - 2024-02-24]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+### Added
+
+* GFQL: Export shorter alias `e` for `e_undirected`
+
 ## [0.33.0 - 2023-12-26]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+## [0.33.1 - 2024-02-24]
+
 ### Added
 
 * GFQL: Export shorter alias `e` for `e_undirected`

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -106,8 +106,6 @@ GitHub Actions: See `.github/workflows`
 
 ## Publish: Merge, Tag, & Upload
 
-1. Merge the desired PR to master and switch to master head (`git checkout master && git pull`)
-
 1. Manually update CHANGELOG.md
 
 1. Tag the repository with a new version number. We use semantic version numbers of the form *X.Y.Z*.
@@ -120,3 +118,5 @@ GitHub Actions: See `.github/workflows`
 1. Confirm the [publish](https://github.com/graphistry/pygraphistry/actions?query=workflow%3A%22Publish+Python+%F0%9F%90%8D+distributions+%F0%9F%93%A6+to+PyPI+and+TestPyPI%22) Github Action published to [pypi](https://pypi.org/project/graphistry/), or manually run it for the master branch
 
 1. Toggle version as active at [ReadTheDocs](https://readthedocs.org/projects/pygraphistry/versions/)
+
+1. Merge the desired PR to master and switch to master head (`git checkout master && git pull`)

--- a/graphistry/__init__.py
+++ b/graphistry/__init__.py
@@ -50,7 +50,7 @@ from graphistry.pygraphistry import (  # noqa: E402, F401
 )
 
 from graphistry.compute import (
-    n, e_forward, e_reverse, e_undirected,
+    n, e, e_forward, e_reverse, e_undirected,
     Chain,
 
     is_in, IsIn,

--- a/graphistry/compute/__init__.py
+++ b/graphistry/compute/__init__.py
@@ -1,6 +1,6 @@
 from .ComputeMixin import ComputeMixin
 from .ast import (
-    n, e_forward, e_reverse, e_undirected
+    n, e, e_forward, e_reverse, e_undirected
 )
 from .chain import Chain
 from .predicates.is_in import (

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -90,6 +90,9 @@ def combine_steps(g: Plottable, kind: str, steps: List[Tuple[ASTObject,Plottable
         getattr(g_step, df_fld)[[id]]
         for (_, g_step) in steps
     ]).drop_duplicates(subset=[id])
+    for (op, g_step) in steps:
+        logger.debug('adding nodes to concat: %s', g_step._nodes[[g_step._node]])
+        logger.debug('adding edges to concat: %s', g_step._edges[[g_step._source, g_step._destination]])
 
     # df[[id, op_name1, ...]]
     logger.debug('combine_steps ops: %s', [op for (op, _) in steps])

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -293,6 +293,13 @@ def chain(self: Plottable, ops: Union[List[ASTObject], Chain], engine: Union[Eng
         )
         g_stack.append(g_step)
 
+    import logging
+    if logger.isEnabledFor(logging.DEBUG):
+        for (i, g_step) in enumerate(g_stack):
+            logger.debug('~' * 10 + '\nstep %s', i)
+            logger.debug('nodes: %s', g_step._nodes)
+            logger.debug('edges: %s', g_step._edges)
+
     logger.debug('======================== BACKWARDS ========================')
 
     # Backwards
@@ -324,6 +331,13 @@ def chain(self: Plottable, ops: Union[List[ASTObject], Chain], engine: Union[Eng
             )
         )
         g_stack_reverse.append(g_step_reverse)
+
+    import logging
+    if logger.isEnabledFor(logging.DEBUG):
+        for (i, g_step) in enumerate(g_stack_reverse):
+            logger.debug('~' * 10 + '\nstep %s', i)
+            logger.debug('nodes: %s', g_step._nodes)
+            logger.debug('edges: %s', g_step._edges)
 
     logger.debug('============ COMBINE NODES ============')
     final_nodes_df = combine_steps(g, 'nodes', list(zip(ops, reversed(g_stack_reverse))), engine_concrete)

--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -78,7 +78,6 @@ def hop(self: Plottable,
     #TODO target_wave_front code also includes nodes for handling intermediate hops
     # ... better to make an explicit param of allowed intermediates? (vs recording each intermediate hop)
 
-    # ensure False when publishing
     debugging_hop = False
 
     if debugging_hop and logger.isEnabledFor(logging.DEBUG):

--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -152,6 +152,7 @@ def hop(self: Plottable,
         logger.debug('=====================')
 
     first_iter = True
+    combined_node_ids = None
     while True:
 
         if debugging_hop and logger.isEnabledFor(logging.DEBUG):
@@ -341,6 +342,15 @@ def hop(self: Plottable,
             logger.debug('wave_front:\n%s', wave_front)
             logger.debug('matches_nodes:\n%s', matches_nodes)
 
+    if debugging_hop and logger.isEnabledFor(logging.DEBUG):
+        logger.debug('~~~~~~~~~~ LOOP END POST ~~~~~~~~~~~')
+        logger.debug('matches_nodes:\n%s', matches_nodes)
+        logger.debug('matches_edges:\n%s', matches_edges)
+        logger.debug('combined_node_ids:\n%s', combined_node_ids)
+        logger.debug('nodes (self):\n%s', self._nodes)
+        logger.debug('nodes (init):\n%s', nodes)
+        logger.debug('target_wave_front:\n%s', target_wave_front)
+
     #hydrate edges
     final_edges = edges_indexed.merge(matches_edges, on=EDGE_ID, how='inner')
     if EDGE_ID not in self._edges:
@@ -358,6 +368,7 @@ def hop(self: Plottable,
         rich_nodes = self._nodes
         if target_wave_front is not None:
             rich_nodes = concat([rich_nodes, target_wave_front], ignore_index=True, sort=False).drop_duplicates(subset=[g2._node])
+        logger.debug('rich_nodes available for inner merge:\n%s', rich_nodes[[self._node]])
         final_nodes = rich_nodes.merge(
             matches_nodes if matches_nodes is not None else wave_front[:0],
             on=self._node,

--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -78,7 +78,8 @@ def hop(self: Plottable,
     #TODO target_wave_front code also includes nodes for handling intermediate hops
     # ... better to make an explicit param of allowed intermediates? (vs recording each intermediate hop)
 
-    debugging_hop = True
+    # ensure False when publishing
+    debugging_hop = False
 
     if debugging_hop and logger.isEnabledFor(logging.DEBUG):
         logger.debug('=======================')

--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -298,7 +298,10 @@ def hop(self: Plottable,
         if debugging_hop and logger.isEnabledFor(logging.DEBUG):
             logger.debug('~~~~~~~~~~ LOOP STEP MERGES 1 ~~~~~~~~~~~')
             logger.debug('matches_edges:\n%s', matches_edges)
+            logger.debug('matches_nodes:\n%s', matches_nodes)
             logger.debug('new_node_ids:\n%s', new_node_ids)
+            logger.debug('hop_edges_forward:\n%s', hop_edges_forward)
+            logger.debug('hop_edges_reverse:\n%s', hop_edges_reverse)
 
         # Finally include all initial root nodes matched against, now that edge triples satisfy all source/dest/edge predicates
         # Only run first iteration b/c root nodes already accounted for in subsequent

--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -242,7 +242,8 @@ def hop(self: Plottable,
                 logger.debug('--- direction in [reverse, undirected] ---')
                 logger.debug('hop_edges_reverse basic:\n%s', hop_edges_reverse)
 
-            if target_wave_front is not None:
+            #FIXME: What test case does this enable? Disabled to pass shortest path backwards pass steps
+            if False and target_wave_front is not None:
                 assert nodes is not None, "target_wave_front indicates nodes"
                 if hops_remaining:
                     intermediate_target_wave_front = concat([
@@ -348,10 +349,15 @@ def hop(self: Plottable,
 
     #hydrate nodes
     if self._nodes is not None:
+        logger.debug('~~~~~~~~~~ NODES HYDRATION ~~~~~~~~~~~')
+        #FIXME what was this for? Removed for shortest-path reverse pass fixes
+        #if target_wave_front is not None:
+        #    rich_nodes = target_wave_front
+        #else:
+        #    rich_nodes = self._nodes
+        rich_nodes = self._nodes
         if target_wave_front is not None:
-            rich_nodes = target_wave_front
-        else:
-            rich_nodes = self._nodes
+            rich_nodes = concat([rich_nodes, target_wave_front], ignore_index=True, sort=False).drop_duplicates(subset=[g2._node])
         final_nodes = rich_nodes.merge(
             matches_nodes if matches_nodes is not None else wave_front[:0],
             on=self._node,

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -947,6 +947,7 @@ def process_dirty_dataframes(
         and not is_dataframe_all_numeric(y)  # noqa: E126,W503
         and has_dirty_cat  # noqa: E126,W503
     ):
+        from dirty_cat import SuperVectorizer, GapEncoder, SimilarityEncoder
         t2 = time()
         logger.debug("-Fitting Targets --\n%s", y.columns)
 

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -82,15 +82,21 @@ def lazy_import_has_min_dependancy():
     try:
         import scipy.sparse  # noqa
         from scipy import __version__ as scipy_version
-        from dirty_cat import __version__ as dirty_cat_version
         from sklearn import __version__ as sklearn_version
         logger.debug(f"SCIPY VERSION: {scipy_version}")
-        logger.debug(f"Dirty CAT VERSION: {dirty_cat_version}")
         logger.debug(f"sklearn VERSION: {sklearn_version}")
         return True, 'ok'
     except ModuleNotFoundError as e:
         return False, e
 
+def lazy_import_has_dirty_cat():
+    import warnings
+    warnings.filterwarnings("ignore")
+    try:
+        import dirty_cat 
+        return True, 'ok', dirty_cat
+    except ModuleNotFoundError as e:
+        return False, e, None
 
 def assert_imported_text():
     has_dependancy_text_, import_text_exn, _ = lazy_import_has_dependancy_text()
@@ -878,11 +884,13 @@ def process_dirty_dataframes(
     :return: Encoded data matrix and target (if not None),
             the data encoder, and the label encoder.
     """
-    from dirty_cat import SuperVectorizer, GapEncoder, SimilarityEncoder
+    has_dirty_cat, _, dirty_cat = lazy_import_has_dirty_cat()
     from sklearn.preprocessing import FunctionTransformer
     t = time()
 
-    if not is_dataframe_all_numeric(ndf):
+    all_numeric = is_dataframe_all_numeric(ndf)
+    if not all_numeric and has_dirty_cat:
+        from dirty_cat import SuperVectorizer, GapEncoder, SimilarityEncoder
         data_encoder = SuperVectorizer(
             auto_cast=True,
             cardinality_threshold=cardinality_threshold,
@@ -906,7 +914,7 @@ def process_dirty_dataframes(
             features_transformed = data_encoder.get_feature_names_out()
 
         all_transformers = data_encoder.transformers
-        logger.info(f"-Shape of [[dirty_cat fit]] data {X_enc.shape}")
+        logger.debug(f"-Shape of [[dirty_cat fit]] data {X_enc.shape}")
         logger.debug(f"-Transformers: \n{all_transformers}\n")
         logger.debug(
             f"-Transformed Columns: \n{features_transformed[:20]}...\n"
@@ -922,8 +930,12 @@ def process_dirty_dataframes(
             X_enc, columns=features_transformed, index=ndf.index
         )
         X_enc = X_enc.fillna(0.0)
+    elif all_numeric and not has_dirty_cat:
+        numeric_ndf = ndf.select_dtypes(include=[np.number])  # type: ignore
+        logger.warning("-*-*- DataFrame is not numeric and no dirty_cat, dropping non-numeric")
+        X_enc, _, data_encoder, _ = get_numeric_transformers(numeric_ndf, None)
     else:
-        logger.info("-*-*- DataFrame is completely numeric")
+        logger.debug("-*-*- DataFrame is completely numeric")
         X_enc, _, data_encoder, _ = get_numeric_transformers(ndf, None)
 
 
@@ -933,6 +945,7 @@ def process_dirty_dataframes(
         y is not None
         and len(y.columns) > 0  # noqa: E126,W503
         and not is_dataframe_all_numeric(y)  # noqa: E126,W503
+        and has_dirty_cat
     ):
         t2 = time()
         logger.debug("-Fitting Targets --\n%s", y.columns)
@@ -976,6 +989,15 @@ def process_dirty_dataframes(
             "--Fitting SuperVectorizer on TARGET took"
             f" {(time() - t2) / 60:.2f} minutes\n"
         )
+    elif (
+        y is not None
+        and len(y.columns) > 0  # noqa: E126,W503
+        and not is_dataframe_all_numeric(y)  # noqa: E126,W503
+        and not has_dirty_cat
+    ):
+        logger.warning("-*-*- y is not numeric and no dirty_cat, dropping non-numeric")
+        y2 = y.select_dtypes(include=[np.number])
+        y_enc, _, _, label_encoder = get_numeric_transformers(y2, None)
     else:
         y_enc, _, label_encoder, _ = get_numeric_transformers(y, None)
 

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -885,12 +885,13 @@ def process_dirty_dataframes(
             the data encoder, and the label encoder.
     """
     has_dirty_cat, _, dirty_cat = lazy_import_has_dirty_cat()
+    if has_dirty_cat:
+        from dirty_cat import SuperVectorizer, GapEncoder, SimilarityEncoder
     from sklearn.preprocessing import FunctionTransformer
     t = time()
 
     all_numeric = is_dataframe_all_numeric(ndf)
     if not all_numeric and has_dirty_cat:
-        from dirty_cat import SuperVectorizer, GapEncoder, SimilarityEncoder
         data_encoder = SuperVectorizer(
             auto_cast=True,
             cardinality_threshold=cardinality_threshold,
@@ -947,7 +948,6 @@ def process_dirty_dataframes(
         and not is_dataframe_all_numeric(y)  # noqa: E126,W503
         and has_dirty_cat  # noqa: E126,W503
     ):
-        from dirty_cat import SuperVectorizer, GapEncoder, SimilarityEncoder
         t2 = time()
         logger.debug("-Fitting Targets --\n%s", y.columns)
 

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -996,7 +996,7 @@ def process_dirty_dataframes(
         and not has_dirty_cat  # noqa: E126,W503
     ):
         logger.warning("-*-*- y is not numeric and no dirty_cat, dropping non-numeric")
-        y2 = y.select_dtypes(include=[np.number])
+        y2 = y.select_dtypes(include=[np.number])  # type: ignore
         y_enc, _, _, label_encoder = get_numeric_transformers(y2, None)
     else:
         y_enc, _, label_encoder, _ = get_numeric_transformers(y, None)

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -945,7 +945,7 @@ def process_dirty_dataframes(
         y is not None
         and len(y.columns) > 0  # noqa: E126,W503
         and not is_dataframe_all_numeric(y)  # noqa: E126,W503
-        and has_dirty_cat
+        and has_dirty_cat  # noqa: E126,W503
     ):
         t2 = time()
         logger.debug("-Fitting Targets --\n%s", y.columns)
@@ -993,7 +993,7 @@ def process_dirty_dataframes(
         y is not None
         and len(y.columns) > 0  # noqa: E126,W503
         and not is_dataframe_all_numeric(y)  # noqa: E126,W503
-        and not has_dirty_cat
+        and not has_dirty_cat  # noqa: E126,W503
     ):
         logger.warning("-*-*- y is not numeric and no dirty_cat, dropping non-numeric")
         y2 = y.select_dtypes(include=[np.number])

--- a/graphistry/tests/test_compute_chain.py
+++ b/graphistry/tests/test_compute_chain.py
@@ -146,6 +146,37 @@ class TestComputeChainMixin(NoAuthTestCase):
         ])
         assert len(g2._nodes) == 1
 
+    def test_shortest_path(self):
+
+        g = chain_graph()
+
+        if False:
+            g2a = g.chain([n({'n': 'a'}), e_forward(hops=1), n()])
+            assert g2a._nodes.shape == (2, 1)
+            assert g2a._edges.shape == (1, 2)
+
+            g2b = g.chain([n({'n': 'a'}), e_forward(hops=2), n()])
+            assert g2b._nodes.shape == (3, 1)
+            assert g2b._edges.shape == (2, 2)
+
+            g3a = g.chain([n({'n': 'a'}), e_forward(hops=1), n({'n': 'b'})])
+            assert g3a._nodes.shape == (2, 1)
+            assert g3a._edges.shape == (1, 2)
+
+        g3b = g.chain([n({'n': 'a'}), e_forward(hops=2), n({'n': 'c'})])
+        assert g3b._nodes.shape == (3, 1)
+        assert g3b._edges.shape == (2, 2)
+
+        if False:
+
+            g3c = g.chain([n({'n': 'a'}), e_undirected(hops=2), n({'n': 'c'})])
+            assert g3c._nodes.shape == (3, 1)
+            assert g3c._edges.shape == (2, 2)
+
+            g3d = g.chain([n({'n': 'a'}), e_forward(to_fixed_point=True), n({'n': 'c'})])
+            assert g3d._nodes.shape == (3, 1)
+            assert g3d._edges.shape == (2, 2)
+
 
 def compare_graphs(g, nodes: List[Dict[str, str]], edges: List[Dict[str, str]]) -> None:
     assert g._nodes.sort_values(by='n').to_dict(orient='records') == nodes

--- a/graphistry/tests/test_compute_cluster.py
+++ b/graphistry/tests/test_compute_cluster.py
@@ -5,8 +5,10 @@ import graphistry
 from graphistry.constants import DBSCAN
 from graphistry.util import ModelDict
 from graphistry.compute.cluster import lazy_dbscan_import_has_dependency
+from graphistry.umap_utils import lazy_umap_import_has_dependancy
 
 has_dbscan, _, has_gpu_dbscan, _ = lazy_dbscan_import_has_dependency()
+has_umap, _, _ = lazy_umap_import_has_dependancy()
 
 
 ndf = edf = pd.DataFrame({'src': [1, 2, 1, 4], 'dst': [4, 5, 6, 1], 'label': ['a', 'b', 'b', 'c']})
@@ -22,7 +24,7 @@ class TestComputeCluster(unittest.TestCase):
             self.assertTrue(g._edge_dbscan is not None, 'instance has no `_edge_dbscan` method')
             self.assertTrue(DBSCAN in g._edges, 'edge df has no `_dbscan` attribute')
     
-    @pytest.mark.skipif(not has_dbscan, reason="requires ai dependencies")
+    @pytest.mark.skipif(not has_dbscan or not has_umap, reason="requires ai dependencies")
     def test_umap_cluster(self):
         g = graphistry.nodes(ndf).edges(edf, 'src', 'dst')
         for kind in ['nodes', 'edges']:
@@ -42,7 +44,7 @@ class TestComputeCluster(unittest.TestCase):
             g = g.featurize(kind=kind, n_topics=2).dbscan(kind=kind, verbose=True)
             self._condition(g, kind)
             
-    @pytest.mark.skipif(not has_dbscan, reason="requires ai dependencies")
+    @pytest.mark.skipif(not has_dbscan or not has_umap, reason="requires ai dependencies")
     def test_dbscan_params(self):
         dbscan_params = [ModelDict('Testing UMAP', kind='nodes', min_dist=0.2, min_samples=1, cols=None, target=False, 
                                    fit_umap_embedding=False, verbose=True, engine_dbscan='sklearn'), 
@@ -55,7 +57,7 @@ class TestComputeCluster(unittest.TestCase):
             g2 = g.dbscan(**params)
             self.assertTrue(g2._dbscan_params == params, f'dbscan params not set correctly, found {g2._dbscan_params} but expected {params}')
         
-    @pytest.mark.skipif(not has_gpu_dbscan, reason="requires ai dependencies")
+    @pytest.mark.skipif(not has_gpu_dbscan or not has_umap, reason="requires ai dependencies")
     def test_transform_dbscan(self):
         kind = 'nodes'
         g = graphistry.nodes(ndf).edges(edf, 'src', 'dst')

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,11 @@ stubs = [
   'pandas-stubs', 'types-requests', 'ipython', 'tqdm-stubs'
 ]
 
+test_workarounds = ['scikit-learn<=1.3.2']
+
 dev_extras = {
     'docs': ['sphinx==3.4.3', 'docutils==0.16', 'sphinx_autodoc_typehints==1.11.1', 'sphinx-rtd-theme==0.5.1', 'Jinja2<3.1'],
-    'test': ['flake8>=5.0', 'mock', 'mypy', 'pytest'] + stubs,
+    'test': ['flake8>=5.0', 'mock', 'mypy', 'pytest'] + stubs + test_workarounds,
     'testai': [
       'numba>=0.57.1'  # https://github.com/numba/numba/issues/8615
     ],


### PR DESCRIPTION
Fixes https://github.com/graphistry/pygraphistry/issues/546 + https://github.com/graphistry/pygraphistry/issues/545

Beyond the targeted fix, this also disabled 2 `hop()` code paths that were causing a problem, and worrisome, it was not clear why they exist: disabling did not break any tests

---

### Added

* GFQL: Export shorter alias `e` for `e_undirected`

### Fixed

* GFQL: `hop()` defaults to `debugging_hop=False`
* GFQL: Edge cases around shortest-path multi-hop queries failing to enrich against target nodes during backwards pass