### PR TITLE
fix(neo4j): handle new spatial object format in driver 5.28+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+## [0.42.1 - 2025-10-02]
+
 ### Fixed
 * neo4j: Handle new spatial object format in driver 5.28+ for backwards compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Dev
 
+### Fixed
+* neo4j: Handle new spatial object format in driver 5.28+ for backwards compatibility
+
 ## [0.42.0 - 2025-10-02]
 
 ### Fixed

--- a/graphistry/bolt_util.py
+++ b/graphistry/bolt_util.py
@@ -138,7 +138,7 @@ def flatten_spatial_col(df : pd.DataFrame, col : str) -> pd.DataFrame:  # noqa: 
 
     ###
 
-    out_df[col] = df[col].apply(str)
+    out_df[col] = df[col].apply(stringify_spatial)
 
     return out_df
 

--- a/graphistry/tests/test_bolt_util.py
+++ b/graphistry/tests/test_bolt_util.py
@@ -376,43 +376,18 @@ class Test_Neo4jConnector:
 def test_stringify_spatial_unit():
     """Unit tests for stringify_spatial function format compatibility"""
     from graphistry.bolt_util import stringify_spatial
-    import neo4j.spatial
 
     # Test None and non-spatial inputs
     assert stringify_spatial(None) is None
     assert stringify_spatial("test") == "test"
 
-    # Mock old and new format Point objects
-    class MockOldPoint:
-        def __str__(self):
-            return "POINT(1.0 2.0 3.0)"
+    # Test with real Neo4j spatial objects to ensure our fix works
+    point = neo4j.spatial.Point([1.0, 2.0, 3.0])
+    cartesian = neo4j.spatial.CartesianPoint([4.0, 5.0])
+    wgs84 = neo4j.spatial.WGS84Point([6.0, 7.0, 8.0])
 
-    class MockNewPoint:
-        def __str__(self):
-            return "WGS84Point(1.0, 2.0, 3.0)"
-
-    # Test old format is preserved
-    old_isinstance = isinstance
-
-    def mock_isinstance_old(obj, cls):
-        return cls == neo4j.spatial.Point and isinstance(obj, MockOldPoint)
-
-    import builtins
-    builtins.isinstance = mock_isinstance_old
-    try:
-        result = stringify_spatial(MockOldPoint())
-        assert result == "POINT(1.0 2.0 3.0)"
-    finally:
-        builtins.isinstance = old_isinstance
-
-    # Test new format is converted
-
-    def mock_isinstance_new(obj, cls):
-        return cls == neo4j.spatial.Point and isinstance(obj, MockNewPoint)
-
-    builtins.isinstance = mock_isinstance_new
-    try:
-        result = stringify_spatial(MockNewPoint())
-        assert result == "POINT(1.0 2.0 3.0)"
-    finally:
-        builtins.isinstance = old_isinstance
+    # All should be converted to old POINT(...) format with space-separated coords
+    results = [stringify_spatial(obj) for obj in [point, cartesian, wgs84]]
+    for result in results:
+        assert result.startswith("POINT(") and result.endswith(")")
+        assert "," not in result  # No commas in coordinates

--- a/graphistry/tests/test_bolt_util.py
+++ b/graphistry/tests/test_bolt_util.py
@@ -393,6 +393,7 @@ def test_stringify_spatial_unit():
 
     # Test old format is preserved
     old_isinstance = isinstance
+
     def mock_isinstance_old(obj, cls):
         return cls == neo4j.spatial.Point and isinstance(obj, MockOldPoint)
 
@@ -405,6 +406,7 @@ def test_stringify_spatial_unit():
         builtins.isinstance = old_isinstance
 
     # Test new format is converted
+
     def mock_isinstance_new(obj, cls):
         return cls == neo4j.spatial.Point and isinstance(obj, MockNewPoint)
 


### PR DESCRIPTION
## Summary
Fixes Neo4j spatial test failures caused by string representation format change in Neo4j Python driver 5.28+.

## Root Cause
Neo4j driver commit `54dc5db9` (August 2025) changed spatial object `__repr__` method:
- **OLD**: `POINT(1.0 2.0 3.0)`
- **NEW**: `WGS84Point(1.0, 2.0, 3.0)` / `CartesianPoint(1.0, 2.0)` / `Point(1.0, 2.0, 3.0)`

This change was made to conform with Python's `__repr__` recommendations for better debugging.

## Changes
- Updated `stringify_spatial()` function in `graphistry/bolt_util.py` to normalize both old and new formats
- **Backwards compatible**: Old format `POINT(...)` is preserved unchanged
- **Forwards compatible**: New formats are converted to old format `POINT(x y z)`
- Uses regex to extract coordinates and normalize comma-separated to space-separated format

## Test Plan
- [x] Reproduced failing tests locally with Neo4j 5.28.2
- [x] Implemented backwards/forwards compatible fix
- [x] All spatial tests pass: `test_spatial_homogenous`, `test_spatial_homogenous_na`, `test_spatial_heterogeneous`
- [x] Full `test_bolt_util.py` suite passes with no regressions
- [x] Handles all spatial types: `Point`, `CartesianPoint`, `WGS84Point`

## Fixes
Resolves CI test failures on Python 3.11:
- `test_spatial_homogenous`
- `test_spatial_homogenous_na` 
- `test_spatial_heterogeneous`

🤖 Generated with [Claude Code](https://claude.ai/code)