### PR TITLE
fix: Support modern sentence transformer model namespaces with backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,23 @@ All notable changes to the PyGraphistry are documented in this file. The PyGraph
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and all PyGraphistry-specific breaking changes are explictly noted here.
 
-## [ - ]
+## [0.38.0 - 2025-06-17]
 
 ### Feat
 * Kusto/Azure Data Explorer integration. `PyGraphistry.kusto()`, `kusto_query()`, `kusto_query_graph()`
 * Extra kusto install target `pip install graphistry[kusto]` installs azure-kusto-data, azure-identity
 
+### Fixed
+* Fix sentence transformer model name handling to support both legacy format and new organization-prefixed formats (e.g., `mixedbread-ai/mxbai-embed-large-v1`)
+
 ### Changed
 * Legacy `Plottable.spanner_init()` & `PyGraphistry.spanner_init()` helpers no longer shipped. Use `spanner()`
 
 ### Breaking
-* Kusto device authentication doesn't persist. 
+* Kusto device authentication doesn't persist.
+
+### Test
+* Add comprehensive tests for sentence transformer model name formats including legacy, organization-prefixed, and local path formats
 
 ## [0.37.0 - 2025-06-05]
 


### PR DESCRIPTION
## Summary

This PR fixes sentence transformer model name handling to support both legacy formats and new organization-prefixed formats (e.g., `mixedbread-ai/mxbai-embed-large-v1`), while maintaining full backwards compatibility.

The issue arose when attempting to use models from organizations other than `sentence-transformers/`, which was causing the Docker build to fail with a 401 Unauthorized error.

## Changes

- **Fixed model name handling in `encode_textual()`**: 
  - Legacy format (e.g., `paraphrase-MiniLM-L6-v2`) → automatically prefixed with `sentence-transformers/`
  - Organization-prefixed format (e.g., `mixedbread-ai/mxbai-embed-large-v1`) → kept as-is
  - Local paths (e.g., `/models/average_word_embeddings_komninos`) → kept as-is

- **Added comprehensive tests**:
  - Test legacy format compatibility
  - Test sentence-transformers namespace
  - Test alternative organization namespaces
  - Test local model paths (for Docker environments)
  - Verify identical embeddings are produced regardless of format

## Test plan

- [x] Unit tests added in `test_feature_utils.py`
- [x] Manually tested with various model name formats
- [x] Verified backwards compatibility with legacy code
- [ ] CI tests will run via `test-full-ai` job

## Example usage

```python
# All of these now work correctly:

# Legacy format (backwards compatible)
g.featurize(model_name='paraphrase-MiniLM-L6-v2')

# Explicit sentence-transformers namespace
g.featurize(model_name='sentence-transformers/paraphrase-MiniLM-L6-v2')

# Alternative organization namespaces
g.featurize(model_name='mixedbread-ai/mxbai-embed-large-v1')
g.featurize(model_name='nomic-ai/nomic-embed-text-v1')
g.featurize(model_name='BAAI/bge-large-en-v1.5')

# Local paths (Docker)
g.featurize(model_name='/models/average_word_embeddings_komninos')
```

🤖 Generated with Claude Code