### PR TITLE
fix(engine): use dynamic import for Plottable instanceof check to avoid Jinja dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+### Fixed
+* Engine: Fix resolve_engine() to use dynamic import for Plottable isinstance check to avoid Jinja dependency from pandas df.style getter (#701)
+
 ### Docs
 * Update copyright year from 2024 to 2025 in documentation and LICENSE.txt
 * GFQL: Add comprehensive specification documentation (#698)

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -39,8 +39,16 @@ def resolve_engine(
         return Engine(engine.value)
 
     if g_or_df is not None:
-        from graphistry.Plottable import Plottable
-        if isinstance(g_or_df, Plottable):
+        # Use dynamic import to avoid Jinja dependency issues from pandas df.style getter
+        try:
+            from graphistry.plotter import Plotter
+            is_plottable = isinstance(g_or_df, Plotter)
+        except ImportError:
+            # Fallback to old import if plotter module not available
+            from graphistry.Plottable import Plottable
+            is_plottable = isinstance(g_or_df, Plottable)
+        
+        if is_plottable:
             if g_or_df._nodes is not None and g_or_df._edges is not None:
                 if not isinstance(g_or_df._nodes, type(g_or_df._edges)):
                     #raise ValueError(f'Edges and nodes must be same type for auto engine selection, got: {type(g_or_df._edges)} and {type(g_or_df._nodes)}')


### PR DESCRIPTION
## Summary
Fix resolve_engine() to use dynamic import pattern to avoid Jinja dependency issues from pandas df.style getter.

## Problem
The resolve_engine() function was doing a direct import of graphistry.Plottable for isinstance checks, which created a dynamic dependency on Jinja because pandas dataframes' df.style getter triggers a failing Jinja import.

This was causing CI failures like: https://github.com/graphistry/pygraphistry/actions/runs/16314132630/job/46075996777

## Solution
- Try importing graphistry.plotter.Plotter first (avoids Jinja dependency)
- Fallback to graphistry.Plottable if plotter module not available
- Use intermediate variable for cleaner code

## Changes
- Updated resolve_engine() in graphistry/Engine.py
- Added try/except block with dynamic import pattern
- Maintained backward compatibility with fallback import

## Testing
- Verified syntax is correct
- Tested that the function still works as expected
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)