### PR TITLE
fix(cypher): reject unsound aggregate multiplicity queries

### DIFF
--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -1872,7 +1872,7 @@ def _reject_unsound_relationship_multiplicity_aggregates(
         if isinstance(active_target, ASTEdge) and relationship_count == 1:
             return
     raise _unsupported(
-        "Cypher multiplicity-sensitive aggregates over relationship MATCH patterns are not yet supported without a multiplicity-preserving row carrier",
+        "This Cypher aggregate would need repeated MATCH rows from a relationship pattern, but the current runtime collapses those rows before aggregation. Queries like MATCH (a)-[r]->(b) RETURN a, count(*) are not supported yet.",
         field=query.return_.kind,
         value=[item.expression.text for item in query.return_.items],
         line=query.return_.span.line,

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -1245,7 +1245,7 @@ def test_string_cypher_rejects_unsound_node_carrier_multiplicity_sensitive_aggre
         ),
     )
 
-    with pytest.raises(GFQLValidationError, match="multiplicity-sensitive aggregates"):
+    with pytest.raises(GFQLValidationError, match="repeated MATCH rows"):
         graph.gfql(query)
 
 


### PR DESCRIPTION
## Summary
- make the local Cypher compiler fail fast on multiplicity-sensitive aggregates that would run on a deduped node carrier after relationship `MATCH`
- keep the safe single-edge relationship-carrier cases working (`count(r)`, `RETURN r.id, count(*)`)
- add regressions for the newly rejected wrong-answer shapes and retarget the old vacuous relationship aggregate tests onto sound cases

## Scope
This is `PR1` from the aggregate-multiplicity follow-up plan: stop wrong answers now without adding the later multiplicity-preserving row carrier.

## Local validation
- `PYTHONPATH=. uv run --no-project pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `PYTHONPATH=. uv run --no-project pytest -q graphistry/tests/compute/test_gfql.py -k 'cypher_string or gfql_string'`
- `ruff check graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `python -m mypy --ignore-missing-imports --follow-imports=skip --explicit-package-bases graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `python -m py_compile graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
