### PR TITLE
feat(ci): Update GPU CI with environment protection and parallel testing

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -21,7 +21,7 @@ jobs:
   gpu-permission:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && contains(fromJson('["lmeyerov", "tanmoyio", "aucahuasi", "silkspace", "DataBoyTx"]'), github.actor))
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Do nothing
@@ -48,6 +48,7 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.label.name, 'gpu-ci'))
     runs-on:
       group: GPU Runners - Public
+    environment: gpu-staff
 
     strategy:
       matrix:
@@ -96,4 +97,4 @@ jobs:
       run: |
         source pygraphistry/bin/activate
         python -m pytest --version
-        python -B -m pytest -vv
+        python -B -m pytest -vv -n auto --dist loadfile


### PR DESCRIPTION
## Summary
- Add `gpu-staff` environment for access control
- Remove hardcoded user list (now handled by environment)  
- Enable parallel test execution with pytest-xdist

## Test plan
- [ ] Add `gpu-ci` label to this PR to trigger GPU tests
- [ ] Verify tests run in parallel
- [ ] Confirm environment access control works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)