### PR TITLE
feat(gfql): Improve hypergraph opts parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   * The old `chain*` methods are deprecated and will be removed in a future version
   * All functionality remains the same, only the method names have changed
 
+### Fixed
+* GFQL: Fix hypergraph typing - add method to Plottable Protocol, resolve circular import
+
 ### Added
 * GFQL: Add hypergraph transformation support for creating entity relationships from event data
   * Simple transformation: `g.gfql(hypergraph(entity_types=['user', 'product']))`
@@ -23,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   * Remote execution: `g.gfql_remote(hypergraph(...))`
   * DAG composition: Use with `let()` for complex transformations
   * Safelist validation for all hypergraph parameters
+  * Enhanced `opts` parameter validation for nested structures (CATEGORIES, EDGES, SKIP)
   * 19 unit tests including mocked remote execution
 * GFQL: Add comprehensive validation framework with detailed error reporting
   * Built-in validation: `Chain()` constructor validates syntax automatically

--- a/docs/source/gfql/builtin_calls.rst
+++ b/docs/source/gfql/builtin_calls.rst
@@ -63,7 +63,7 @@ Transform event data into entity relationships by connecting entities that appea
    * - opts
      - dict
      - No
-     - Additional options to pass to the hypergraph engine
+     - Configuration options for hypergraph transformation (see below)
    * - drop_na
      - boolean
      - No
@@ -93,11 +93,64 @@ Transform event data into entity relationships by connecting entities that appea
      - No
      - Chunk size for streaming processing
 
+**The opts Parameter:**
+
+The ``opts`` dictionary configures advanced hypergraph behavior by controlling how entities are identified and connected. All keys are optional and the dictionary structure is validated to ensure type safety:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Key
+     - Type
+     - Description
+   * - TITLE
+     - string
+     - Node title field name (default: 'nodeTitle')
+   * - DELIM
+     - string
+     - Delimiter for composite IDs (default: '::')
+   * - NODEID
+     - string
+     - Node ID field name (default: 'nodeID')
+   * - ATTRIBID
+     - string
+     - Attribute ID field name (default: 'attribID')
+   * - EVENTID
+     - string
+     - Event ID field name (default: 'EventID')
+   * - EVENTTYPE
+     - string
+     - Event type field name (default: 'event')
+   * - SOURCE
+     - string
+     - Source node field name for edges (default: 'src')
+   * - DESTINATION
+     - string
+     - Destination node field name for edges (default: 'dst')
+   * - CATEGORY
+     - string
+     - Category field name (default: 'category')
+   * - NODETYPE
+     - string
+     - Node type field name (default: 'type')
+   * - EDGETYPE
+     - string
+     - Edge type field name (default: 'edgeType')
+   * - NULLVAL
+     - string
+     - Value representing null (default: 'null')
+   * - SKIP
+     - list[string]
+     - Column names to exclude from entity extraction. Each item must be a string
+   * - CATEGORIES
+     - dict[str, list[str]]
+     - Maps category names to lists of values for grouping. Keys must be strings, values must be lists of strings
+   * - EDGES
+     - dict[str, list[str]]
+     - Defines which entity types can connect to each other. Keys represent source entity types (strings), values are lists of target entity types (strings) that the source can connect to
+
 **Examples:**
-
-.. code-block:: python
-
-    from graphistry.compute import hypergraph
 
     # Transform user-product interactions into entity graph
     events_df = pd.DataFrame({
@@ -123,6 +176,24 @@ Transform event data into entity relationships by connecting entities that appea
     hg = g.gfql(hypergraph(
         entity_types=['user', 'product'],
         engine='cudf'
+    ))
+
+    # Advanced opts configuration with CATEGORIES and EDGES
+    hg = g.gfql(hypergraph(
+        entity_types=['user', 'product', 'category'],
+        opts={
+            'TITLE': 'Entity Graph',
+            'SKIP': ['timestamp', 'metadata'],  # Exclude these columns
+            'CATEGORIES': {
+                'user_type': ['premium', 'regular', 'trial'],
+                'product_type': ['electronics', 'clothing', 'books']
+            },
+            'EDGES': {
+                'user': ['product', 'category'],  # Users connect to products and categories
+                'product': ['user', 'category'],  # Products connect back to users and categories
+                'category': ['product']           # Categories only connect to products
+            }
+        }
     ))
 
     # In a DAG with other operations

--- a/docs/source/gfql/builtin_calls.rst
+++ b/docs/source/gfql/builtin_calls.rst
@@ -152,6 +152,8 @@ The ``opts`` dictionary configures advanced hypergraph behavior by controlling h
 
 **Examples:**
 
+.. code-block:: python
+
     # Transform user-product interactions into entity graph
     events_df = pd.DataFrame({
         'user': ['alice', 'bob', 'alice'],

--- a/graphistry/Plottable.py
+++ b/graphistry/Plottable.py
@@ -10,6 +10,7 @@ from graphistry.models.compute.features import GraphEntityKind
 from graphistry.plugins_types.cugraph_types import CuGraphKind
 from graphistry.plugins_types.embed_types import ProtoSymbolic, XSymbolic, YSymbolic
 from graphistry.plugins_types.graphviz_types import EdgeAttr, Format, GraphAttr, NodeAttr, Prog
+from graphistry.plugins_types.hypergraph import HypergraphResult
 from graphistry.plugins_types.umap_types import UMAPEngine
 from graphistry.privacy import Mode as PrivacyMode, Privacy, ModeAction
 from graphistry.Engine import EngineAbstract
@@ -423,7 +424,22 @@ class Plottable(Protocol):
         ops is Union[List[ASTObject], Chain]
         """
         ...
-    
+
+    def hypergraph(
+        self,
+        raw_events: Any,
+        entity_types: Optional[List[str]] = None,
+        opts: dict = {},
+        drop_na: bool = True,
+        drop_edge_attrs: bool = False,
+        verbose: bool = True,
+        direct: bool = False,
+        engine: str = 'pandas',
+        npartitions: Optional[int] = None,
+        chunksize: Optional[int] = None
+    ) -> HypergraphResult:
+        ...
+
     def chain_remote(
         self: 'Plottable',
         chain: Union[Any, Dict[str, JSONVal]],

--- a/graphistry/compute/gfql/call_executor.py
+++ b/graphistry/compute/gfql/call_executor.py
@@ -55,15 +55,11 @@ def execute_call(g: Plottable, function: str, params: Dict[str, Any], engine: En
             else:
                 validated_params['engine'] = 'pandas'
 
-        # Import and call hypergraph
+        # Call hypergraph method directly (now properly typed in Plottable Protocol)
         try:
-            # Hypergraph is a method on Plottable, mypy doesn't see it due to mixin structure
-            hypergraph_method = getattr(g, 'hypergraph')
-            result = hypergraph_method(raw_events, **validated_params)
-            # Hypergraph returns a dict with 'graph' key containing the Plottable
-            if isinstance(result, dict) and 'graph' in result:
-                return result['graph']
-            return result
+            result = g.hypergraph(raw_events, **validated_params)
+            # Hypergraph returns a HypergraphResult dict with 'graph' key containing the Plottable
+            return result['graph']
         except Exception as e:
             raise GFQLTypeError(
                 ErrorCode.E303,

--- a/graphistry/plugins_types/hypergraph.py
+++ b/graphistry/plugins_types/hypergraph.py
@@ -1,10 +1,12 @@
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 from graphistry.Engine import DataframeLike
-from graphistry.Plottable import Plottable
+
+if TYPE_CHECKING:
+    from graphistry.Plottable import Plottable
 
 class HypergraphResult(TypedDict):
     entities: DataframeLike
     events: DataframeLike
     edges: DataframeLike
     nodes: DataframeLike
-    graph: Plottable
+    graph: 'Plottable'

--- a/graphistry/tests/compute/test_hypergraph_opts_validation.py
+++ b/graphistry/tests/compute/test_hypergraph_opts_validation.py
@@ -1,0 +1,207 @@
+"""Tests for improved hypergraph opts parameter validation."""
+
+import pytest
+from graphistry.compute.gfql.call_safelist import (
+    validate_hypergraph_opts,
+    validate_call_params
+)
+from graphistry.compute.exceptions import GFQLTypeError
+
+
+class TestHypergraphOptsValidation:
+    """Test the improved validation for hypergraph opts parameter."""
+
+    def test_opts_empty_dict(self):
+        """Test that empty dict is valid for opts."""
+        assert validate_hypergraph_opts({}) is True
+
+    def test_opts_with_string_params(self):
+        """Test opts with valid string parameters."""
+        opts = {
+            'TITLE': 'myTitle',
+            'DELIM': '|',
+            'NODEID': 'node_id',
+            'ATTRIBID': 'attr_id',
+            'EVENTID': 'event_id',
+            'EVENTTYPE': 'evt',
+            'SOURCE': 'from',
+            'DESTINATION': 'to',
+            'CATEGORY': 'cat',
+            'NODETYPE': 'ntype',
+            'EDGETYPE': 'etype',
+            'NULLVAL': 'NA'
+        }
+        assert validate_hypergraph_opts(opts) is True
+
+    def test_opts_with_skip_list(self):
+        """Test opts with SKIP parameter."""
+        opts = {
+            'SKIP': ['col1', 'col2', 'col3']
+        }
+        assert validate_hypergraph_opts(opts) is True
+
+    def test_opts_with_categories(self):
+        """Test opts with CATEGORIES mapping."""
+        opts = {
+            'CATEGORIES': {
+                'n': ['aa', 'bb', 'cc'],
+                'type1': ['x', 'y', 'z']
+            }
+        }
+        assert validate_hypergraph_opts(opts) is True
+
+    def test_opts_with_edges(self):
+        """Test opts with EDGES mapping."""
+        opts = {
+            'EDGES': {
+                'aa': ['cc', 'bb'],
+                'cc': ['cc'],
+                'user': ['product', 'session']
+            }
+        }
+        assert validate_hypergraph_opts(opts) is True
+
+    def test_opts_with_all_params(self):
+        """Test opts with all valid parameters combined."""
+        opts = {
+            'TITLE': 'myTitle',
+            'DELIM': '::',
+            'NODEID': 'id',
+            'SKIP': ['timestamp', 'metadata'],
+            'CATEGORIES': {'n': ['type1', 'type2']},
+            'EDGES': {'user': ['product'], 'product': ['user']}
+        }
+        assert validate_hypergraph_opts(opts) is True
+
+    def test_opts_invalid_string_param_type(self):
+        """Test opts with invalid type for string parameter."""
+        opts = {
+            'TITLE': 123  # Should be string
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_opts_invalid_skip_not_list(self):
+        """Test opts with invalid SKIP (not a list)."""
+        opts = {
+            'SKIP': 'col1'  # Should be list
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_opts_invalid_skip_not_strings(self):
+        """Test opts with invalid SKIP (list contains non-strings)."""
+        opts = {
+            'SKIP': ['col1', 123, 'col3']  # All items should be strings
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_opts_invalid_categories_not_dict(self):
+        """Test opts with invalid CATEGORIES (not a dict)."""
+        opts = {
+            'CATEGORIES': ['type1', 'type2']  # Should be dict
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_opts_invalid_categories_value_not_list(self):
+        """Test opts with invalid CATEGORIES value (not a list)."""
+        opts = {
+            'CATEGORIES': {
+                'n': 'aa'  # Should be list of strings
+            }
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_opts_invalid_edges_structure(self):
+        """Test opts with invalid EDGES structure."""
+        opts = {
+            'EDGES': {
+                'aa': 'cc'  # Should be list, not string
+            }
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_opts_not_dict(self):
+        """Test that non-dict opts is rejected."""
+        assert validate_hypergraph_opts("not a dict") is False
+        assert validate_hypergraph_opts(None) is False
+        assert validate_hypergraph_opts([]) is False
+
+    def test_opts_unknown_keys_allowed(self):
+        """Test that unknown keys are allowed for forward compatibility."""
+        opts = {
+            'TITLE': 'test',
+            'CUSTOM_PARAM': 'value',  # Unknown but should be allowed
+            'ANOTHER': 123
+        }
+        assert validate_hypergraph_opts(opts) is True
+
+    def test_opts_invalid_key_type(self):
+        """Test opts with non-string keys."""
+        opts = {
+            123: 'value'  # Keys must be strings
+        }
+        assert validate_hypergraph_opts(opts) is False
+
+    def test_validate_call_params_with_valid_opts(self):
+        """Test full validation through validate_call_params."""
+        params = {
+            'entity_types': ['user', 'product'],
+            'opts': {
+                'CATEGORIES': {'n': ['type1', 'type2']},
+                'EDGES': {'user': ['product']}
+            },
+            'drop_na': True,
+            'direct': False
+        }
+
+        # Should not raise
+        validated = validate_call_params('hypergraph', params)
+        assert validated == params
+
+    def test_validate_call_params_with_invalid_opts(self):
+        """Test that invalid opts raises error through validate_call_params."""
+        params = {
+            'entity_types': ['user', 'product'],
+            'opts': {
+                'CATEGORIES': 'not_a_dict'  # Invalid structure
+            }
+        }
+
+        with pytest.raises(GFQLTypeError) as exc_info:
+            validate_call_params('hypergraph', params)
+
+        assert "Invalid type for parameter 'opts'" in str(exc_info.value)
+
+    def test_real_world_opts_example(self):
+        """Test real-world opts examples from existing tests."""
+        # From test_hypergraph.py
+        opts1 = {"CATEGORIES": {"n": ["aa", "bb", "cc"]}}
+        assert validate_hypergraph_opts(opts1) is True
+
+        opts2 = {"EDGES": {"aa": ["cc"], "cc": ["cc"]}}
+        assert validate_hypergraph_opts(opts2) is True
+
+        opts3 = {"EDGES": {"aa": ["cc", "bb", "aa"], "cc": ["cc"]}}
+        assert validate_hypergraph_opts(opts3) is True
+
+        opts4 = {"EDGES": {"id": ["a1"], "a1": ["🙈"]}}  # Unicode should work
+        assert validate_hypergraph_opts(opts4) is True
+
+    def test_opts_complex_nested_structure(self):
+        """Test opts with complex nested structure."""
+        opts = {
+            'TITLE': 'Complex Graph',
+            'DELIM': '||',
+            'SKIP': ['meta1', 'meta2', 'timestamp'],
+            'CATEGORIES': {
+                'department': ['sales', 'engineering', 'marketing'],
+                'level': ['junior', 'senior', 'lead'],
+                'region': ['NA', 'EU', 'APAC']
+            },
+            'EDGES': {
+                'user': ['product', 'session', 'transaction'],
+                'product': ['category', 'supplier'],
+                'session': ['user', 'device']
+            },
+            'CUSTOM_FIELD': 'allowed'
+        }
+        assert validate_hypergraph_opts(opts) is True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.10
 
 # TODO check tests
 exclude = graph_vector_pb2|versioneer|_version|graphistry/tests

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.8
 
 # TODO check tests
 exclude = graph_vector_pb2|versioneer|_version|graphistry/tests


### PR DESCRIPTION
## Summary
Improve validation and typing for hypergraph `opts` parameter.

## Changes
- Add `validate_hypergraph_opts()` function with proper nested structure validation for CATEGORIES, EDGES, SKIP, etc.
- Add 19 comprehensive tests for opts validation
- Fix typing: Add hypergraph method to Plottable Protocol, remove untyped getattr
- Fix circular import between Plottable and HypergraphResult
- Update docs with precise opts parameter types and examples

## Testing
- All 19 tests pass locally in Docker
- Type checking passes for Python 3.8-3.12

## Files Changed
- `graphistry/compute/gfql/call_safelist.py` - Added validation function
- `graphistry/tests/compute/test_hypergraph_opts_validation.py` - New test file
- `graphistry/Plottable.py` - Added hypergraph method to Protocol
- `graphistry/compute/gfql/call_executor.py` - Removed getattr, use typed method
- `graphistry/plugins_types/hypergraph.py` - Fixed circular import
- `docs/source/gfql/builtin_calls.rst` - Enhanced opts documentation