### PR TITLE
chore: update copyright year from 2024 to 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+### Docs
+* Update copyright year from 2024 to 2025 in documentation and LICENSE.txt
+
 ## [0.39.1 - 2025-07-07]
 
 ### Fixed

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023, Graphistry, Inc.
+Copyright (c) 2025, Graphistry, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ logger.setLevel(logging.DEBUG)
 # -- Project information -----------------------------------------------------
 
 project = "PyGraphistry"
-copyright = "2024, Graphistry, Inc."
+copyright = "2025, Graphistry, Inc."
 author = "Graphistry, Inc."
 
 html_title = "PyGraphistry Documentation"


### PR DESCRIPTION
## Summary
- Update copyright year from 2024 to 2025 in docs/source/conf.py
- This change will regenerate all documentation with the new copyright year

## Details
This PR updates the copyright statement for the new year. The primary change is in `docs/source/conf.py`, which is the source configuration for all generated documentation.

## Test plan
- [ ] Documentation builds successfully
- [ ] Generated HTML docs show 2025 copyright
- [ ] All tests pass

## Related
- Part of annual copyright update process
- No functional changes

🤖 Generated with [Claude Code](https://claude.ai/code)