### PR TITLE
chore(release): v0.45.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+## [0.45.2 - 2025-10-17]
+
 ### Fixed
 * **GFQL Remote: Metadata hydration after server-computed operations** (#798)
   * Server-computed metadata (bindings, encodings, styles, name/description) now returned to client after GFQL operations like `call('umap')`


### PR DESCRIPTION
## Release v0.45.2

This release includes important fixes for GFQL metadata hydration and dataset_id invalidation.

### Fixed
* **GFQL Remote: Metadata hydration after server-computed operations** (#798)
  * Server-computed metadata (bindings, encodings, styles, name/description) now returned to client after GFQL operations like `call('umap')`
  * Centralized metadata serialization/deserialization in `graphistry.io.metadata` with TypedDict structures
  * Properly typed `_complex_encodings` as `ComplexEncodingsDict` throughout codebase
* **Plot: Fix dataset_id invalidation in encoding and style methods** (#797)
  * Fixed 7 methods not invalidating `dataset_id` after modifying encodings/metadata/styles
  * Added 25 tests in `test_dataset_id_invalidation.py`
  * Found via AST pattern matching + Pysa call graph analysis

### Refactored
* **Import organization**: Hoisted dynamic imports to module level following PEP 8 conventions (#798)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)