### PR TITLE
fix(tests): Fix NoAuthTestCase authentication bypass pattern

### DIFF
--- a/graphistry/tests/common.py
+++ b/graphistry/tests/common.py
@@ -4,7 +4,37 @@ import graphistry.pygraphistry
 
 
 class NoAuthTestCase(unittest.TestCase):
+    """Test case that bypasses authentication for tests.
+
+    WARNING: This class manipulates internal PyGraphistry state to bypass
+    authentication. This is a deliberate hack that:
+    - Is NOT thread-safe (but works with pytest-xdist process isolation)
+    - Depends on internal implementation details
+    - Could break if PyGraphistry refactors authentication
+
+    The pattern works because:
+    1. pytest-xdist runs workers in separate processes (not threads)
+    2. Each process has its own PyGraphistry class instance
+    3. Tests from the same file run in the same worker (--dist loadfile)
+
+    Known issues:
+    - If any test calls register(), it resets _is_authenticated globally
+    - test_client_session.py affects all subsequent tests via _client_mode_enabled
+    - Tests have order dependencies (e.g., test_ipython.py)
+
+    TODO: Replace with proper mocking of authenticate() method
+    """
+
     @classmethod
     def setUpClass(cls):
-        graphistry.pygraphistry.PyGraphistry._is_authenticated = True
+        # Register once per test class to set up the session
         graphistry.register(api=1)
+        # HACK: Set _is_authenticated after register() to bypass auth
+        # This is reset by register(), so we set it after
+        graphistry.pygraphistry.PyGraphistry._is_authenticated = True
+
+    def setUp(self):
+        # Reset _is_authenticated before each test method
+        # This handles cases where other tests might have called register()
+        # or otherwise reset the authentication state
+        graphistry.pygraphistry.PyGraphistry._is_authenticated = True


### PR DESCRIPTION
## Summary
Fixes the NoAuthTestCase authentication bypass pattern that has been fundamentally broken, causing potential CI failures.

## Problem
The `NoAuthTestCase` pattern has been broken because:
- `register(api=1)` always resets `_is_authenticated = False`  
- Tests only passed due to lucky execution ordering within test classes
- The issue became visible when `test_client_session.py` was added (sets `_client_mode_enabled`)

## Root Cause
After investigation (see branch feat/gfql-policy-hooks for analysis docs), discovered this bug exists in ALL versions back to at least v0.34.17 and likely much earlier. It's not a regression but a long-standing issue that was masked by test execution order.

## Solution
1. **Fixed order**: Call `register(api=1)` first, THEN set `_is_authenticated = True`
2. **Added setUp()**: Resets `_is_authenticated` before each test method for better isolation
3. **Added documentation**: Comprehensive warnings about the hack and its limitations

## Why This Works
- pytest-xdist uses separate **processes** (not threads)
- Each process has its own PyGraphistry instance  
- Process isolation makes the hack "safe enough" despite not being thread-safe

## Testing
- ✅ `test_no_ipython` passes in isolation
- ✅ Tests pass in reverse order 
- ✅ Tests pass in default alphabetical order

## Technical Debt
This is acknowledged as a hack that should eventually be replaced with proper mocking of the `authenticate()` method. The fix provides immediate CI stability while documenting the issue for future refactoring.

Fixes test failures in `test_ipython.py::TestPlotterReturnValue::test_no_ipython` and potentially other NoAuthTestCase-dependent tests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>