### PR TITLE
ci: emphasize tck-gfql conformance report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
         source pygraphistry/bin/activate
         git clone --depth 1 https://github.com/graphistry/tck-gfql.git
         cd tck-gfql
+        echo "### tck-gfql conformance report" >> "$GITHUB_STEP_SUMMARY"
         PYGRAPHISTRY_PATH="${{ github.workspace }}" PYGRAPHISTRY_INSTALL=1 ./bin/ci.sh
 
   python-lint-types:


### PR DESCRIPTION
Adds a visible header in the GHA summary before running tck-gfql so the report stands out.