### PR TITLE
Conform to caller's logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 * Docs: Fix case sensitivity in server toctree to link concurrency.rst (#723)
+* Logging: stop attaching a handler if one exists, let caller decide how to log
 
 ## [0.41.0 - 2025-07-26]
 

--- a/graphistry/util.py
+++ b/graphistry/util.py
@@ -41,9 +41,14 @@ def setup_logger(name='', verbose=VERBOSE, fullpath=TRACE):
         else:
             logger.setLevel(os.environ['LOG_LEVEL'])
 
-    if not logger.handlers and (verbose is not None or os.environ.get('LOG_LEVEL', None) is not None):
+    if (
+        not bool(logging.getLogger().handlers)
+        and not logger.handlers  # don't double-attach
+        and (verbose is not None or os.environ.get('LOG_LEVEL'))
+    ):
         logger.addHandler(get_handler(short=False))
 
+    logger.propagate = True
     return logger
 
 


### PR DESCRIPTION
Pygraphistry is logging with it's own format in louie,

```
DEBUG graphistrygpt/plugins/kusto/client.py:41 [Kusto query] .show tables

[kusto.py:368 -                 _kql() ]   KustoMixin._query(): .show tables
```

This doesn't attach the logger if one is already setup