### PR TITLE
docs(changelog): prepare 0.51.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+## [0.51.2 - 2026-03-13]
+
 ### Fixed
 - **GFQL / Cypher validation**: Hardened local Cypher fail-fast handling for additional unsupported read-only query shapes so valid-but-unsupported queries raise `GFQLValidationError` instead of surfacing syntax errors, runtime errors, or wrong rows.
 


### PR DESCRIPTION
## Summary
- cut the current Development notes into `0.51.2 - 2026-03-13`
- restore an empty Development stub for future unreleased changes

## Validation
- changelog-only change