### PR TITLE
fix: annotate umap weighted edges for mypy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Fixed
+- **Mypy**: Declare UMAP mixin weighted-edge DataFrame attributes for type checking.
+
 ### Tests
 - **Temporal**: Added datetime unit parity coverage (ms/us/ns) for ring layouts, GFQL time ring layouts, and temporal comparison predicates; relaxed honeypot hypergraph datetime unit expectations.
 

--- a/graphistry/umap_utils.py
+++ b/graphistry/umap_utils.py
@@ -26,13 +26,17 @@ from .utils.plottable_memoize import check_set_memoize
 
 logger = setup_logger(__name__)
 
+DataFrameLike = Union[pd.DataFrame, Any]
+
 if TYPE_CHECKING:
-    MIXIN_BASE = FeatureMixin
+    class _UMAPMixinBase(FeatureMixin):
+        _weighted_edges_df: Optional[DataFrameLike]
+        _weighted_edges_df_from_nodes: Optional[DataFrameLike]
+        _weighted_edges_df_from_edges: Optional[DataFrameLike]
+
+    MIXIN_BASE = _UMAPMixinBase
 else:
     MIXIN_BASE = object
-
-
-DataFrameLike = Union[pd.DataFrame, Any]
 
 # Error message for empty feature matrix
 _EMPTY_FEATURES_ERROR_MSG = (


### PR DESCRIPTION
## Summary
- declare UMAP mixin weighted-edge DataFrame attributes for mypy
- update changelog (Development) entry

## Testing
- not run (type-only change)