### PR TITLE
fix(imports): replace relative imports with absolute imports in GFQL modules

### DIFF
--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -23,3 +23,11 @@ flake8 \
   --max-complexity=10 \
   --max-line-length=127 \
   --statistics
+
+# Check for relative imports with '..' using flake8-quotes or custom regex
+# This will fail if any relative imports with .. are found
+echo "Checking for relative imports with '..' ..."
+if grep -r "from \.\." graphistry --include="*.py" --exclude-dir="__pycache__"; then
+    echo "ERROR: Found relative imports with '..'. Use absolute imports instead."
+    exit 1
+fi

--- a/graphistry/compute/ast_temporal.py
+++ b/graphistry/compute/ast_temporal.py
@@ -1,21 +1,19 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, date, time
-from typing import Dict, Any, Union, TYPE_CHECKING
+from typing import Dict, Any, Union
 import pandas as pd
 from dateutil import parser as date_parser  # type: ignore[import]
 import pytz  # type: ignore[import]
 
 from graphistry.utils.json import JSONVal
-
-if TYPE_CHECKING:
-    from ..models.gfql.types.temporal import DateTimeWire, DateWire, TimeWire, TemporalWire
+from graphistry.models.gfql.types.temporal import DateTimeWire, DateWire, TimeWire, TemporalWire
 
 
 class TemporalValue(ABC):
     """Base class for temporal values with tagging support"""
     
     @abstractmethod
-    def to_json(self) -> 'TemporalWire':
+    def to_json(self) -> TemporalWire:
         """Serialize to JSON-compatible dictionary"""
         pass
     
@@ -64,9 +62,8 @@ class DateTimeValue(TemporalValue):
         
         return pd.Timestamp(dt)
     
-    def to_json(self) -> 'DateTimeWire':
+    def to_json(self) -> DateTimeWire:
         """Return dict for tagged temporal value"""
-        from ..models.gfql.types.temporal import DateTimeWire
         result: DateTimeWire = {
             "type": "datetime",
             "value": self.value,
@@ -94,9 +91,8 @@ class DateValue(TemporalValue):
         """Parse date string in ISO format (YYYY-MM-DD)"""
         return date_parser.isoparse(value).date()
     
-    def to_json(self) -> 'DateWire':
+    def to_json(self) -> DateWire:
         """Return dict for tagged temporal value"""
-        from ..models.gfql.types.temporal import DateWire
         result: DateWire = {
             "type": "date",
             "value": self.value
@@ -130,9 +126,8 @@ class TimeValue(TemporalValue):
             # Extract time from full datetime
             return date_parser.isoparse(value).time()
     
-    def to_json(self) -> 'TimeWire':
+    def to_json(self) -> TimeWire:
         """Return dict for tagged temporal value"""
-        from ..models.gfql.types.temporal import TimeWire
         result: TimeWire = {
             "type": "time", 
             "value": self.value

--- a/graphistry/compute/predicates/comparison.py
+++ b/graphistry/compute/predicates/comparison.py
@@ -4,11 +4,11 @@ import numpy as np
 from datetime import datetime, date, time
 
 from .ASTPredicate import ASTPredicate
-from ..ast_temporal import TemporalValue, DateTimeValue, DateValue, TimeValue
-from ...models.gfql.coercions.temporal import to_ast
-from ...models.gfql.types.guards import is_native_numeric, is_any_temporal, is_string
+from graphistry.compute.ast_temporal import TemporalValue, DateTimeValue, DateValue, TimeValue
+from graphistry.models.gfql.coercions.temporal import to_ast
+from graphistry.models.gfql.types.guards import is_native_numeric, is_any_temporal, is_string
 from graphistry.models.gfql.types.predicates import ComparisonInput, BetweenBoundInput
-from ...utils.json import JSONVal
+from graphistry.utils.json import JSONVal
 from graphistry.compute.typing import SeriesT
 
 if TYPE_CHECKING:

--- a/graphistry/compute/predicates/is_in.py
+++ b/graphistry/compute/predicates/is_in.py
@@ -7,8 +7,8 @@ from datetime import datetime, date, time
 from graphistry.utils.json import assert_json_serializable
 from .ASTPredicate import ASTPredicate
 # Temporal value classes imported for type checking only
-from ...models.gfql.coercions.temporal import to_native
-from ...models.gfql.types.guards import is_basic_scalar, is_any_temporal
+from graphistry.models.gfql.coercions.temporal import to_native
+from graphistry.models.gfql.types.guards import is_basic_scalar, is_any_temporal
 from graphistry.models.gfql.types.predicates import IsInElementInput
 from graphistry.models.gfql.types.temporal import TemporalWire, DateTimeWire, DateWire, TimeWire
 from graphistry.compute.typing import SeriesT

--- a/graphistry/compute/predicates/types.py
+++ b/graphistry/compute/predicates/types.py
@@ -5,7 +5,7 @@ import numpy as np
 from datetime import datetime, date, time
 
 # Import temporal wire types
-from ...models.gfql.types.temporal import DateTimeWire, DateWire, TimeWire
+from graphistry.models.gfql.types.temporal import DateTimeWire, DateWire, TimeWire
 
 # Normalized types after processing inputs
 NormalizedNumeric = Union[int, float, np.number]

--- a/graphistry/models/gfql/coercions/numeric.py
+++ b/graphistry/models/gfql/coercions/numeric.py
@@ -8,7 +8,7 @@ but this provides a consistent interface.
 from typing import Union
 import numpy as np
 
-from ..types.numeric import NativeNumeric
+from graphistry.models.gfql.types.numeric import NativeNumeric
 
 
 def to_native(val: NativeNumeric) -> NativeNumeric:

--- a/graphistry/models/gfql/coercions/temporal.py
+++ b/graphistry/models/gfql/coercions/temporal.py
@@ -8,10 +8,10 @@ from typing import Union
 from datetime import datetime, date, time
 import pandas as pd
 
-from ....compute.ast_temporal import (
+from graphistry.compute.ast_temporal import (
     TemporalValue, DateTimeValue, DateValue, TimeValue
 )
-from ..types.temporal import NativeTemporal, TemporalWire
+from graphistry.models.gfql.types.temporal import NativeTemporal, TemporalWire
 
 
 # ============= To AST Transforms =============

--- a/graphistry/models/gfql/types/guards.py
+++ b/graphistry/models/gfql/types/guards.py
@@ -17,7 +17,7 @@ from datetime import datetime, date, time
 import pandas as pd
 import numpy as np
 
-from ....compute.ast_temporal import TemporalValue
+from graphistry.compute.ast_temporal import TemporalValue
 from .temporal import NativeTemporal, TemporalWire
 from .numeric import NativeNumeric
 


### PR DESCRIPTION
## Summary
- Fixes pip install issues caused by relative imports in GFQL modules
- Replaces all `..` relative imports with absolute `graphistry.` imports
- Adds lint check to prevent future relative imports

## Problem
Recent GFQL commits introduced relative imports using `..` which broke pip install/import functionality. When installed via pip, the relative imports couldn't resolve properly, causing import errors.

## Solution
- Converted all relative imports to absolute imports using the `graphistry` package namespace
- Added a grep check in `bin/lint.sh` to catch any future relative imports during linting

## Changes
- Updated 7 GFQL-related Python files to use absolute imports
- Modified `bin/lint.sh` to check for and reject relative imports with `..`

## Test plan
- [x] Verified no relative imports remain: `grep -r "from \.\." graphistry --include="*.py"` returns empty
- [x] Lint script successfully detects relative imports if added
- [ ] Pip install and import should work correctly after merge

🤖 Generated with [Claude Code](https://claude.ai/code)