### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -73,9 +73,9 @@ def resolve_engine(
 def df_to_pdf(df, engine: Engine):
     if engine == Engine.PANDAS:
         return df
-    elif engine == Engine.CUDF:
+    if engine == Engine.CUDF:
         return df.to_pandas()
-    elif engine == Engine.DASK:
+    if engine == Engine.DASK:
         return df.compute()
     raise ValueError('Only engines pandas/cudf supported')
 
@@ -83,20 +83,18 @@ def df_to_engine(df, engine: Engine):
     if engine == Engine.PANDAS:
         if isinstance(df, pd.DataFrame):
             return df
-        else:
-            return df.to_pandas()
+        return df.to_pandas()
     elif engine == Engine.CUDF:
         import cudf
         if isinstance(df, cudf.DataFrame):
             return df
-        else:
-            return cudf.DataFrame.from_pandas(df)
+        return cudf.DataFrame.from_pandas(df)
     raise ValueError('Only engines pandas/cudf supported')
 
 def df_concat(engine: Engine):
     if engine == Engine.PANDAS:
         return pd.concat
-    elif engine == Engine.CUDF:
+    if engine == Engine.CUDF:
         import cudf
         return cudf.concat
     raise NotImplementedError("Only pandas/cudf supported")
@@ -104,7 +102,7 @@ def df_concat(engine: Engine):
 def df_cons(engine: Engine):
     if engine == Engine.PANDAS:
         return pd.DataFrame
-    elif engine == Engine.CUDF:
+    if engine == Engine.CUDF:
         import cudf
         return cudf.DataFrame
     raise NotImplementedError("Only pandas/cudf supported")
@@ -112,7 +110,7 @@ def df_cons(engine: Engine):
 def s_cons(engine: Engine):
     if engine == Engine.PANDAS:
         return pd.Series
-    elif engine == Engine.CUDF:
+    if engine == Engine.CUDF:
         import cudf
         return cudf.Series
     raise NotImplementedError("Only pandas/cudf supported")

--- a/graphistry/_version.py
+++ b/graphistry/_version.py
@@ -118,9 +118,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
             return {"version": dirname[len(parentdir_prefix):],
                     "full-revisionid": None,
                     "dirty": False, "error": None, "date": None}
-        else:
-            rootdirs.append(root)
-            root = os.path.dirname(root)  # up a level
+    rootdirs.append(root)
+    root = os.path.dirname(root)  # up a level
 
     if verbose:
         print("Tried directories %s but none started with prefix %s" %

--- a/graphistry/bolt_util.py
+++ b/graphistry/bolt_util.py
@@ -163,15 +163,14 @@ def neo_val_to_pd_val(v):
     if v_mod == 'neo4j.time':
         if v.__class__ == neo4j.time.DateTime:
             return v.to_native()  # datetime.datetime
-        elif v.__class__ == neo4j.time.Date:
+        if v.__class__ == neo4j.time.Date:
             return datetime.combine(v.to_native(), t0)  # datatime.datatime
-        elif v.__class__ == neo4j.time.Time:
+        if v.__class__ == neo4j.time.Time:
             return pd.to_timedelta(v.iso_format())  # timedelta
-        elif v.__class__ == neo4j.time.Duration:
+        if v.__class__ == neo4j.time.Duration:
             #TODO expand out?
             return v.iso_format()  # str
-        else:
-            return str(v)
+        return str(v)
 
     #handle neo4j.spatial.* later
 

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -320,6 +320,7 @@ class ComputeMixin(MIXIN_BASE):
             )
 
             g2 = g2.drop_nodes(roots[g2._node])
+
         nodes_df0 = nodes_with_levels[0]
         if len(nodes_with_levels) > 1:
             nodes_df = pd.concat([nodes_df0] + nodes_with_levels[1:])

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -105,10 +105,9 @@ def maybe_filter_dict_from_json(d: Dict, key: str) -> Optional[Dict]:
             k: predicates_from_json(v) if isinstance(v, dict) else v
             for k, v in d[key].items()
         }
-    elif key in d and d[key] is not None:
+    if d[key] is not None:
         raise ValueError('filter_dict must be a dict or None')
-    else:
-        return None
+    return None
 
 ##############################################################################
 

--- a/graphistry/compute/cluster.py
+++ b/graphistry/compute/cluster.py
@@ -94,8 +94,7 @@ def make_safe_gpu_dataframes(X, y, engine):
     if has_cudf_dependancy_:
         # print('DBSCAN CUML Matrices')
         return safe_cudf(X, y)
-    else:
-        return X, y
+    return X, y
 
 
 def get_model_matrix(g, kind: str, cols: Optional[Union[List, str]], umap, target):
@@ -318,7 +317,7 @@ class ClusterMixin(MIXIN_BASE):
     def _transform_dbscan(
         self, df: pd.DataFrame, ydf, kind, verbose
     ) -> Tuple[Union[pd.DataFrame, None], pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        
+    
         res = self.bind()
         if hasattr(res, "_dbscan_params"):
             # Assume that we are transforming to last fit of dbscan
@@ -344,11 +343,11 @@ class ClusterMixin(MIXIN_BASE):
                 X_ = emb
             else:
                 X_ = XX
-            
+        
             if res.engine_dbscan == 'cuml':
                 print('Transform DBSCAN not yet supported for engine_dbscan=`cuml`, use engine=`umap_learn`, `pandas` or `sklearn` instead')
                 return emb, X, y, df
-            
+        
             X_, emb = make_safe_gpu_dataframes(X_, emb, 'pandas')  
 
             labels = dbscan_predict(X_, dbscan)  # type: ignore
@@ -357,13 +356,13 @@ class ClusterMixin(MIXIN_BASE):
                 df = df.assign(_dbscan=labels, x=emb.x, y=emb.y)  # type: ignore
             else:
                 df = df.assign(_dbscan=labels)
-            
+        
             if verbose:
                 print(f"Transformed DBSCAN: {len(df[DBSCAN].unique())} clusters")
 
             return emb, X, y, df  # type: ignore
-        else:
-            raise Exception("No dbscan model found. Please run `g.dbscan()` first")
+    
+        raise Exception("No dbscan model found. Please run `g.dbscan()` first")
 
     def transform_dbscan(
         self,

--- a/graphistry/compute/collapse.py
+++ b/graphistry/compute/collapse.py
@@ -370,46 +370,46 @@ def collapse_algo(
     
     if compute_key in seen:  # it has already traversed this path, skip
         return g
-    else:
-        if has_property(g, parent, attribute, column):  # if (T, *)
-            # add start node to super node index
-            tkey = f"{parent} {parent}"  # it will reduce this to `parent` but can add to `seen`
-            if tkey not in compute_key:  # its love!
-                seen[tkey] = 1
-                collapse_nodes_and_edges(g, parent, parent)
-            if has_property(g, child, attribute, column):  # if (T, T)
-                if VERBOSE:
-                    logger.info("-" * 80)
-                    logger.info(
-                        f" ** [ parent: {parent}, child: {child} ] both have property"
-                    )
-                collapse_nodes_and_edges(
-                    g, parent, child
-                )  # will make a new parent off of parent, child names
-                # add to seen
-                seen[compute_key] = 1
-                for e in get_edges_of_node(
-                    g, parent, outgoing_edges=True, hops=1
-                ).values:  # False just includes the child node and goes into infinite loop when parent = child
-                    collapse_algo(
-                        g, e, child, attribute, column, seen
-                    )  # now child is the parent, and the edges are the start node
-        # else do nothing collapse-y to parent, move on to child
-        else:  # if (F, *)
-            #  do nothing to child, parent is child, and child is edge and recurse
-            for e in get_edges_of_node(g, child, outgoing_edges=True, hops=1).values:
-                if VERBOSE:
-                    logger.info(
-                        f" -- Parent {parent} does not have property, looking at node <[ {e} from {child} ]>"
-                    )
-
-                if (e == child) and (parent == child):
-                    # get it unstuck
-                    return g
-                
+    
+    if has_property(g, parent, attribute, column):  # if (T, *)
+        # add start node to super node index
+        tkey = f"{parent} {parent}"  # it will reduce this to `parent` but can add to `seen`
+        if tkey not in compute_key:  # its love!
+            seen[tkey] = 1
+            collapse_nodes_and_edges(g, parent, parent)
+        if has_property(g, child, attribute, column):  # if (T, T)
+            if VERBOSE:
+                logger.info("-" * 80)
+                logger.info(
+                    f" ** [ parent: {parent}, child: {child} ] both have property"
+                )
+            collapse_nodes_and_edges(
+                g, parent, child
+            )  # will make a new parent off of parent, child names
+            # add to seen
+            seen[compute_key] = 1
+            for e in get_edges_of_node(
+                g, parent, outgoing_edges=True, hops=1
+            ).values:  # False just includes the child node and goes into infinite loop when parent = child
                 collapse_algo(
                     g, e, child, attribute, column, seen
                 )  # now child is the parent, and the edges are the start node
+    else:  # if (F, *)
+        #  do nothing to child, parent is child, and child is edge and recurse
+        for e in get_edges_of_node(g, child, outgoing_edges=True, hops=1).values:
+            if VERBOSE:
+                logger.info(
+                    f" -- Parent {parent} does not have property, looking at node <[ {e} from {child} ]>"
+                )
+
+            if (e == child) and (parent == child):
+                # get it unstuck
+                return g
+            
+            collapse_algo(
+                g, e, child, attribute, column, seen
+            )  # now child is the parent, and the edges are the start node
+
     return g
 
 

--- a/graphistry/compute/predicates/numeric.py
+++ b/graphistry/compute/predicates/numeric.py
@@ -106,8 +106,7 @@ class Between(ASTPredicate):
     def __call__(self, s: SeriesT) -> SeriesT:
         if self.inclusive:
             return (s >= self.lower) & (s <= self.upper)
-        else:
-            return (s > self.lower) & (s < self.upper)
+        return (s > self.lower) & (s < self.upper)
         
     def validate(self) -> None:
         assert isinstance(self.lower, (int, float))

--- a/graphistry/embed_utils.py
+++ b/graphistry/embed_utils.py
@@ -347,7 +347,7 @@ class HeterographEmbedModuleMixin(MIXIN_BASE):
 
     def _score_triplets(self, triplets, threshold, anomalous, retain_old_edges, return_dataframe):
         """Score triplets using the trained model."""
-        
+    
         log(f"{triplets.shape[0]} triplets for inference")
         ############################################################
         # the bees knees 
@@ -363,7 +363,7 @@ class HeterographEmbedModuleMixin(MIXIN_BASE):
         else:
             predicted_links = triplets
             this_score = scores
-            
+        
         predicted_links = pd.DataFrame(predicted_links, columns=[self._source, self._relation, self._destination])
         predicted_links[self._source] = predicted_links[self._source].map(self._id2node)
         predicted_links[self._relation] = predicted_links[self._relation].map(self._id2relation)
@@ -371,7 +371,7 @@ class HeterographEmbedModuleMixin(MIXIN_BASE):
 
         predicted_links['score'] = this_score.detach().numpy()
         predicted_links.sort_values(by='score', ascending=False, inplace=True)
-        
+    
         log(f"-- {predicted_links.shape[0]} triplets scored at threshold {threshold:.2f}")
 
         if retain_old_edges:
@@ -381,13 +381,11 @@ class HeterographEmbedModuleMixin(MIXIN_BASE):
             ).drop_duplicates()
         else:
             all_links = predicted_links
-            
         
         if return_dataframe:
             return all_links
-        else:
-            g_new = self.nodes(self._nodes, self._node).edges(all_links, self._source, self._destination)
-            return g_new
+        g_new = self.nodes(self._nodes, self._node).edges(all_links, self._source, self._destination)
+        return g_new
         
         
     def predict_links(
@@ -550,12 +548,11 @@ class HeterographEmbedModuleMixin(MIXIN_BASE):
 
 
     def _eval(self, threshold: float):
-        if self._test_idx is not None:
-            triplets = self._triplets[self._test_idx]  # type: ignore
-            score = self._score(triplets)
-            score = len(score[score >= threshold]) / len(score)  # type: ignore
-            return score
-        else:
+            if self._test_idx is not None:
+                triplets = self._triplets[self._test_idx]  # type: ignore
+                score = self._score(triplets)
+                score = len(score[score >= threshold]) / len(score)  # type: ignore
+                return score
             log("WARNING: train_split must be < 1 for _eval()")
 
 

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -181,12 +181,11 @@ def resolve_y(df: Optional[pd.DataFrame], y: YSymbolic) -> pd.DataFrame:
 
     if y is None:
         return df[[]]  # oh brills, basically index
-    elif isinstance(y, str):
+    if isinstance(y, str):
         return df[[y]]
-    elif isinstance(y, list):
+    if isinstance(y, list):
         return df[y]
-    else:
-        raise ValueError(f"Unexpected type for y: {type(y)}")
+    raise ValueError(f"Unexpected type for y: {type(y)}")
 
 
 XSymbolic = Optional[Union[List[str], str, pd.DataFrame]]
@@ -202,12 +201,11 @@ def resolve_X(df: Optional[pd.DataFrame], X: XSymbolic) -> pd.DataFrame:
 
     if X is None:
         return df
-    elif isinstance(X, str):
+    if isinstance(X, str):
         return df[[X]]
-    elif isinstance(X, list):
+    if isinstance(X, list):
         return df[X]
-    else:
-        raise ValueError(f"Unexpected type for X: {type(X)}")
+    raise ValueError(f"Unexpected type for X: {type(X)}")
 
 
 # #########################################################################
@@ -466,10 +464,7 @@ def check_if_textual_column(
                 f"of words {mean_n_words:.2f}"
             )
             return True
-        else:
-            return False
-    else:
-        return False
+    return False
 
 
 def get_textual_columns(
@@ -2200,11 +2195,10 @@ class FeatureMixin(MIXIN_BASE):
             if scaled:
                 return getattr(self, encoder).transform_scaled(df, ydf)
             return getattr(self, encoder).transform(df, ydf)
-        else:
-            logger.debug(
-                "Fit on data (g.featurize(kind='..', ...))"
-                "before being able to transform data"
-            )
+        logger.debug(
+            "Fit on data (g.featurize(kind='..', ...))"
+            "before being able to transform data"
+        )
 
     def transform(self, df: pd.DataFrame, 
                   y: Optional[pd.DataFrame] = None, 

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -386,24 +386,6 @@ def format_hyperedges(
     is_using_categories = len(defs.categories.keys()) > 0
     cat_lookup = make_reverse_lookup(defs.categories)
 
-    # mt_pdf = pd.DataFrame({
-    #     **{
-    #         **({defs.category: pd.Series([], dtype='object')} if is_using_categories else {}),
-    #         defs.edge_type: pd.Series([], dtype='object'),
-    #         defs.attrib_id: pd.Series([], dtype='object'),
-    #         defs.event_id: pd.Series([], dtype='object'),
-    #         defs.category: pd.Series([], dtype='object'),
-    #         defs.node_id: pd.Series([], dtype='object'),
-    #     },
-    #     **({
-    #         x: pd.Series([], dtype=events[x].dtype)
-    #         for x in entity_types
-    #     } if drop_edge_attrs else {
-    #         x: pd.Series([], dtype=events[x].dtype)
-    #         for x in events.columns
-    #     })
-    # })
-
     subframes = []
     for col in sorted(entity_types):
         fields = list(set([defs.event_id] + ([x for x in events.columns] if not drop_edge_attrs else [ col ])))
@@ -439,7 +421,6 @@ def format_hyperedges(
             + [defs.edge_type, defs.attrib_id, defs.event_id]  # noqa: W503
             + ([defs.category] if is_using_categories else []) ))  # noqa: W503
         if debug and (engine in [Engine.DASK, Engine.DASK_CUDF]):
-            #subframes = [df.persist() for df in subframes]
             for df in subframes:
                 logger.debug('edge sub: %s', df.dtypes)
         out = concat(subframes, engine, debug).reset_index(drop=True)[ result_cols ]
@@ -448,8 +429,7 @@ def format_hyperedges(
             out.compute()
             logger.debug('////format_hyperedges')
         return out
-    else:
-        return mt_series(engine)
+    return mt_series(engine)
 
 
 def direct_edgelist_shape(entity_types: List[str], defs: HyperBindings) -> Dict[str, List[str]]:
@@ -459,11 +439,10 @@ def direct_edgelist_shape(entity_types: List[str], defs: HyperBindings) -> Dict[
     """
     if defs.edges is not None:
         return defs.edges
-    else:
-        out = {}
-        for entity_i in range(len(entity_types)):
-            out[ entity_types[entity_i] ] = entity_types[(entity_i + 1):]
-        return out
+    out = {}
+    for entity_i in range(len(entity_types)):
+        out[ entity_types[entity_i] ] = entity_types[(entity_i + 1):]
+    return out
   
       
 #ex output: DataFrameLike([{'edgeType': 'state', 'attribID': 'state::CA', 'eventID': 'eventID::0'}])
@@ -513,8 +492,7 @@ def format_direct_edges(
             out.compute()
             logger.debug('////format_direct_edges')
         return out
-    else:
-        return events[:0][[]]
+    return events[:0][[]]
 
 
 def format_hypernodes(events, defs, drop_na):

--- a/graphistry/layout/gib/gib.py
+++ b/graphistry/layout/gib/gib.py
@@ -15,14 +15,13 @@ logger = setup_logger(__name__)
 def resolve_partition_key(g, partition_key=None):
     if partition_key is not None:
         return partition_key
-    elif g._nodes is not None and 'partition' in g._nodes:
+    if g._nodes is not None and 'partition' in g._nodes:
         return 'partition'
-    elif g._nodes is not None and 'community' in g._nodes:
+    if g._nodes is not None and 'community' in g._nodes:
         return 'community'
-    elif g._nodes is not None and 'cluster' in g._nodes:
+    if g._nodes is not None and 'cluster' in g._nodes:
         return 'cluster'
-    else:
-        return 'partition'
+    return 'partition'
 
 
 def group_in_a_box_layout(

--- a/graphistry/layout/graph/vertex.py
+++ b/graphistry/layout/graph/vertex.py
@@ -26,13 +26,12 @@ class Vertex(VertexBase):
 
     @property
     def index(self):
-        from .graphBase import GraphBase
-        if self.__index:
-            return self.__index
-        elif isinstance(self.component, GraphBase):
-            self.__index = self.component.verticesPoset.index(self)
-            return self.__index
-        else:
+            from .graphBase import GraphBase
+            if self.__index:
+                return self.__index
+            if isinstance(self.component, GraphBase):
+                self.__index = self.component.verticesPoset.index(self)
+                return self.__index
             return None
 
     def __lt__(self, v):

--- a/graphistry/layout/sugiyama/sugiyamaLayout.py
+++ b/graphistry/layout/sugiyama/sugiyamaLayout.py
@@ -293,10 +293,7 @@ class SugiyamaLayout(object):
 
         # we will simply ignore the given root not corresponding to any vertices
         found = g.get_vertex_from_data(root)
-        if found is not None:
-            return found
-        else:
-            return None
+        return found
 
     def _edge_inverter(self):
         """
@@ -597,8 +594,7 @@ class SugiyamaLayout(object):
         def scale_x(value):
             if x_bounds[0] == x_bounds[1]:
                 return value
-            else:
-                return (value - x_bounds[0]) / (x_bounds[1] - x_bounds[0])
+            return (value - x_bounds[0]) / (x_bounds[1] - x_bounds[0])
 
         for layer in self.layers:
             for v in layer:

--- a/graphistry/layout/utils/layer.py
+++ b/graphistry/layout/utils/layer.py
@@ -120,12 +120,10 @@ class Layer(list):
         layer_index = layout_vertex.layer
         if layout_vertex.nvs is not None and direction in layout_vertex.nvs:
             return layout_vertex.nvs[direction]
-        else:
-            above = [u for u in v.neighbors(0) if self.layout.layoutVertices[u].layer == layer_index - 1]
-            below = [u for u in v.neighbors(0) if self.layout.layoutVertices[u].layer == layer_index + 1]
-            layout_vertex.nvs = {-1: above, +1: below}
-            # if layout_vertex.dummy:
-            return layout_vertex.nvs[direction]
+        above = [u for u in v.neighbors(0) if self.layout.layoutVertices[u].layer == layer_index - 1]
+        below = [u for u in v.neighbors(0) if self.layout.layoutVertices[u].layer == layer_index + 1]
+        layout_vertex.nvs = {-1: above, +1: below}
+        return layout_vertex.nvs[direction]
         # try:
         #     return layout_vertex.nvs[direction]
         # except AttributeError:

--- a/graphistry/layout/utils/poset.py
+++ b/graphistry/layout/utils/poset.py
@@ -27,11 +27,10 @@ class Poset(object):
         return "\n".join(s)
 
     def add(self, obj):
-        if obj is None:
-            raise ValueError
-        if obj in self:
-            return self.get(obj)
-        else:
+            if obj is None:
+                raise ValueError
+            if obj in self:
+                return self.get(obj)
             self.o[obj] = obj
             return obj
 

--- a/graphistry/plugins/cugraph.py
+++ b/graphistry/plugins/cugraph.py
@@ -23,10 +23,9 @@ def df_to_gdf(df: Any):
     import cudf
     if isinstance(df, cudf.DataFrame):
         return df
-    elif isinstance(df, pd.DataFrame):
+    if isinstance(df, pd.DataFrame):
         return cudf.from_pandas(df)
-    else:
-        raise ValueError('Unsupported data type, expected pd.DataFrame or cudf.DataFrame, got: %s', type(df))
+    raise ValueError('Unsupported data type, expected pd.DataFrame or cudf.DataFrame, got: %s', type(df))
 
 
 def from_cugraph(self,
@@ -284,7 +283,7 @@ def compute_cugraph(
             .merge(out, how='left', on=g._node)
         )
         return g.nodes(nodes_gdf)
-    elif alg in edge_compute_algs_to_attr:
+    if alg in edge_compute_algs_to_attr:
         out = getattr(cugraph, alg)(G, **params)
         if isinstance(out, tuple):
             out = out[0]
@@ -307,7 +306,7 @@ def compute_cugraph(
             .merge(out, how='left', on=[g._source, g._destination])
         )
         return g.edges(edges_gdf)
-    elif alg in graph_compute_algs:
+    if alg in graph_compute_algs:
         out = getattr(cugraph, alg)(G, **params)
         if isinstance(out, tuple):
             out = out[0]

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -94,10 +94,9 @@ def strtobool(val: Any) -> bool:
     val = str(val).lower()
     if val in ('y', 'yes', 't', 'true', 'on', '1'):
         return True
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    if val in ('n', 'no', 'f', 'false', 'off', '0'):
         return False
-    else:
-        raise ValueError("invalid truth value %r" % (val,))
+    raise ValueError("invalid truth value %r" % (val,))
 
 class PyGraphistry(object):
     _config = _get_initial_config()
@@ -282,9 +281,8 @@ class PyGraphistry(object):
             input("Press Enter to open browser ...")
             # open browser to auth_url
             webbrowser.open(auth_url)
-        else:
-            print(f"Please open a browser, browse to this URL, and sign in: {auth_url}")
-            print("After, if you get timeout error, run graphistry.sso_get_token() to complete the authentication")
+        print(f"Please open a browser, browse to this URL, and sign in: {auth_url}")
+        print("After, if you get timeout error, run graphistry.sso_get_token() to complete the authentication")
 
         if sso_timeout is not None:
             time.sleep(1)
@@ -320,21 +318,9 @@ class PyGraphistry(object):
             else:
                 print("Please run graphistry.sso_get_token() to complete the authentication after you have authenticated via SSO")
                 return None
-        else:
-            # print("Start getting token ...")
-            # token = None
-            # for i in range(10):
-            #     token, org_name = PyGraphistry._sso_get_token()
-            #     if token:
-            #         # set org_name to sso org
-            #         PyGraphistry._config['org_name'] = org_name
-            #         print("Successfully logged in")
-            #         return PyGraphistry.api_token()
-            #     print("Keep trying to get token ...")
-            #     time.sleep(5)
 
-            print("Please run graphistry.sso_get_token() to complete the authentication")
-            return None
+        print("Please run graphistry.sso_get_token() to complete the authentication")
+        return None
 
     @staticmethod
     def sso_get_token():
@@ -454,9 +440,8 @@ class PyGraphistry(object):
         """Cache credentials for JWT token access. Default off due to not being safe."""
         if value is None:
             return PyGraphistry._config["store_token_creds_in_memory"]
-        else:
-            v = bool(strtobool(value)) if isinstance(value, str) else value
-            PyGraphistry._config["store_token_creds_in_memory"] = v
+        v = bool(strtobool(value)) if isinstance(value, str) else value
+        PyGraphistry._config["store_token_creds_in_memory"] = v
 
     @staticmethod
     def client_protocol_hostname(value=None):
@@ -475,8 +460,7 @@ class PyGraphistry(object):
                 else cfg_client_protocol_hostname
             )
             return cph
-        else:
-            PyGraphistry._config["client_protocol_hostname"] = value
+        PyGraphistry._config["client_protocol_hostname"] = value
 
     @staticmethod
     def api_key(value=None):
@@ -2434,8 +2418,7 @@ class PyGraphistry(object):
             json_response = response.json()
             if json_response.get('status', None) == 'OK':
                 return True
-            else:
-                return json_response.get('message', '')
+            return json_response.get('message', '')
         except:
             logger.error('Error: %s', response, exc_info=True)
             raise Exception("Unknown Error")
@@ -2499,12 +2482,12 @@ switch_org = PyGraphistry.switch_org
 
 class NumpyJSONEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, np.ndarray) and obj.ndim == 1:
-            return obj.tolist()
-        elif isinstance(obj, np.generic):
-            return obj.item()
-        elif isinstance(obj, type(pd.NaT)):
-            return None
-        elif isinstance(obj, datetime):
-            return obj.isoformat()
-        return json.JSONEncoder.default(self, obj)
+            if isinstance(obj, np.ndarray) and obj.ndim == 1:
+                return obj.tolist()
+            if isinstance(obj, np.generic):
+                return obj.item()
+            if isinstance(obj, type(pd.NaT)):
+                return None
+            if isinstance(obj, datetime):
+                return obj.isoformat()
+            return json.JSONEncoder.default(self, obj)

--- a/graphistry/text_utils.py
+++ b/graphistry/text_utils.py
@@ -134,7 +134,7 @@ class SearchToGraphMixin(MIXIN_BASE):
                 g2 = g.umap(kind='nodes', X=['text_col_1', ..],
                 min_words=0 # forces all named columns are textually encoded
                 )
-            
+        
             If an index is not yet built, it is generated `g2.build_index()` on the fly at search time.
             Otherwise, can set `g2.build_index()` to build it ahead of time.
 
@@ -162,7 +162,6 @@ class SearchToGraphMixin(MIXIN_BASE):
                     f"Columns to search for `{query}` \
                              need to be given when fuzzy=False, found {cols}"
                 )
-
             logger.info(f"-- Word Match: [[ {query} ]]")
             return (
                 pd.concat(
@@ -173,9 +172,8 @@ class SearchToGraphMixin(MIXIN_BASE):
                 ),
                 None,
             )
-        else:
-            logger.info(f"-- Search: [[ {query} ]]")
-            return self._query(query, thresh=thresh, top_n=top_n)
+        logger.info(f"-- Search: [[ {query} ]]")
+        return self._query(query, thresh=thresh, top_n=top_n)
 
     def search_graph(
         self,

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -83,10 +83,9 @@ def is_legacy_cuml():
         vs = cuml.__version__.split(".")
         if (vs[0] in ["0", "21"]) or (vs[0] == "22" and float(vs[1]) < 6):
             return True
-        else:
-            return False
     except ModuleNotFoundError:
         return False
+    return False
 
 
 UMAPEngineConcrete = Literal['cuml', 'umap_learn']
@@ -135,10 +134,7 @@ def make_safe_gpu_dataframes(X, y, engine):
         return new_kwargs['X'], new_kwargs['y']
 
     has_cudf_dependancy_, _, cudf = lazy_cudf_import_has_dependancy()
-    if has_cudf_dependancy_:
-        return safe_cudf(X, y)
-    else:
-        return X, y
+    return safe_cudf(X, y) if has_cudf_dependancy_ else (X, y)
 
 ###############################################################################
 
@@ -248,13 +244,12 @@ class UMAPMixin(MIXIN_BASE):
 
     #@safe_gpu_dataframes
     def _check_target_is_one_dimensional(self, y: Union[pd.DataFrame, None]):
-        if y is None:
-            return None
-        if y.ndim == 1:
-            return y
-        elif y.ndim == 2 and y.shape[1] == 1:
-            return y
-        else:
+            if y is None:
+                return None
+            if y.ndim == 1:
+                return y
+            if y.ndim == 2 and y.shape[1] == 1:
+                return y
             logger.warning(
                 f"* Ignoring target column of shape {y.shape} in UMAP fit, "
                 "as it is not one dimensional"
@@ -262,11 +257,10 @@ class UMAPMixin(MIXIN_BASE):
             return None
     
     def _get_embedding(self, kind='nodes'):
-        if kind == 'nodes':
-            return self._node_embedding
-        elif kind == 'edges':
-            return self._edge_embedding
-        else:
+            if kind == 'nodes':
+                return self._node_embedding
+            if kind == 'edges':
+                return self._edge_embedding
             raise ValueError('kind must be one of `nodes` or `edges`')
 
     def umap_fit(self, X: pd.DataFrame, y: Union[pd.DataFrame, None] = None, verbose=False):
@@ -719,7 +713,7 @@ class UMAPMixin(MIXIN_BASE):
             emb = res._node_embedding
         else:
             emb = res._edge_embedding
-            
+        
         if isinstance(df, type(emb)):
             df[x_name] = emb.values.T[0]
             df[y_name] = emb.values.T[1]
@@ -747,8 +741,7 @@ class UMAPMixin(MIXIN_BASE):
                 return res.bind(point_x=x_name, point_y=y_name).layout_settings(
                     play=play
                 )
-            else:
-                return res.bind(point_x=x_name, point_y=y_name)
+            return res.bind(point_x=x_name, point_y=y_name)
 
         return res
 

--- a/graphistry/util.py
+++ b/graphistry/util.py
@@ -154,17 +154,18 @@ def check_set_memoize(
         logger.warning(
             f"! Failed {name} speedup attempt. Continuing without memoization speedups."
         )
+        return False
+
     try:
         if hashed in weakref:
             logger.debug(f"{name} memoization hit: %s", hashed)
             return weakref[hashed].v
-        else:
-            logger.debug(
-                f"{name} memoization miss for id (of %s): %s", len(weakref), hashed
-            )
+        logger.debug(
+            f"{name} memoization miss for id (of %s): %s", len(weakref), hashed
+        )
     except:
         logger.debug(f"Failed to hash {name} kwargs", exc_info=True)
-        pass
+        return False
 
     if memoize and (hashed is not None):
         w = WeakValueWrapper(g)
@@ -382,8 +383,7 @@ def is_notebook():
             return False
     except:
         return False
-    else:  # pragma: no cover
-        return True
+    return True
     
     
 def printmd(string, color=None, size=20):

--- a/graphistry/utils/json.py
+++ b/graphistry/utils/json.py
@@ -19,9 +19,8 @@ def assert_json_serializable(data):
 def serialize_to_json_val(obj: Any) -> JSONVal:
     if isinstance(obj, (str, int, float, bool, type(None))):
         return obj
-    elif isinstance(obj, list):
+    if isinstance(obj, list):
         return [serialize_to_json_val(item) for item in obj]
-    elif isinstance(obj, dict):
+    if isinstance(obj, dict):
         return {key: serialize_to_json_val(value) for key, value in obj.items()}
-    else:
-        raise TypeError(f"Unsupported type for to_json: {type(obj)}")
+    raise TypeError(f"Unsupported type for to_json: {type(obj)}")

--- a/versioneer.py
+++ b/versioneer.py
@@ -1173,9 +1173,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
             return {"version": dirname[len(parentdir_prefix):],
                     "full-revisionid": None,
                     "dirty": False, "error": None, "date": None}
-        else:
-            rootdirs.append(root)
-            root = os.path.dirname(root)  # up a level
+    rootdirs.append(root)
+    root = os.path.dirname(root)  # up a level
 
     if verbose:
         print("Tried directories %s but none started with prefix %s" %


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.