### PR TITLE
fix(docs): correct hallucinated chain_remote_python to python_remote_g

### DIFF
--- a/docs/source/gfql/remote.rst
+++ b/docs/source/gfql/remote.rst
@@ -170,7 +170,7 @@ Run remote python on the current graph
     # Upload any local graph data to the remote server
     g2 = g1.upload()
 
-    g3 = g2.chain_remote_python(my_remote_trim_graph_task)
+    g3 = g2.python_remote_g(my_remote_trim_graph_task)
 
     assert len(g3._nodes) == 10
     assert len(g3._edges) == 10


### PR DESCRIPTION
Fixes #730

## Summary
- Corrected documentation that referenced non-existent `chain_remote_python` method
- Changed to the correct method name `python_remote_g`

## Changes
- Line 173 in `docs/source/gfql/remote.rst`: `chain_remote_python` → `python_remote_g`

## Test plan
- [x] Verified `chain_remote_python` doesn't exist in codebase
- [x] Verified `python_remote_g` is the correct method
- [ ] Documentation builds correctly (will be verified in CI)

🤖 Generated with Claude Code