### PR TITLE
Attempt to fix refresh() for SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+## [0.33.7 - 2024-04-06]
+
+* Fix refresh() for SSO
+
 ## [0.33.6 - 2024-04-05]
 
 ### Added

--- a/graphistry/exceptions.py
+++ b/graphistry/exceptions.py
@@ -10,3 +10,10 @@ class SsoRetrieveTokenTimeoutException(SsoException):
     Koa, 15 Sep 2022  Custom Exception to Sso retrieve token time out exception scenario
     """
     pass
+
+
+class TokenExpireException(Exception):
+    """
+    Koa, 15 Mar 2024  Custom Exception for JWT Token expiry when refresh
+    """
+    pass

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -245,10 +245,7 @@ class PyGraphistry(object):
 
             auth_url = arrow_uploader.sso_auth_url
 
-            # if isinstance(e, TokenExpireException):
-            #     print("Token is expired, you need to relogin")
-
-            if auth_url: # and (not PyGraphistry.api_token() or isinstance(e, TokenExpireException)):
+            if auth_url:
                 PyGraphistry._handle_auth_url(auth_url, sso_timeout, sso_opt_into_type)
                 return auth_url
             raise e

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -318,10 +318,23 @@ class PyGraphistry(object):
                 print("Successfully logged in")
                 return PyGraphistry.api_token()
             else:
+                print("Please run graphistry.sso_get_token() to complete the authentication after you have authenticated via SSO")
                 return None
         else:
-            print("Please run graphistry.sso_get_token() to complete the authentication")
+            print("Start getting token ...")
+            token = None
+            for i in range(10):
+                token, org_name = PyGraphistry._sso_get_token()
+                if token:
+                    # set org_name to sso org
+                    PyGraphistry._config['org_name'] = org_name
+                    print("Successfully logged in")
+                    return PyGraphistry.api_token()
+                print("Keep trying to get token ...")
+                time.sleep(5)
 
+            print("Please run graphistry.sso_get_token() to complete the authentication")
+            return None
 
     @staticmethod
     def sso_get_token():

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -384,6 +384,9 @@ class PyGraphistry(object):
             PyGraphistry._is_authenticated = True
             return PyGraphistry.api_token()
         except Exception as e:
+            print(f"what is relogin :{PyGraphistry.relogin}")
+            import traceback
+            print(f"{traceback.format_exc()}")
             if PyGraphistry.store_token_creds_in_memory():
                 logger.debug("JWT refresh via creds")
                 logger.debug("2. @PyGraphistry refresh :relogin")

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -321,17 +321,17 @@ class PyGraphistry(object):
                 print("Please run graphistry.sso_get_token() to complete the authentication after you have authenticated via SSO")
                 return None
         else:
-            print("Start getting token ...")
-            token = None
-            for i in range(10):
-                token, org_name = PyGraphistry._sso_get_token()
-                if token:
-                    # set org_name to sso org
-                    PyGraphistry._config['org_name'] = org_name
-                    print("Successfully logged in")
-                    return PyGraphistry.api_token()
-                print("Keep trying to get token ...")
-                time.sleep(5)
+            # print("Start getting token ...")
+            # token = None
+            # for i in range(10):
+            #     token, org_name = PyGraphistry._sso_get_token()
+            #     if token:
+            #         # set org_name to sso org
+            #         PyGraphistry._config['org_name'] = org_name
+            #         print("Successfully logged in")
+            #         return PyGraphistry.api_token()
+            #     print("Keep trying to get token ...")
+            #     time.sleep(5)
 
             print("Please run graphistry.sso_get_token() to complete the authentication")
             return None

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -296,8 +296,10 @@ class PyGraphistry(object):
                 try:
                     if not token:
                         if elapsed_time % 10 == 1:
-                            print("Waiting for token : {} seconds ...".format(sso_timeout - elapsed_time + 1))
-
+                            count_down = "Waiting for token : {} seconds ...".format(sso_timeout - elapsed_time + 1)
+                            print(count_down)
+                            from IPython.display import display, HTML
+                            display(HTML(f'<strong>{count_down}</string>'))
                         time.sleep(1)
                         elapsed_time = elapsed_time + 1
                         if elapsed_time > sso_timeout:


### PR DESCRIPTION
Refresh in SSO will not display the auth_url due to condition error.
This PR enhance the existing code to throw Token Expire exception and print the correct print out to tell the user that token is expired and required to relogin via SSO.
