### PR TITLE
handle api_version=1 more gracefuly

### DIFF
--- a/graphistry/client_session.py
+++ b/graphistry/client_session.py
@@ -12,7 +12,7 @@ from .plugins_types.kusto_types import KustoConfig
 
 
 
-ApiVersion = Literal[3]
+ApiVersion = Literal[1, 3]
 
 ENV_GRAPHISTRY_API_KEY = "GRAPHISTRY_API_KEY"
 
@@ -56,9 +56,16 @@ class ClientSession:
         env_api_version = get_from_env("GRAPHISTRY_API_VERSION", int)
         if env_api_version is None:
             env_api_version = 3
-        elif env_api_version != 3:
-            raise ValueError("Expected API version to be 3. Legacy API versions 1 and 2 are no longer supported. Got: %s" % env_api_version)
-        self.api_version: ApiVersion = cast(ApiVersion, env_api_version)  
+        elif env_api_version not in (1, 3):
+            raise ValueError("Expected API version to be 1 or 3, got: %s" % env_api_version)
+        if env_api_version == 1:
+            warnings.warn(
+                "api=1 is deprecated and will be removed in a future version. "
+                "Please use api=3.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.api_version: ApiVersion = cast(ApiVersion, env_api_version)
 
         self.dataset_prefix: str = get_from_env("GRAPHISTRY_DATASET_PREFIX", str, "PyGraphistry/")
         self.hostname: str = get_from_env("GRAPHISTRY_HOSTNAME", str, "hub.graphistry.com")

--- a/graphistry/pygraphistry.py
+++ b/graphistry/pygraphistry.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, cast, overload
 from typing_extensions import Literal
 from graphistry.privacy import Mode, ModeAction
@@ -540,15 +541,23 @@ class GraphistryClient(AuthManagerProtocol):
         return otel_config(enabled=enabled, detail=detail, reset=reset)
 
     def api_version(self, value: Optional[ApiVersion] = None) -> ApiVersion:
-        """Set or get the API version. Only api=3 is supported.
-        Legacy API versions 1 and 2 are no longer supported.
+        """Set or get the API version. api=3 is recommended.
+        api=1 is deprecated and will be removed in a future version.
         Also set via environment variable GRAPHISTRY_API_VERSION."""
 
         if value is None:
             value = self.session.api_version
 
-        if value != 3:
-            raise ValueError("Expected API version to be 3. Legacy API versions 1 and 2 are no longer supported. Got: %s" % value)
+        if value not in (1, 3):
+            raise ValueError("Expected API version to be 1 or 3, got: %s" % value)
+
+        if value == 1:
+            warnings.warn(
+                "api=1 is deprecated and will be removed in a future version. "
+                "Please use api=3.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # setter
         self.session.api_version = value
@@ -583,7 +592,7 @@ class GraphistryClient(AuthManagerProtocol):
         personal_key_secret: Optional[str] = None,
         server: Optional[str] = None,
         protocol: Optional[str] = None,
-        api: Optional[Literal[3]] = None,
+        api: Optional[Literal[1, 3]] = None,
         certificate_validation: Optional[bool] = None,
         bolt: Optional[Union[Dict, Any]] = None,
         store_token_creds_in_memory: Optional[bool] = None,
@@ -617,8 +626,8 @@ class GraphistryClient(AuthManagerProtocol):
         :type server: Optional[str]
         :param protocol: Protocol to use for server uploaders, defaults to "https".
         :type protocol: Optional[str]
-        :param api: API version (only 3 is supported, uses Arrow+JWT)
-        :type api: Optional[Literal[3]]
+        :param api: API version (3 recommended; 1 is deprecated and will be removed in a future version)
+        :type api: Optional[Literal[1, 3]]
         :param certificate_validation: Override default-on check for valid TLS certificate by setting to True.
         :type certificate_validation: Optional[bool]
         :param bolt: Neo4j bolt information. Optional driver or named constructor arguments for instantiating a new one.

--- a/graphistry/tests/test_pygraphistry.py
+++ b/graphistry/tests/test_pygraphistry.py
@@ -6,6 +6,7 @@ try:
 except ImportError:  # pragma: no cover - stdlib fallback
     from unittest.mock import patch
 import graphistry
+import warnings
 
 from graphistry.pygraphistry import PyGraphistry, GraphistryClient
 from graphistry.messages import (
@@ -207,3 +208,47 @@ def test_switch_organization_not_permitted(mock_response, capfd):
     # PyGraphistry.org_name("not-permitted-org")
     # out, err = capfd.readouterr()
     # assert "Failed to switch organization" in out
+
+
+class TestApiVersionDeprecation(unittest.TestCase):
+    """Tests that api=1 emits a DeprecationWarning and continues working as v1."""
+
+    def test_api_version_1_emits_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            PyGraphistry.api_version(1)
+            dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(dep), 1)
+            self.assertIn("api=1 is deprecated", str(dep[0].message))
+
+    def test_api_version_1_stays_as_1(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = PyGraphistry.api_version(1)
+        self.assertEqual(result, 1)
+
+    def test_api_version_3_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            PyGraphistry.api_version(3)
+            dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(dep), 0)
+
+    def test_api_version_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            PyGraphistry.api_version(2)
+
+    def test_register_api_1_emits_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            PyGraphistry.register(api=1, server="test.example.com")
+            dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertGreaterEqual(len(dep), 1)
+            self.assertTrue(any("api=1 is deprecated" in str(d.message) for d in dep))
+
+    def test_register_api_3_no_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            PyGraphistry.register(api=3, server="test.example.com")
+            dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(dep), 0)


### PR DESCRIPTION
```
##Fix
* Add back support for api version=1, and added deprecation warning to hint user
```

Issue: https://github.com/graphistry/clients/blob/dbt-sso-databricks-issue/DBT/sso-databricks-issue/github_issues/pygraphistry-003-api-version-locked-to-v3.md