### PR TITLE
fix(docs): Fix notebook validation error in hop_and_chain tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+### Fixed
+* Docs: Fix notebook validation error in hop_and_chain_graph_pattern_mining.ipynb by adding missing 'outputs' field to code cell
+
 ### Infra
 * CI: Add explicit timeout-minutes to all CI jobs to prevent stuck workflows (#710)
 * CI: Add smart change detection to optimize CI runtime (#710)

--- a/demos/more_examples/graphistry_features/hop_and_chain_graph_pattern_mining.ipynb
+++ b/demos/more_examples/graphistry_features/hop_and_chain_graph_pattern_mining.ipynb
@@ -144,7 +144,9 @@
     "\n",
     "print(len(g_immediate_community2._nodes), 'senators', len(g_immediate_community2._edges), 'relns')\n",
     "g_immediate_community2._edges[['from', 'to', 'weight2']].sort_values(by=['weight2']).head(10)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- Fix docs build failure caused by invalid notebook JSON structure in `hop_and_chain_graph_pattern_mining.ipynb`
- Add missing 'outputs' and 'execution_count' fields to code cell 9

## Problem
The docs build was failing with a notebook validation error:
```
[NbConvertApp] ERROR  < /dev/null |  Notebook JSON is invalid: 'outputs' is a required property
Failed validating 'required' in code_cell
```

## Solution
- Added the required `outputs` field (empty list) to cell 9
- Added `execution_count` field (set to null) to cell 9
- No content changes - only structural fixes for Jupyter notebook format compliance

## Testing
- Validated notebook structure passes after fix
- The notebook now conforms to Jupyter notebook JSON schema

🤖 Generated with [Claude Code](https://claude.ai/code)