### PR TITLE
fix(Engine): Fix resolve_engine to check both Plotter and Plottable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 * Engine: Fix resolve_engine() to use dynamic import for Plottable isinstance check to avoid Jinja dependency from pandas df.style getter (#701)
+* Engine: Fix resolve_engine() to check both Plotter and Plottable classes for proper type detection
 
 ### Infra
 * CI: Enable parallel test execution in GPU CI with pytest-xdist (#703)

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -40,13 +40,20 @@ def resolve_engine(
 
     if g_or_df is not None:
         # Use dynamic import to avoid Jinja dependency issues from pandas df.style getter
+        is_plottable = False
         try:
             from graphistry.plotter import Plotter
             is_plottable = isinstance(g_or_df, Plotter)
         except ImportError:
-            # Fallback to old import if plotter module not available
-            from graphistry.Plottable import Plottable
-            is_plottable = isinstance(g_or_df, Plottable)
+            pass
+
+        if not is_plottable:
+            # Also check Plottable base class
+            try:
+                from graphistry.Plottable import Plottable
+                is_plottable = isinstance(g_or_df, Plottable)
+            except ImportError:
+                pass
         
         if is_plottable:
             if g_or_df._nodes is not None and g_or_df._edges is not None:


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `resolve_engine()` function where it would incorrectly return `Engine.CUDF` for pandas DataFrames when cuDF was available, causing tests to fail in GPU environments.

## Problem
The previous fix in #701 introduced dynamic imports to avoid Jinja dependency issues, but it only checked `Plottable` if the `Plotter` import failed. However, when `Plotter` could be imported but `isinstance(g_or_df, Plotter)` returned False (as happens with test classes like `CGFull`), the function would fall through to the cuDF availability check and incorrectly return `Engine.CUDF` for pandas DataFrames.

## Solution
This fix ensures both `Plotter` and `Plottable` classes are checked before falling back to the cuDF availability check. The logic now:
1. First tries to check if the object is a `Plotter`
2. If not, also checks if it's a `Plottable`
3. Only falls back to the cuDF availability check if neither check succeeds

## Test Results
This fixes the following failing tests in GPU environments:
- `test_chain_simple_cudf_pd`
- `test_chain_kv_cudf_pd`
- `test_chain_pred_cudf_pd`

These tests were failing with:
```
TypeError: cannot concatenate object of type <class 'pandas.core.frame.DataFrame'>
```

All tests now pass correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)