### PR TITLE
feat(typing): add PEP 561 type distribution support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,11 @@ jobs:
       run: |
         ./bin/build.sh
 
+    - name: Validate py.typed in wheel
+      run: |
+        unzip -l dist/graphistry*.whl | grep -q "graphistry/py.typed" || (echo "ERROR: py.typed marker missing from wheel - users won't get type information" && exit 1)
+        echo "✅ py.typed marker confirmed in wheel distribution"
+
   
   test-docs:
     needs: [changes, python-lint-types]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+### Added
+* Typing: Add PEP 561 type distribution support (#714)
+  * Add py.typed marker file to enable type checking with mypy, pyright, and PyCharm
+  * Configure MANIFEST.in and setup.cfg to include py.typed in source and wheel distributions
+  * Add CI validation to prevent regressions where py.typed might be accidentally removed
+  * Enables accurate type information and autocompletion for PyGraphistry APIs
+
 ### Fixed
 * Docs: Fix notebook validation error in hop_and_chain_graph_pattern_mining.ipynb by adding missing 'outputs' field to code cell
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+## [0.41.0 - 2025-07-26]
+
 ### Added
 * Typing: Add PEP 561 type distribution support (#714)
   * Add py.typed marker file to enable type checking with mypy, pyright, and PyCharm

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include graphistry/_version.py
+include graphistry/py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,8 @@ versionfile_build = graphistry/_version.py
 tag_prefix =
 parentdir_prefix = graphistry-
 
+[options.package_data]
+graphistry = py.typed
+
 [aliases]
 test=pytest


### PR DESCRIPTION
## Summary

Add proper type distribution support to PyGraphistry following PEP 561 standards. This enables type checkers (mypy, pyright, PyCharm) to provide accurate type information and autocompletion for PyGraphistry APIs.

### Changes Made

- **Add py.typed marker file**: Created `graphistry/py.typed` to indicate type information is available (PEP 561 standard)
- **Configure source distribution**: Updated `MANIFEST.in` to include py.typed in source packages
- **Configure wheel distribution**: Added `[options.package_data]` to `setup.cfg` to include py.typed in wheels
- **Add CI validation**: Added build job validation to prevent regressions where py.typed might be accidentally removed

### User Impact

**Before**: Type checkers saw PyGraphistry as untyped, falling back to `Any` types
```python
import graphistry
g = graphistry.bind()  # Type: Any (no type information)
```

**After**: Users get accurate type information and IDE support
```python
import graphistry  
g = graphistry.bind()  # Type: graphistry.plotter.Plotter
# Full autocompletion and type checking now works\!
```

### Technical Details

- Follows PEP 561 specification for type information distribution
- Uses empty py.typed file to indicate inline type annotations should be used
- No runtime behavior changes - purely improves development experience
- CI validation ensures py.typed remains in distributions

## Test Plan

- [x] Verified py.typed is included in built wheels (`unzip -l dist/*.whl  < /dev/null |  grep py.typed`)
- [x] Tested type checking works with installed wheel (`mypy` detects `graphistry.plotter.Plotter` types)
- [x] Confirmed no runtime behavior changes
- [x] Added CI validation to prevent regressions

🤖 Generated with [Claude Code](https://claude.ai/code)