### PR TITLE
refactor(lazy import): centralize, optimize, CPU fallback when broken…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * Graceful CPU fallbacks: When lazy GPU dependency imports throw `ImportError`, commonly seen due to broken CUDA environments or having CUDA libraries but no GPU, warn and fall back to CPU.
 
+* Ring layouts now support filtered inputs, giving expected positions
+
 ### Changed
 
 * Centralize lazy imports into `graphistry.utils.lazy_import`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Development]
 
+### Fixed
+
+* Graceful CPU fallbacks: When lazy GPU dependency imports throw `ImportError`, commonly seen due to broken CUDA environments or having CUDA libraries but no GPU, warn and fall back to CPU.
+
+### Changed
+
+* Centralize lazy imports into `graphistry.utils.lazy_import`
+* Lazy imports distinguish `ModuleNotFound` (=> `False`) from `ImportError` (warn + `False`)
+
 ## [0.34.0 - 2024-07-17]
 
 ### Infra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * Ring layouts now support filtered inputs, giving expected positions
 
+* `encode_axis()` updates are now functional, not inplace
+
 ### Changed
 
 * Centralize lazy imports into `graphistry.utils.lazy_import`

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -374,9 +374,8 @@ class PlotterBase(Plottable):
         """
 
         complex_encodings = {**self._complex_encodings} if self._complex_encodings else {}
-        if 'node_encodings' not in complex_encodings:
-            complex_encodings['node_encodings'] = {}
-        node_encodings = {**complex_encodings['node_encodings']}
+        node_encodings = {**complex_encodings['node_encodings']} if 'node_encodings' not in complex_encodings else {}
+        complex_encodings['node_encodings'] = node_encodings
         node_encodings['current'] = {**node_encodings['current']} if 'current' in node_encodings else {}
         node_encodings['default'] = {**node_encodings['default']} if 'default' in node_encodings else {}
         node_encodings['default']["pointAxisEncoding"] = {

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -373,14 +373,12 @@ class PlotterBase(Plottable):
 
         """
 
-        complex_encodings = self._complex_encodings or {}
+        complex_encodings = {**self._complex_encodings} if self._complex_encodings else {}
         if 'node_encodings' not in complex_encodings:
             complex_encodings['node_encodings'] = {}
-        node_encodings = complex_encodings['node_encodings']
-        if 'current' not in node_encodings:
-            node_encodings['current'] = {}
-        if 'default' not in node_encodings:
-            node_encodings['default'] = {}
+        node_encodings = {**complex_encodings['node_encodings']}
+        node_encodings['current'] = {**node_encodings['current']} if 'current' in node_encodings else {}
+        node_encodings['default'] = {**node_encodings['default']} if 'default' in node_encodings else {}
         node_encodings['default']["pointAxisEncoding"] = {
             "graphType": "point",
             "encodingType": "axis",

--- a/graphistry/dgl_utils.py
+++ b/graphistry/dgl_utils.py
@@ -5,6 +5,10 @@ from typing import Dict, Optional, TYPE_CHECKING, Tuple
 import numpy as np
 import pandas as pd
 
+from graphistry.utils.lazy_import import (
+    lazy_dgl_import,
+    lazy_torch_import_has_dependency
+)
 from . import constants as config
 from .feature_utils import (
     FeatureEngine,
@@ -32,26 +36,6 @@ if TYPE_CHECKING:
         pass
 else:
     MIXIN_BASE = object
-
-
-def lazy_dgl_import_has_dependency():
-    try:
-        import warnings
-        warnings.filterwarnings('ignore')
-        import dgl  # noqa: F811
-        return True, 'ok', dgl
-    except ModuleNotFoundError as e:
-        return False, e, None
-
-
-def lazy_torch_import_has_dependency():
-    try:
-        import warnings
-        warnings.filterwarnings('ignore')
-        import torch  # noqa: F811
-        return True, 'ok', torch
-    except ModuleNotFoundError as e:
-        return False, e, None
 
 
 logger = setup_logger(name=__name__)
@@ -181,7 +165,7 @@ def pandas_to_dgl_graph(
         sp_mat: sparse scipy matrix
         ordered_nodes_dict: dict ordered from most common src and dst nodes
     """
-    _, _, dgl = lazy_dgl_import_has_dependency()  # noqa: F811
+    _, _, dgl = lazy_dgl_import()  # noqa: F811
     sp_mat, ordered_nodes_dict = pandas_to_sparse_adjacency(df, src, dst, weight_col)
     g = dgl.from_scipy(sp_mat, device=device)  # there are other ways too
     logger.info(f"Graph Type: {type(g)}") 
@@ -225,7 +209,7 @@ class DGLGraphMixin(MIXIN_BASE):
         """
 
         if not self.dgl_initialized:
-            lazy_dgl_import_has_dependency()
+            lazy_dgl_import()
             lazy_torch_import_has_dependency()
             self.train_split = train_split
             self.device = device

--- a/graphistry/layout/ring/categorical.py
+++ b/graphistry/layout/ring/categorical.py
@@ -170,6 +170,8 @@ def ring_categorical(
     if g._nodes is None:
         raise ValueError('Missing nodes')
 
+    g = g.nodes(g._nodes.reset_index(drop=True))
+
     engine_concrete = resolve_engine(engine, g._nodes)
 
     if ring_col is None or not isinstance(ring_col, str):

--- a/graphistry/layout/ring/continuous.py
+++ b/graphistry/layout/ring/continuous.py
@@ -182,6 +182,8 @@ def ring_continuous(
     if g._nodes is None:
         raise ValueError('Missing nodes')
 
+    g = g.nodes(g._nodes.reset_index(drop=True))
+
     engine_concrete = resolve_engine(engine, g._nodes)
 
     if ring_col is None:

--- a/graphistry/layout/ring/time.py
+++ b/graphistry/layout/ring/time.py
@@ -318,6 +318,8 @@ def time_ring(
 
     if g._nodes is None:
         raise ValueError('Expected nodes table')
+    
+    g = g.nodes(g._nodes.reset_index(drop=True))
 
     engine_concrete = resolve_engine(engine, g._nodes)
 

--- a/graphistry/tests/test_compute_cluster.py
+++ b/graphistry/tests/test_compute_cluster.py
@@ -4,11 +4,13 @@ import pytest
 import graphistry
 from graphistry.constants import DBSCAN
 from graphistry.util import ModelDict
-from graphistry.compute.cluster import lazy_dbscan_import_has_dependency
-from graphistry.umap_utils import lazy_umap_import_has_dependancy
+from graphistry.utils.lazy_import import (
+    lazy_dbscan_import,
+    lazy_umap_import
+)
 
-has_dbscan, _, has_gpu_dbscan, _ = lazy_dbscan_import_has_dependency()
-has_umap, _, _ = lazy_umap_import_has_dependancy()
+has_dbscan, _, has_gpu_dbscan, _ = lazy_dbscan_import()
+has_umap, _, _ = lazy_umap_import()
 
 
 ndf = edf = pd.DataFrame({'src': [1, 2, 1, 4], 'dst': [4, 5, 6, 1], 'label': ['a', 'b', 'b', 'c']})

--- a/graphistry/tests/test_dgl_utils.py
+++ b/graphistry/tests/test_dgl_utils.py
@@ -3,10 +3,10 @@ import pytest
 import graphistry
 import pandas as pd
 from graphistry.util import setup_logger
+from graphistry.utils.lazy_import import lazy_dgl_import
 
-from graphistry.dgl_utils import lazy_dgl_import_has_dependency
 
-has_dgl, _, dgl = lazy_dgl_import_has_dependency()
+has_dgl, _, dgl = lazy_dgl_import()
 
 if has_dgl:
     import torch

--- a/graphistry/tests/test_embed_utils.py
+++ b/graphistry/tests/test_embed_utils.py
@@ -5,12 +5,13 @@ import unittest
 import graphistry
 import numpy as np
 
-from graphistry.embed_utils import lazy_embed_import_dep, check_cudf
+from graphistry.embed_utils import check_cudf
+from graphistry.utils.lazy_import import lazy_embed_import
 
 import logging
 logger = logging.getLogger(__name__)
 
-dep_flag, _, _, _, _, _, _, _ = lazy_embed_import_dep()
+dep_flag, _, _, _, _, _, _, _ = lazy_embed_import()
 has_cudf, cudf = check_cudf()
 
 # enable tests if has cudf and env didn't explicitly disable

--- a/graphistry/tests/test_feature_utils.py
+++ b/graphistry/tests/test_feature_utils.py
@@ -14,18 +14,20 @@ from graphistry.feature_utils import (
     process_dirty_dataframes,
     process_nodes_dataframes,
     resolve_feature_engine,
-    lazy_import_has_min_dependancy,
-    lazy_import_has_dependancy_text,
     FastEncoder
 )
 
 from graphistry.features import topic_model, ngrams_model
 from graphistry.constants import SCALERS
+from graphistry.utils.lazy_import import (
+    lazy_import_has_min_dependancy,
+    lazy_sentence_transformers_import
+)
 
 np.random.seed(137)
 
 has_min_dependancy, _ = lazy_import_has_min_dependancy()
-has_min_dependancy_text, _, _ = lazy_import_has_dependancy_text()
+has_min_dependancy_text, _, _ = lazy_sentence_transformers_import()
 
 logger = logging.getLogger(__name__)
 warnings.filterwarnings("ignore")

--- a/graphistry/tests/test_text_utils.py
+++ b/graphistry/tests/test_text_utils.py
@@ -10,13 +10,14 @@ from graphistry.feature_utils import remove_internal_namespace_if_present
 from graphistry.tests.test_feature_utils import (
     ndf_reddit,
     edge_df,
-    lazy_import_has_min_dependancy,
+)
+from graphistry.utils.lazy_import import (
+    lazy_umap_import,
+    lazy_import_has_min_dependancy
 )
 
-from graphistry.umap_utils import lazy_umap_import_has_dependancy
-
 has_dependancy, _ = lazy_import_has_min_dependancy()
-has_umap, _, _ = lazy_umap_import_has_dependancy()
+has_umap, _, _ = lazy_umap_import()
 
 logger = logging.getLogger(__name__)
 

--- a/graphistry/tests/test_umap_utils.py
+++ b/graphistry/tests/test_umap_utils.py
@@ -25,17 +25,17 @@ from graphistry.tests.test_feature_utils import (
     lazy_import_has_min_dependancy,
     check_allclose_fit_transform_on_same_data,
 )
-from graphistry.umap_utils import (
-    lazy_umap_import_has_dependancy,
-    lazy_cuml_import_has_dependancy,
-    lazy_cudf_import_has_dependancy,
+from graphistry.utils.lazy_import import (
+    lazy_cudf_import,
+    lazy_cuml_import,
+    lazy_umap_import,
 )
 from graphistry.util import cache_coercion_helper
 
 has_dependancy, _ = lazy_import_has_min_dependancy()
-has_cuml, _, _ = lazy_cuml_import_has_dependancy()
-has_umap, _, _ = lazy_umap_import_has_dependancy()
-has_cudf, _, cudf = lazy_cudf_import_has_dependancy()
+has_cuml, _, _ = lazy_cuml_import()
+has_umap, _, _ = lazy_umap_import()
+has_cudf, _, cudf = lazy_cudf_import()
 
 # print('has_dependancy', has_dependancy)
 # print('has_cuml', has_cuml)

--- a/graphistry/utils/lazy_import.py
+++ b/graphistry/utils/lazy_import.py
@@ -1,0 +1,179 @@
+from typing import Any
+import warnings
+from graphistry .util import setup_logger, check_set_memoize
+logger = setup_logger(__name__)
+
+
+#TODO use new importer when it lands (this is copied from umap_utils)
+def lazy_cudf_import():
+    try:
+        warnings.filterwarnings("ignore")
+        import cudf  # type: ignore
+
+        return True, "ok", cudf
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn("Unexpected exn during lazy import", exc_info=e)
+        return False, e, None
+
+def lazy_cuml_import():
+    try:
+        warnings.filterwarnings("ignore")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            import cuml  # type: ignore
+
+        return True, "ok", cuml
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn("Unexpected exn during lazy import", exc_info=e)
+        return False, e, None
+
+def lazy_dbscan_import():
+    has_min_dependency = True
+    DBSCAN = None
+    try:
+        from sklearn.cluster import DBSCAN
+    except ModuleNotFoundError:
+        has_min_dependency = False
+        logger.info("Please install sklearn for CPU DBSCAN")
+    except Exception as e:
+        logger.warn("Unexpected exn during lazy import", exc_info=e)
+        return False, None, False, None
+
+    has_cuml_dependency = True
+    cuDBSCAN = None
+    try:
+        from cuml import DBSCAN as cuDBSCAN
+    except ModuleNotFoundError:
+        has_cuml_dependency = False
+        logger.info("Please install cuml for GPU DBSCAN")
+    except Exception as e:
+        has_cuml_dependency = False
+        logger.warn("Unexpected exn during lazy import", exc_info=e)
+
+    return has_min_dependency, DBSCAN, has_cuml_dependency, cuDBSCAN
+
+def lazy_dgl_import():
+    try:
+        warnings.filterwarnings('ignore')
+        import dgl  # noqa: F811
+        return True, 'ok', dgl
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn("Unexpected exn during lazy import", exc_info=e)
+        return False, e, None
+
+def lazy_dirty_cat_import():
+    warnings.filterwarnings("ignore")
+    try:
+        import dirty_cat 
+        return True, 'ok', dirty_cat
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return False, e, None
+
+def lazy_embed_import():
+    try:
+        import torch
+        import torch.nn as nn
+        import dgl
+        from dgl.dataloading import GraphDataLoader
+        import torch.nn.functional as F
+        from graphistry.networks import HeteroEmbed
+        from tqdm import trange
+        return True, torch, nn, dgl, GraphDataLoader, HeteroEmbed, F, trange
+    except ModuleNotFoundError:
+        return False, None, None, None, None, None, None, None
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return False, None, None, None, None, None, None, None
+
+def lazy_networks_import():  # noqa
+    try:
+        import dgl
+        import dgl.nn as dglnn
+        import dgl.function as fn
+        import torch
+        import torch.nn as nn
+        import torch.nn.functional as F
+        Module = nn.Module
+        return nn, dgl, dglnn, fn, torch, F, Module
+    except ModuleNotFoundError:
+        return None, None, None, None, None, None, None
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return None, None, None, None, None, None, None
+
+def lazy_torch_import_has_dependency():
+    try:
+        warnings.filterwarnings('ignore')
+        import torch  # noqa: F811
+        return True, 'ok', torch
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return False, e, None
+
+def lazy_umap_import():
+    try:
+        warnings.filterwarnings("ignore")
+        import umap  # noqa
+
+        return True, "ok", umap
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return False, e, None
+
+#@check_set_memoize
+def lazy_sentence_transformers_import():
+    warnings.filterwarnings("ignore")
+    try:
+        from sentence_transformers import SentenceTransformer
+        return True, 'ok', SentenceTransformer
+    except ModuleNotFoundError as e:
+        return False, e, None
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return False, e, None
+
+def lazy_import_has_min_dependancy():
+    warnings.filterwarnings("ignore")
+    try:
+        import scipy.sparse  # noqa
+        from scipy import __version__ as scipy_version
+        from sklearn import __version__ as sklearn_version
+        logger.debug(f"SCIPY VERSION: {scipy_version}")
+        logger.debug(f"sklearn VERSION: {sklearn_version}")
+        return True, 'ok'
+    except ModuleNotFoundError as e:
+        return False, e
+    except Exception as e:
+        logger.warn('Unexpected exn during lazy import', exc_info=e)
+        return False, e, None
+
+def assert_imported_text():
+    has_dependancy_text_, import_text_exn, _ = lazy_sentence_transformers_import()
+    if not has_dependancy_text_:
+        logger.error(  # noqa
+            "AI Package sentence_transformers not found,"
+            "trying running `pip install graphistry[ai]`"
+        )
+        raise import_text_exn
+
+def assert_imported():
+    has_min_dependancy_, import_min_exn = lazy_import_has_min_dependancy()
+    if not has_min_dependancy_:
+        logger.error(  # noqa
+                     "AI Packages not found, trying running"  # noqa
+                     "`pip install graphistry[ai]`"  # noqa
+        )
+        raise import_min_exn


### PR DESCRIPTION
Fixes colab until https://github.com/graphistry/pygraphistry/pull/517 gets figured out


---

### Fixed

* Graceful CPU fallbacks: When lazy GPU dependency imports throw `ImportError`, now warns and falls back, instead of crashing. Commonly seen due to:
  - GPU libs installed but broken CUDA environments
  - GPU libs installed but no GPU

* Ring layouts handle filtered DF inputs, no longer giving unexpected positions

* `g.encode_axis(...)` updates now functional; were erroneously doing global inplace updates

### Changed

* Centralize lazy imports into `graphistry.utils.lazy_import`
* Lazy imports distinguish `ModuleNotFound` (=> `False`) from `ImportError` (warn + `False`)

### Optimized

More cudf sniffing without an import