### PR TITLE
docs(changelog): prepare 0.51.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+## [0.51.0 - 2026-03-02]
+
 ### Added
 - **GEXF**: Added GEXF import/export with viz attribute bindings (color/size/position/thickness/opacity), validation, tests, and demo notebook.
 - **GEXF**: Map node viz shapes to FA4 point icons on import.
@@ -26,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL / WHERE**: Fixed vector-strategy guard to initialize start/end domains before pair-est gating (prevents UnboundLocalError).
 
 ### Performance
+- **Compute / hop**: Optimized hop traversal with simplified domain operations and reduced redundant checks (8-35% faster across scenarios).
 - **GFQL / WHERE**: Use DF-native forward pruning for cuDF equality constraints to avoid host syncs (pandas path unchanged).
 - **GFQL / WHERE**: Default non-adjacent WHERE mode now `auto`, enabling value-mode + domain semijoin auto, with edge semijoin auto for edge clauses (opt-out via env).
 - **GFQL / WHERE**: Auto mode skips value-mode on multi-clause non-adjacent WHERE when pair estimates exceed the semijoin threshold (guardrail against blowups).


### PR DESCRIPTION
## Summary
Prepares CHANGELOG.md for 0.51.0 release.

### Changes
- Converts `## [Development]` section to `## [0.51.0 - 2026-03-02]`
- Adds hop performance entry (8-35% improvement)

### Release Highlights
- **GEXF Import/Export**: Full support with viz attribute bindings
- **GFQL WHERE Clauses** (experimental): Yannakakis-style semijoin reduction
- **OpenTelemetry Integration**: Optional tracing for plot/upload/GFQL
- **Hop Performance**: 8-35% faster traversals
- **Ruff Linting**: Replaced flake8
- **GFQL Benchmarks**: New CI-integrated benchmark suite

### Next Steps (after merge)
1. Create tag: `git tag 0.51.0 && git push --tags`
2. GitHub Actions will auto-publish to PyPI
3. Create GitHub Release
4. Activate ReadTheDocs version