### PR TITLE
Dev/umap kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * UMAP: Optional kwargs passthrough to umap library constructor, fit, and transform methods: `g.umap(..., umap_kwargs={...}, umap_fit_kwargs={...}, umap_transform_kwargs={...})`
 * Additional GPU support in featurize paths
 
+### Changed
+
+* Replace `verbose` with `logging`
+
 ### Refactor
 
 * Narrow `use_scaler` and `use_scaler_target` typing to `ScalerType` (`Literal[...]`) vs `str`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+* UMAP: Optional kwargs passthrough to umap library constructor, fit, and transform methods: `g.umap(..., umap_kwargs={...}, umap_fit_kwargs={...}, umap_transform_kwargs={...})`
 * Additional GPU support in featurize paths
 
 ### Refactor

--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -19,7 +19,7 @@ flake8 \
   graphistry \
   --exclude graphistry/graph_vector_pb2.py,graphistry/_version.py \
   --count \
-  --ignore=C901,E121,E122,E123,E124,E125,E128,E131,E144,E201,E202,E203,E231,E251,E265,E301,E302,E303,E401,E501,E722,F401,W291,W293 \
+  --ignore=C901,E121,E122,E123,E124,E125,E128,E131,E144,E201,E202,E203,E231,E251,E265,E301,E302,E303,E401,E501,E722,F401,W291,W293,W503 \
   --max-complexity=10 \
   --max-line-length=127 \
   --statistics

--- a/graphistry/Plottable.py
+++ b/graphistry/Plottable.py
@@ -74,6 +74,9 @@ class Plottable(object):
     _xy: Optional[pd.DataFrame]
 
     _umap : Optional[UMAP]
+    _umap_params: Optional[Dict[str, Any]]
+    _umap_fit_kwargs: Optional[Dict[str, Any]]
+    _umap_transform_kwargs: Optional[Dict[str, Any]]
 
     _adjacency : Optional[Any]
     _entity_to_index : Optional[dict]

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -191,6 +191,9 @@ class PlotterBase(Plottable):
 
         # the fit umap instance
         self._umap = None
+        self._umap_params : Optional[Dict[str, Any]] = None
+        self._umap_fit_kwargs : Optional[Dict[str, Any]] = None
+        self._umap_transform_kwargs : Optional[Dict[str, Any]] = None
 
         self._adjacency = None
         self._entity_to_index = None

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -1821,54 +1821,6 @@ class FastEncoder:
         return X, y
 
 
-# ######################################################################################################################
-#
-#
-#
-# ######################################################################################################################
-
-
-def prune_weighted_edges_df_and_relabel_nodes(
-    wdf: pd.DataFrame, scale: float = 0.1, index_to_nodes_dict: Optional[Dict] = None
-) -> pd.DataFrame:
-    """Prune the weighted edge DataFrame so to return high fidelity similarity scores.
-
-    :param wdf: weighted edge DataFrame gotten via UMAP
-    :param scale: lower values means less edges > (max - scale * std)
-    :param index_to_nodes_dict: dict of index to node name;
-            remap src/dst values if provided
-    :return: pd.DataFrame
-    """
-    # we want to prune edges, so we calculate some statistics
-    desc = wdf.describe()
-    eps = 1e-3
-
-    mean = desc[config.WEIGHT]["mean"]
-    std = desc[config.WEIGHT]["std"]
-    max_val = desc[config.WEIGHT]["max"] + eps
-    min_val = desc[config.WEIGHT]["min"] - eps
-    thresh = np.max(
-        [max_val - scale, min_val]
-    )  # if std =0 we add eps so we still have scale in the equation
-
-    logger.info(
-        f" -- edge weights: mean({mean:.2f}), "
-        f"std({std:.2f}), max({max_val}), "
-        f"min({min_val:.2f}), thresh({thresh:.2f})"
-    )
-    wdf2 = wdf[
-        wdf[config.WEIGHT] >= thresh
-    ]  # adds eps so if scale = 0, we have small window/wiggle room
-    logger.info(
-        " -- Pruning weighted edge DataFrame "
-        f"from {len(wdf):,} to {len(wdf2):,} edges."
-    )
-    if index_to_nodes_dict is not None:
-        wdf2[config.SRC] = wdf2[config.SRC].map(index_to_nodes_dict)
-        wdf2[config.DST] = wdf2[config.DST].map(index_to_nodes_dict)
-    return wdf2
-
-
 # ###########################################################################
 #
 #      Fast Memoize

--- a/graphistry/tests/test_feature_utils.py
+++ b/graphistry/tests/test_feature_utils.py
@@ -30,6 +30,7 @@ has_min_dependancy, _ = lazy_import_has_min_dependancy()
 has_min_dependancy_text, _, _ = lazy_sentence_transformers_import()
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 warnings.filterwarnings("ignore")
 logging.getLogger("graphistry.feature_utils").setLevel(logging.DEBUG)
 

--- a/graphistry/tests/test_umap_utils.py
+++ b/graphistry/tests/test_umap_utils.py
@@ -143,12 +143,10 @@ class TestUMAPFitTransform(unittest.TestCase):
     # check to see that .fit and transform gives similar embeddings on same data
     @pytest.mark.skipif(not has_umap, reason="requires umap feature dependencies")
     def setUp(self):
-        verbose = True
         g = graphistry.nodes(ndf_reddit)
         self.gn = g
         
         self.test = ndf_reddit.sample(5)
-
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
@@ -159,8 +157,7 @@ class TestUMAPFitTransform(unittest.TestCase):
                 use_ngrams=True,
                 ngram_range=(1, 2),
                 use_scaler="robust",
-                cardinality_threshold=2,
-                verbose=verbose,
+                cardinality_threshold=2
             )
 
         self.g2 = g2
@@ -168,10 +165,10 @@ class TestUMAPFitTransform(unittest.TestCase):
         self.X, self.Y = fenc.X, fenc.y
         self.EMB = g2._node_embedding
         self.emb, self.x, self.y = g2.transform_umap(
-            ndf_reddit, ndf_reddit, kind="nodes", return_graph=False, verbose=verbose
+            ndf_reddit, ndf_reddit, kind="nodes", return_graph=False
         )
         self.g3 = g2.transform_umap(
-            ndf_reddit, ndf_reddit, kind="nodes", return_graph=True, verbose=verbose
+            ndf_reddit, ndf_reddit, kind="nodes", return_graph=True
         )
 
         # do the same for edges
@@ -192,14 +189,13 @@ class TestUMAPFitTransform(unittest.TestCase):
                 use_scaler_target=None,
                 cardinality_threshold=2,
                 n_topics=4,
-                verbose=verbose,
             )
 
         fenc = g2._edge_encoder
         self.Xe, self.Ye = fenc.X, fenc.y
         self.EMBe = g2._edge_embedding
         self.embe, self.xe, self.ye = g2.transform_umap(
-            edge_df22, y=edge2_target_df, kind="edges", return_graph=False, verbose=verbose
+            edge_df22, y=edge2_target_df, kind="edges", return_graph=False
         )        
         self.g2e = g2
 
@@ -388,7 +384,7 @@ class TestUMAPMethods(unittest.TestCase):
         ]
         self._check_attributes(g, attributes)
 
-    def cases_test_graph(self, g, kind="nodes", df=ndf_reddit, verbose=False):
+    def cases_test_graph(self, g, kind="nodes", df=ndf_reddit):
         if kind == "nodes":
             ndf = g._nodes
             self.cases_check_node_attributes(g)

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -3,6 +3,7 @@ from time import time
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 from inspect import getmodule
 
+import numpy as np
 import pandas as pd
 
 from graphistry.utils.lazy_import import (
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
 else:
     MIXIN_BASE = object
 
+
+DataFrameLike = Union[pd.DataFrame, Any]
 
 ###############################################################################
 

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -371,10 +371,9 @@ class UMAPMixin(MIXIN_BASE):
             sample: Sample number of existing graph's neighbors to use for contextualization -- helps make denser graphs
             return_graph: Whether to return a graph or just the embeddings
             fit_umap_embedding: Whether to infer graph from the UMAP embedding on the new data, default True
-            verbose: Whether to print information about the graph inference
         """
         df, y = make_safe_gpu_dataframes(df, y, 'pandas')
-        X, y_ = self.transform(df, y, kind=kind, return_graph=False, verbose=verbose)
+        X, y_ = self.transform(df, y, kind=kind, return_graph=False)
         X, y_ = make_safe_gpu_dataframes(X, y_, self.engine)  # type: ignore
         emb = self._umap.transform(X, **umap_transform_kwargs)  # type: ignore
         emb = self._bundle_embedding(emb, index=df.index)
@@ -383,8 +382,7 @@ class UMAPMixin(MIXIN_BASE):
             X, y_ = make_safe_gpu_dataframes(X, y_, 'pandas')
             g = self._infer_edges(emb, X, y_, df, 
                                   infer_on_umap_embedding=fit_umap_embedding, merge_policy=merge_policy,
-                                  eps=min_dist, sample=sample, n_neighbors=n_neighbors,
-                                  verbose=verbose) 
+                                  eps=min_dist, sample=sample, n_neighbors=n_neighbors) 
             return g
         return emb, X, y_
 
@@ -752,7 +750,7 @@ class UMAPMixin(MIXIN_BASE):
             res = res.prune_self_edges()
 
         if dbscan:
-            res = res.dbscan(min_dist=min_dist, kind=kind, fit_umap_embedding=True, verbose=verbose)  # type: ignore
+            res = res.dbscan(min_dist=min_dist, kind=kind, fit_umap_embedding=True)  # type: ignore
 
         if not inplace:
             return res

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -609,6 +609,11 @@ class UMAPMixin(MIXIN_BASE):
         # temporary until we have full cudf support in feature_utils.py
         has_cudf, _, cudf = lazy_cudf_import()
 
+        if inplace:
+            res = self
+        else:
+            res = self.bind()
+
         if has_cudf:
             flag_nodes_cudf = isinstance(self._nodes, cudf.DataFrame)
             flag_edges_cudf = isinstance(self._edges, cudf.DataFrame)

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -625,12 +625,7 @@ class UMAPMixin(MIXIN_BASE):
                     res = res.umap(X=self._nodes, y=self._edges, kind=kind, feature_engine=feature_engine, **umap_kwargs_combined, **featurize_kwargs)  # type: ignore
                 return res
 
-        if inplace:
-            res = self
-        else:
-            res = self.bind()
-
-        res = res.umap_lazy_init(res, verbose=verbose, **umap_kwargs)  # type: ignore
+        res = res.umap_lazy_init(res, **umap_kwargs_combined)
 
         logger.debug("umap input X :: %s", X)
         logger.debug("umap input y :: %s", y)

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -132,11 +132,52 @@ def umap_graph_to_weighted_edges(umap_graph, engine, is_legacy, cfg=config):
         _weighted_edges_df = pd.DataFrame(
             {src: coo.row, dst: coo.col, weight_col: coo.data}
         )
-    elif (engine == "cuml") and not is_legacy:
-        _weighted_edges_df = pd.DataFrame(
-            {src: coo.get().row, dst: coo.get().col, weight_col: coo.get().data}
-        )
-    return _weighted_edges_df
+    )
+
+
+##############################################################################
+
+
+def prune_weighted_edges_df_and_relabel_nodes(
+    wdf: DataFrameLike, scale: float = 0.1, index_to_nodes_dict: Optional[Dict] = None
+) -> pd.DataFrame:
+    """Prune the weighted edge DataFrame so to return high fidelity similarity scores.
+
+    :param wdf: weighted edge DataFrame gotten via UMAP
+    :param scale: lower values means less edges > (max - scale * std)
+    :param index_to_nodes_dict: dict of index to node name;
+            remap src/dst values if provided
+    :return: pd.DataFrame
+    """
+    # we want to prune edges, so we calculate some statistics
+    desc = wdf.describe()
+    eps = 1e-3
+
+    mean = desc[config.WEIGHT]["mean"]
+    std = desc[config.WEIGHT]["std"]
+    max_val = desc[config.WEIGHT]["max"] + eps
+    min_val = desc[config.WEIGHT]["min"] - eps
+    thresh = np.max(
+        [max_val - scale, min_val]
+    )  # if std =0 we add eps so we still have scale in the equation
+
+    logger.info(
+        f" -- edge weights: mean({mean:.2f}), "
+        f"std({std:.2f}), max({max_val}), "
+        f"min({min_val:.2f}), thresh({thresh:.2f})"
+    )
+    wdf2 = wdf[
+        wdf[config.WEIGHT] >= thresh
+    ]  # adds eps so if scale = 0, we have small window/wiggle room
+    logger.info(
+        " -- Pruning weighted edge DataFrame "
+        f"from {len(wdf):,} to {len(wdf2):,} edges."
+    )
+    if index_to_nodes_dict is not None:
+        wdf2[config.SRC] = wdf2[config.SRC].map(index_to_nodes_dict)
+        wdf2[config.DST] = wdf2[config.DST].map(index_to_nodes_dict)
+    return wdf2
+
 
 
 class UMAPMixin(MIXIN_BASE):

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -621,8 +621,8 @@ class UMAPMixin(MIXIN_BASE):
             flag_nodes_cudf = isinstance(self._nodes, cudf.DataFrame)
             flag_edges_cudf = isinstance(self._edges, cudf.DataFrame)
 
-            if flag_nodes_cudf or flag_edges_cudf:
-                res = self
+            #if flag_nodes_cudf or flag_edges_cudf:
+            if False:
                 if flag_nodes_cudf:
                     res._nodes = res._nodes.to_pandas()
                 if flag_edges_cudf:
@@ -633,7 +633,22 @@ class UMAPMixin(MIXIN_BASE):
                     res = res.umap(X=self._nodes, y=self._edges, kind=kind, feature_engine=feature_engine, **umap_kwargs_combined, **featurize_kwargs)  # type: ignore
                 return res
 
-        res = res.umap_lazy_init(res, **umap_kwargs_combined)
+        res = res.umap_lazy_init(
+            res,
+            n_neighbors=n_neighbors,
+            min_dist=min_dist,
+            spread=spread,
+            local_connectivity=local_connectivity,
+            repulsion_strength=repulsion_strength,
+            negative_sample_rate=negative_sample_rate,
+            n_components=n_components,
+            metric=metric,
+            engine=engine,
+            suffix=suffix,
+            umap_kwargs=umap_kwargs,
+            umap_fit_kwargs=umap_fit_kwargs,
+            umap_transform_kwargs=umap_transform_kwargs
+        )
 
         logger.debug("umap input X :: %s", X)
         logger.debug("umap input y :: %s", y)
@@ -665,8 +680,8 @@ class UMAPMixin(MIXIN_BASE):
                 **featurize_kwargs
             )
 
-            logger.debug("umap X_: %s", X_)
-            logger.debug("umap y_: %s", y_)
+            logger.debug("umap X_ (%s): %s", type(X_), X_)
+            logger.debug("umap y_ (%s): %s", type(y_), y_)
             logger.debug("data is type :: %s", (type(X_)))
             if isinstance(X_, pd.DataFrame):
                 index_to_nodes_dict = dict(zip(range(len(nodes)), nodes))

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -668,7 +668,10 @@ class UMAPMixin(MIXIN_BASE):
             if isinstance(X_, pd.DataFrame):
                 index_to_nodes_dict = dict(zip(range(len(nodes)), nodes))
             elif 'cudf.core.dataframe' in str(getmodule(X_)):
-                index_to_nodes_dict = nodes  # {}?
+                assert isinstance(X_, cudf.DataFrame)
+                logger.debug('nodes type: %s', type(nodes))
+                import cupy as cp
+                index_to_nodes_dict = dict(zip(range(len(nodes)), cp.asnumpy(nodes)))
 
             # add the safe coercion here 
             X_, y_ = make_safe_gpu_dataframes(X_, y_, res.engine)  # type: ignore


### PR DESCRIPTION
### Added

* UMAP: Optional kwargs passthrough to umap library constructor, fit, and transform methods: `g.umap(..., umap_kwargs={...}, umap_fit_kwargs={...}, umap_transform_kwargs={...})`

### Changed

* Replace `verbose` with `logging`

### Refactor

* move prune_weighted_edges_df_and_relabel_nodes to a more relevant file