### PR TITLE
fix(tests): make hypergraph tests work with both pandas and cuDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Fixed
+- **Hypergraph**: Fixed engine auto-detection to use input DataFrame type instead of defaulting to cuDF when available
+
 ## [0.50.1 - 2026-01-09]
 
 ### Added

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -813,7 +813,8 @@ def hypergraph(
 
     engine_resolved : Engine
     if not isinstance(engine, Engine):
-        engine_resolved = resolve_engine(engine, g)
+        # Use raw_events to detect engine type since g may be a class (PyGraphistry) not a Plottable
+        engine_resolved = resolve_engine(engine, raw_events)
     else:
         engine_resolved = engine
     defs = HyperBindings(**opts)


### PR DESCRIPTION
## Summary
- Add `to_pandas()` helper to convert cuDF DataFrames before pandas-specific assertions
- Update `assertFrameEqual` to handle both DataFrame types
- Update `pa.Table.from_pandas()` calls to convert cuDF to pandas first
- Mark `test_hyper_evil` as xfail for cuDF (unsupported mixed/list column types)

## Test plan
- [x] Run hypergraph tests with GPU container: 14 passed, 1 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)