### PR TITLE
docs(scene_settings): clarify point_size uses logarithmic scale

### DIFF
--- a/docs/source/cheatsheet.md
+++ b/docs/source/cheatsheet.md
@@ -692,10 +692,10 @@ g2 = g.scene_settings(
   info=False,
   #tweak graph
   show_arrows=False,
-  point_size=1.0,
-  edge_curvature=0.0,
-  edge_opacity=0.5,
-  point_opacity=0.9
+  point_size=1.0,  # 0.1-10.0 range, log scale (1.0 → "50" in UI)
+  edge_curvature=0.0,  # 0.0-1.0 range
+  edge_opacity=0.5,  # 0.0-1.0 range
+  point_opacity=0.9  # 0.0-1.0 range
 ).plot()
 
 ```
@@ -1477,8 +1477,10 @@ Set visual attributes through [quick data bindings](https://hub.graphistry.com/d
         'play': 2000,
         'menu': True, 'info': True,
         'showArrows': True,
-        'pointSize': 2.0, 'edgeCurvature': 0.5,
-        'edgeOpacity': 1.0, 'pointOpacity': 1.0,
+        'pointSize': 1.0,  # Node size (0.1-10.0, log scale: 0.2→"15", 1.0→"50", 5.0→"85")
+        'edgeCurvature': 0.5,  # Edge curvature (0.0-1.0)
+        'edgeOpacity': 1.0,  # Edge transparency (0.0-1.0)
+        'pointOpacity': 1.0,  # Node transparency (0.0-1.0)
         'lockedX': False, 'lockedY': False, 'lockedR': False,
         'linLog': False, 'strongGravity': False, 'dissuadeHubs': False,
         'edgeInfluence': 1.0, 'precisionVsSpeed': 1.0, 'gravity': 1.0, 'scalingRatio': 1.0,

--- a/docs/source/visualization/layout/settings.rst
+++ b/docs/source/visualization/layout/settings.rst
@@ -21,13 +21,20 @@ Use :meth:`graphistry.PlotterBase.PlotterBase.scene_settings` to modify the appe
        # Hide menus
        menu=False,
        info=False,
-       # Customize graph
+       # Customize graph appearance
        show_arrows=False,
-       point_size=1.0,
-       edge_curvature=0.0,
-       edge_opacity=0.5,
-       point_opacity=0.9
+       point_size=1.0,         # Node size (logarithmic scale: 0.1-10.0 → UI 0-100)
+       edge_curvature=0.0,     # 0.0 = straight edges
+       edge_opacity=0.5,       # 0.0-1.0 range (50% transparent)
+       point_opacity=0.9       # 0.0-1.0 range (90% opaque)
    ).plot()
+
+**Value Ranges:**
+
+- ``point_size``: Range 0.1 to 10.0. The UI uses a logarithmic scale (0-100) for display. For example: 0.2 displays as approximately "15", 0.5 as "35", 1.0 as "50", 2.0 as "65", and 5.0 as "85". This logarithmic mapping provides finer control over smaller point sizes.
+- ``edge_curvature``: Range 0.0 to 1.0 (0.0 for straight edges, displayed as 0-100 in UI)
+- ``edge_opacity``: Range 0.0 to 1.0 (0.0 fully transparent, 1.0 fully opaque, displayed as 0-100 in UI)
+- ``point_opacity``: Range 0.0 to 1.0 (0.0 fully transparent, 1.0 fully opaque, displayed as 0-100 in UI)
 
 
 Styling the Background and Foreground


### PR DESCRIPTION
Clarifies that `point_size` uses a logarithmic scale, not linear.

Users expected `point_size=0.2` to show "20" in the UI, but it shows "15". The UI uses log scaling (domain 0.1-10 → range 0-100) to give finer control over smaller point sizes.

Addresses #633 + #639 
