### PR TITLE
fix(hypergraph): use input DataFrame type for engine auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Fixed
+- **Hypergraph**: Fixed engine auto-detection to use input DataFrame type instead of defaulting to cuDF when available
+
 ## [0.50.1 - 2026-01-09]
 
 ### Added

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -813,7 +813,8 @@ def hypergraph(
 
     engine_resolved : Engine
     if not isinstance(engine, Engine):
-        engine_resolved = resolve_engine(engine, g)
+        # Use raw_events to detect engine type since g may be a class (PyGraphistry) not a Plottable
+        engine_resolved = resolve_engine(engine, raw_events)
     else:
         engine_resolved = engine
     defs = HyperBindings(**opts)


### PR DESCRIPTION
## Summary

When calling `graphistry.hypergraph(df)`, the engine was incorrectly detected from `PyGraphistry` class instead of the input DataFrame, causing pandas DataFrames to be converted to cuDF when cudf was available.

**Root cause**: `resolve_engine(engine, g)` was called with `g=PyGraphistry` (the class), which isn't a DataFrame or Plottable, so it fell through to the "cudf available" default.

**Fix**: Pass `raw_events` (the actual DataFrame) to `resolve_engine` instead of `g`.

## Test plan
- [x] Run hypergraph tests with GPU container: 15 passed
- [x] Run hypergraph tests with CPU-only: 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)