### PR TITLE
fix: resolve mypy 1.8.0 overload-overlap errors for Literal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking
 * Plottable is now a Protocol
 * py.typed added, type checking active on PyGraphistry!
+* transform() and transform_umap() now require some parameters to be keyword-only
 
 ## [0.38.0 - 2025-06-17]
 

--- a/graphistry/Plottable.py
+++ b/graphistry/Plottable.py
@@ -588,6 +588,7 @@ class Plottable(Protocol):
                   n_neighbors: int = 7,
                   merge_policy: bool = False,
                   sample: Optional[int] = None, 
+                  *,
                   return_graph: Literal[True] = True,
                   scaled: bool = True,
                   verbose: bool = False) -> 'Plottable':
@@ -601,7 +602,8 @@ class Plottable(Protocol):
                   n_neighbors: int = 7,
                   merge_policy: bool = False,
                   sample: Optional[int] = None, 
-                  return_graph: Literal[False] = False,
+                  *,
+                  return_graph: Literal[False],
                   scaled: bool = True,
                   verbose: bool = False) -> Tuple[pd.DataFrame, pd.DataFrame]:
         ...
@@ -613,6 +615,7 @@ class Plottable(Protocol):
                   n_neighbors: int = 7,
                   merge_policy: bool = False,
                   sample: Optional[int] = None, 
+                  *,
                   return_graph: bool = True,
                   scaled: bool = True,
                   verbose: bool = False) -> Union[Tuple[pd.DataFrame, pd.DataFrame], 'Plottable']:
@@ -627,6 +630,7 @@ class Plottable(Protocol):
                     n_neighbors: int = 7,
                     merge_policy: bool = False,
                     sample: Optional[int] = None,
+                    *,
                     return_graph: Literal[True] = True,
                     fit_umap_embedding: bool = True,
                     umap_transform_kwargs: Dict[str, Any] = {}
@@ -641,7 +645,8 @@ class Plottable(Protocol):
                     n_neighbors: int = 7,
                     merge_policy: bool = False,
                     sample: Optional[int] = None,
-                    return_graph: Literal[False] = False,
+                    *,
+                    return_graph: Literal[False],
                     fit_umap_embedding: bool = True,
                     umap_transform_kwargs: Dict[str, Any] = {}
     ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
@@ -654,6 +659,7 @@ class Plottable(Protocol):
                     n_neighbors: int = 7,
                     merge_policy: bool = False,
                     sample: Optional[int] = None,
+                    *,
                     return_graph: bool = True,
                     fit_umap_embedding: bool = True,
                     umap_transform_kwargs: Dict[str, Any] = {}

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -2368,6 +2368,7 @@ class FeatureMixin(ComputeMixin):
                   n_neighbors: int = 7,
                   merge_policy: bool = False,
                   sample: Optional[int] = None, 
+                  *,
                   return_graph: Literal[True] = True,
                   scaled: bool = True,
                   verbose: bool = False) -> 'Plottable':
@@ -2381,7 +2382,8 @@ class FeatureMixin(ComputeMixin):
                   n_neighbors: int = 7,
                   merge_policy: bool = False,
                   sample: Optional[int] = None, 
-                  return_graph: Literal[False] = False,
+                  *,
+                  return_graph: Literal[False],
                   scaled: bool = True,
                   verbose: bool = False) -> Tuple[pd.DataFrame, pd.DataFrame]:
         ...
@@ -2393,6 +2395,7 @@ class FeatureMixin(ComputeMixin):
                   n_neighbors: int = 7,
                   merge_policy: bool = False,
                   sample: Optional[int] = None, 
+                  *,
                   return_graph: bool = True,
                   scaled: bool = True,
                   verbose: bool = False) -> Union[Tuple[pd.DataFrame, pd.DataFrame], 'Plottable']:

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -393,6 +393,7 @@ class UMAPMixin(MIXIN_BASE):
                     n_neighbors: int = 7,
                     merge_policy: bool = False,
                     sample: Optional[int] = None,
+                    *,
                     return_graph: Literal[True] = True,
                     fit_umap_embedding: bool = True,
                     umap_transform_kwargs: Dict[str, Any] = {}
@@ -407,7 +408,8 @@ class UMAPMixin(MIXIN_BASE):
                     n_neighbors: int = 7,
                     merge_policy: bool = False,
                     sample: Optional[int] = None,
-                    return_graph: Literal[False] = False,
+                    *,
+                    return_graph: Literal[False],
                     fit_umap_embedding: bool = True,
                     umap_transform_kwargs: Dict[str, Any] = {}
     ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
@@ -420,6 +422,7 @@ class UMAPMixin(MIXIN_BASE):
                     n_neighbors: int = 7,
                     merge_policy: bool = False,
                     sample: Optional[int] = None,
+                    *,
                     return_graph: bool = True,
                     fit_umap_embedding: bool = True,
                     umap_transform_kwargs: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- Fixes mypy 1.8.0 compatibility issues by making `return_graph`, `scaled`, and `verbose` keyword-only arguments
- Resolves type checking errors without suppressing mypy's useful overload checking
- Improves API design by making the intent of boolean flags clearer
- Clean solution that maintains type safety while fixing the overlap issue

## Problem
When running `./bin/typecheck.sh` locally with mypy 1.8.0, the following errors occurred:
```
graphistry/Plottable.py:584: error: Overloaded function signatures 1 and 2 overlap with incompatible return types
graphistry/Plottable.py:623: error: Overloaded function signatures 1 and 2 overlap with incompatible return types
graphistry/umap_utils.py:389: error: Overloaded function signatures 1 and 2 overlap with incompatible return types
graphistry/feature_utils.py:2364: error: Overloaded function signatures 1 and 2 overlap with incompatible return types
```

## Solution
- Made `return_graph`, `scaled`, and `verbose` keyword-only arguments using `*,` separator
- This eliminates the signature overlap that mypy detected while preserving the useful type inference
- When `return_graph=True` (or omitted), returns `Plottable` 
- When `return_graph=False`, returns tuple of DataFrames
- All existing call sites already use keyword arguments, so no breaking changes in practice

## Changes
- `graphistry/Plottable.py`: Updated `transform()` and `transform_umap()` overloads and implementation
- `graphistry/umap_utils.py`: Updated `transform_umap()` overloads and implementation  
- `graphistry/feature_utils.py`: Updated `transform()` overloads and implementation
- `CHANGELOG.md`: Documented the API change

## API Impact
This is technically a breaking change since some parameters are now keyword-only, but:
- ✅ All existing call sites in the codebase already use keywords
- ✅ The API is now clearer about which parameters should be keywords
- ✅ Better follows Python best practices for boolean flags

## Test plan
- [x] Run `./bin/typecheck.sh` locally - now passes without errors
- [x] Verified all existing call sites use keyword arguments
- [x] No runtime behavior changes
- [ ] CI will validate compatibility across Python versions

🤖 Generated with [Claude Code](https://claude.ai/code)