### PR TITLE
fix: Update PyPI publish workflow to use Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,5 +43,3 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TEST }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYGGRAPHISTRY_PYPI }}
+          attestations: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,3 +43,5 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 * Legacy `Plottable.spanner_init()` & `PyGraphistry.spanner_init()` helpers no longer shipped. Use `spanner()`
+* PyPI publish workflow now uses Trusted Publishing (OIDC) instead of password authentication
 
 ### Breaking
 * Kusto device authentication doesn't persist. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [ - ]
 
+### Changed
+* PyPI publish workflow now uses Trusted Publishing (OIDC) instead of password authentication
+
+## [0.38.0 - 2025-06-17]
+
 ### Feat
 * Kusto/Azure Data Explorer integration. `PyGraphistry.kusto()`, `kusto_query()`, `kusto_query_graph()`
 * Extra kusto install target `pip install graphistry[kusto]` installs azure-kusto-data, azure-identity
 
+### Fixed
+* Fix sentence transformer model name handling to support both legacy format and new organization-prefixed formats (e.g., `mixedbread-ai/mxbai-embed-large-v1`)
+
 ### Changed
 * Legacy `Plottable.spanner_init()` & `PyGraphistry.spanner_init()` helpers no longer shipped. Use `spanner()`
-* PyPI publish workflow now uses Trusted Publishing (OIDC) instead of password authentication
 
 ### Breaking
-* Kusto device authentication doesn't persist. 
+* Kusto device authentication doesn't persist.
+
+### Test
+* Add comprehensive tests for sentence transformer model name formats including legacy, organization-prefixed, and local path formats
 
 ## [0.37.0 - 2025-06-05]
 


### PR DESCRIPTION
## Summary
- Update PyPI publish workflow to use Trusted Publishing (OIDC) instead of password authentication
- Fix deprecated `repository_url` parameter warning

## Changes
- Replace deprecated `repository_url` with `repository-url`
- Add `id-token: write` permission for OIDC authentication
- Enable attestations for TestPyPI
- Disable attestations for PyPI to avoid conflicts
- Remove dependency on password secrets (`PYPI_TEST` and `PYGGRAPHISTRY_PYPI`)

## Test plan
✅ Tested with release candidates v0.38.1rc1 through v0.38.1rc4
✅ Successfully published to both TestPyPI and PyPI using Trusted Publishing
✅ Verified package v0.38.1rc4 is available on PyPI

🤖 Generated with [Claude Code](https://claude.ai/code)