### PR TITLE
Release v0.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+## [0.45.1 - 2025-10-16]
+
 ### Fixed
 * **UMAP: Fix mixed DataFrame types when engine='cudf' causing GFQL chain concatenation to fail** (#794)
   * **Problem**: UMAP with `engine='cuml'` was returning pandas nodes + cuDF edges, causing `TypeError: can only concatenate objects which are instances of...` in GFQL chain operations


### PR DESCRIPTION
Patch release with critical UMAP fix and documentation improvements.

## Changes

### Fixed
- **UMAP**: Fix mixed DataFrame types when engine='cudf' causing GFQL chain concatenation to fail (#794)
  - Ensures both nodes and edges match the specified engine type (cuDF or pandas)
  - Prevents TypeError in GFQL chain operations
  - Added comprehensive test coverage

### Docs
- **GFQL**: Fix critical documentation bugs where graph algorithms were called without edges (#795)
  - Fixed PageRank and Louvain examples (3 instances)
  - Changed patterns to include graph structure
  - Style improvements with call() API

## Release Process
- [ ] Merge PR to master
- [ ] Tag as 0.45.1
- [ ] Verify PyPI publish
- [ ] Toggle version at ReadTheDocs  
- [ ] Create GitHub Release