### PR TITLE
coerce float if string or tuple

### DIFF
--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -402,18 +402,16 @@ def try_coerce_to_numeric(ndf: pd.DataFrame):
             if num_floats > len(nndf[j]) / 2:  # most of column is float
                 try:
                     nndf[j] = [float(value) if not isinstance(value, float) else value for value in nndf[j]]
-                    exploded = False
                     logger.info("Coerced strings to floats")
                 except:
                     nndf[j] = nndf[j].apply(lambda x: str(x).split() if isinstance(x, str) and ' ' in x else x)
                     nndf = nndf.explode(j)
                     nndf[j] = nndf[j].astype(float)
                     nndf.reset_index(drop=True, inplace=True)
-                    exploded = True
                     logger.info("Exploded rows with multiple values in single cell")
     except:
         pass
-    return nndf, exploded
+    return nndf
 
 def is_dataframe_all_numeric(df: pd.DataFrame) -> bool:
     is_all_numeric = True
@@ -911,7 +909,7 @@ def process_dirty_dataframes(
     from sklearn.preprocessing import FunctionTransformer
     t = time()
 
-    ndf, explode = try_coerce_to_numeric(ndf)
+    ndf = try_coerce_to_numeric(ndf)
     all_numeric = is_dataframe_all_numeric(ndf)
     if not all_numeric and has_dirty_cat:
         data_encoder = SuperVectorizer(

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -404,11 +404,14 @@ def try_coerce_to_numeric(ndf: pd.DataFrame):
                     nndf[j] = [float(value) if not isinstance(value, float) else value for value in nndf[j]]
                     logger.info("Coerced strings to floats")
                 except:
-                    nndf[j] = nndf[j].apply(lambda x: str(x).split() if isinstance(x, str) and ' ' in x else x)
-                    nndf = nndf.explode(j)
+                    # nndf[j] = nndf[j].apply(lambda x: str(x).split() if isinstance(x, str) and ' ' in x else x)
+                    # nndf = nndf.explode(j)
+                    # logger.info("Exploded rows with multiple values in single cell")
+                    nndf[j] = nndf[j].apply(lambda x: str(x).split()[0] if isinstance(x, str) and ' ' in x else x)
                     nndf[j] = nndf[j].astype(float)
                     nndf.reset_index(drop=True, inplace=True)
-                    logger.info("Exploded rows with multiple values in single cell")
+                    logger.info("took first float of tuple in single cell")
+
     except:
         pass
     return nndf
@@ -932,22 +935,6 @@ def process_dirty_dataframes(
             nndf[object_columns] = nndf[object_columns].astype(str)
             X_enc = data_encoder.fit_transform(nndf, y)
             logger.info("obj columns: %s are being converted to str", object_columns)
-        # except AssertionError:  # is actually all_numeric
-            # nndf = pd.DataFrame(ndf.copy())
-            # object_columns = nndf.select_dtypes(include=['object']).columns
-            # for j in object_columns:
-            #     num_floats = sum(isinstance(x, float) for x in nndf[j].dropna())
-            #     if num_floats > len(nndf[j]) / 2:  # most of column is float
-            #         try:
-            #             nndf[j] = [float(value) if not isinstance(value, float) else value for value in nndf[j]]
-            #             logger.info("Coerced strings to floats")
-            #             X_enc = data_encoder.fit_transform(nndf, y)
-            #         except:
-            #             nndf[j] = nndf[j].apply(lambda x: str(x).split() if isinstance(x, str) and ' ' in x else x)
-            #             nndf = nndf.explode(j)
-            #             nndf[j] = nndf[j].astype(float)
-            #             logger.info("Exploded rows with multiple values in single cell")
-                        # X_enc, _, data_encoder, _ = get_numeric_transformers(nndf, None)
         X_enc = make_array(X_enc)
 
         import warnings

--- a/graphistry/tests/test_feature_utils.py
+++ b/graphistry/tests/test_feature_utils.py
@@ -438,6 +438,18 @@ class TestFeatureMethods(unittest.TestCase):
                                   return_scalers=True)
 
 
+    @pytest.mark.skipif(not has_min_dependancy or not has_min_dependancy_text, reason="requires ai feature dependencies")
+    def test_type_edgecase(self):
+        values = pd.Series(np.random.rand(50))
+        num_to_convert = int(len(values) * 0.05)
+        indices_to_convert = np.random.choice(len(values), num_to_convert, replace=False)
+        for i in indices_to_convert:
+            values[i] = str(values[i])
+        values.loc[13] = '92.026 123.903 702.124'
+        values.loc[33] = '26.092 903.123'
+
+        graphistry.nodes(values).featurize()
+        assert True
 
 if __name__ == "__main__":
     unittest.main()

--- a/graphistry/tests/test_feature_utils.py
+++ b/graphistry/tests/test_feature_utils.py
@@ -440,15 +440,20 @@ class TestFeatureMethods(unittest.TestCase):
 
     @pytest.mark.skipif(not has_min_dependancy or not has_min_dependancy_text, reason="requires ai feature dependencies")
     def test_type_edgecase(self):
-        values = pd.Series(np.random.rand(50))
-        num_to_convert = int(len(values) * 0.05)
-        indices_to_convert = np.random.choice(len(values), num_to_convert, replace=False)
-        for i in indices_to_convert:
-            values[i] = str(values[i])
-        values.loc[13] = '92.026 123.903 702.124'
-        values.loc[33] = '26.092 903.123'
+        df = pd.DataFrame({
+            'A': np.random.rand(50),
+            'B': np.random.rand(50)
+        })
+        num_to_convert = int(len(df.A.values) * 0.1)
+        indices_to_convert = np.random.choice(len(df.A.values), num_to_convert, replace=False)
+        indices_to_convertB = np.random.choice(len(df.A.values), num_to_convert, replace=False)
+        for i,j in zip(indices_to_convert, indices_to_convertB):
+            df.A[i] = str(df.A[i])
+            df.B[j] = str(df.B[j])
+        df.A.loc[13] = '92.026 123.903 702.124'
+        df.B.loc[33] = '26.092 903.123'
 
-        graphistry.nodes(values).featurize()
+        graphistry.nodes(df).featurize()
         assert True
 
 if __name__ == "__main__":

--- a/graphistry/tests/test_umap_utils.py
+++ b/graphistry/tests/test_umap_utils.py
@@ -408,7 +408,7 @@ class TestUMAPMethods(unittest.TestCase):
         indices_to_convert = np.random.choice(len(values), num_to_convert, replace=False)
         for i in indices_to_convert:
             values[i] = str(values[i])
-        values.loc[13] = '92.026 123.903'
+        values.loc[13] = '92.026 123.903 702.124'
         values.loc[33] = '26.092 903.123'
 
         graphistry.nodes(values).umap()

--- a/graphistry/tests/test_umap_utils.py
+++ b/graphistry/tests/test_umap_utils.py
@@ -400,6 +400,19 @@ class TestUMAPMethods(unittest.TestCase):
 
         graphistry.nodes(df).umap()
         assert True
+        
+    @pytest.mark.skipif(not has_umap, reason="requires umap feature dependencies")
+    def test_type_edgecase(self):
+        values = pd.Series(np.random.rand(50))
+        num_to_convert = int(len(values) * 0.05)
+        indices_to_convert = np.random.choice(len(values), num_to_convert, replace=False)
+        for i in indices_to_convert:
+            values[i] = str(values[i])
+        values.loc[13] = '92.026 123.903'
+        values.loc[33] = '26.092 903.123'
+
+        graphistry.nodes(values).umap()
+        assert True
 
     @pytest.mark.skipif(not has_umap, reason="requires umap feature dependencies")
     def test_node_umap(self):

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -721,6 +721,8 @@ class UMAPMixin(MIXIN_BASE):
             emb = res._edge_embedding
             
         if isinstance(df, type(emb)):
+            print(df)
+            print(emb)
             df[x_name] = emb.values.T[0]
             df[y_name] = emb.values.T[1]
         elif isinstance(df, pd.DataFrame) and 'cudf.core.dataframe' in str(getmodule(emb)):

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -721,8 +721,6 @@ class UMAPMixin(MIXIN_BASE):
             emb = res._edge_embedding
             
         if isinstance(df, type(emb)):
-            print(df)
-            print(emb)
             df[x_name] = emb.values.T[0]
             df[y_name] = emb.values.T[1]
         elif isinstance(df, pd.DataFrame) and 'cudf.core.dataframe' in str(getmodule(emb)):


### PR DESCRIPTION
for rare cases first encountered in avr-59k['Source_IP4_Subnet_16'] dataset, for example

`graphistry.nodes(avr59k_splunk['Source_IP4_Subnet_16'].dropna()).umap()`

would throw type error

[see end of this thread](https://graphistry.slack.com/archives/C033H1S0DA6/p1716308253862969?thread_ts=1716307584.556219&cid=C033H1S0DA6)