### PR TITLE
docs(gfql): clarify graph and row execution paths

### DIFF
--- a/docs/source/gfql/builtin_calls.rst
+++ b/docs/source/gfql/builtin_calls.rst
@@ -39,6 +39,8 @@ All Call operations:
 - Can add columns to nodes or edges (schema effects)
 - Are restricted to methods in the safelist for security
 
+Call operations stay in graph state: the result remains a traversable graph with meaningful `_edges`, so you can keep matching or compose additional graph stages with `let()` / `ref()`. If you want row/tabular output, switch into row-pipeline operators such as `rows()`, `with_()`, `select()`, `return_()`, `group_by()`, or use a row-returning local Cypher `CALL ... YIELD ... RETURN ...` query.
+
 Graph Transformation Methods
 ----------------------------
 

--- a/docs/source/gfql/overview.rst
+++ b/docs/source/gfql/overview.rst
@@ -52,8 +52,24 @@ GFQL works on the same graphs as the rest of the PyGraphistry library. The opera
 - **Predicates**: Apply conditions to filter nodes and edges based on their properties, reusing the optimized native operations of the underlying dataframe engine
 - **Same-path constraints (WHERE)**: Relate attributes across steps in a chain using `where`
 - **Row pipelines (`MATCH ... RETURN` style)**: Move from graph pattern matches to tabular results with `rows()`, `where_rows()`, `return_()`, `order_by()`, `group_by()`, `skip()`, and `limit()`
+- **Result kinds**: Some stages keep you in graph state, while row-pipeline stages and row-returning local Cypher `CALL` queries move you into row state
 - **GPU & CPU vectorization**: GFQL automatically leverages GPU acceleration and in-memory columnar processing for massive speedups on your queries
 - **Optional remote mode**: Bind to remote data or upload it quickly as Arrow, and run your same Python and GFQL queries on remote GPU resources when available
+
+Choosing Entry Points And Result Kinds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the entrypoint that matches where the query executes:
+
+- **Local in-memory GFQL / Cypher-style execution**: `g.gfql([...])` or `g.gfql("MATCH ...")` runs on the current `Plottable` in pandas/cuDF.
+- **Remote database Cypher**: `graphistry.cypher("...")` or `g.cypher("...")` runs Cypher over a remote Bolt/Neo4j connection.
+
+GFQL pipelines also have two practical result kinds:
+
+- **Graph state**: Traversable graph results with meaningful `_nodes` and `_edges`. Matchers, graph-preserving `call(...)` transforms, and `let()` / `ref()` DAG stages stay in graph state.
+- **Row state**: Tabular results stored in `_nodes`, with `_edges` reduced to an empty placeholder frame. Row-pipeline steps like `rows()`, `with_()`, `select()`, `return_()`, `group_by()`, and row-returning local Cypher `CALL ... YIELD ... RETURN ...` queries move into row state.
+
+If you need to enrich a graph and keep matching today, prefer graph-preserving `call()` / `let()` composition rather than a row-returning local Cypher `CALL`.
 
 Quick Examples
 ~~~~~~~~~~~~~~~

--- a/docs/source/gfql/quick.rst
+++ b/docs/source/gfql/quick.rst
@@ -22,6 +22,19 @@ Basic Usage
 Use this page as a quick MATCH/chain reference.
 For row-pipeline RETURN semantics, see :doc:`return`.
 
+Choose The Right Entrypoint
+---------------------------
+
+- Use `g.gfql([...])` or `g.gfql("MATCH ...")` for local in-memory GFQL and the local Cypher subset.
+- Use `graphistry.cypher("...")` or `g.cypher("...")` for remote database Cypher over Bolt/Neo4j.
+
+Graph State Vs Row State
+------------------------
+
+- **Graph state** keeps a traversable graph in `_nodes` and `_edges`. Matchers, graph-preserving `call(...)` transforms, and `let()` / `ref()` graph DAG stages stay in graph state.
+- **Row state** stores tabular results in `_nodes` and uses an empty placeholder `_edges` frame. Row-pipeline steps such as `rows()`, `with_()`, `select()`, `return_()`, `group_by()`, and row-returning local Cypher `CALL ... YIELD ... RETURN ...` queries move into row state.
+- If you want to enrich a graph and keep matching today, use a graph-preserving `call()` / `let()` pattern rather than a row-returning local Cypher `CALL`.
+
 Node Matchers
 -------------
 
@@ -514,6 +527,20 @@ Run graph algorithms like PageRank, community detection, and layouts directly wi
 
       # Results have pagerank column
       top_nodes = result._nodes.sort_values('pagerank', ascending=False).head(10)
+
+- **Enrich a graph, then keep matching:**
+
+  .. code-block:: python
+
+      from graphistry import call
+
+      g_ranked = g.gfql([call('compute_cugraph', {'alg': 'pagerank'})])
+      top_ranked = g_ranked.gfql(
+          "MATCH (n) WHERE n.pagerank > 0.01 RETURN n.id AS id, n.pagerank AS pagerank ORDER BY pagerank DESC LIMIT 10"
+      )
+
+  Local note: `g.gfql("CALL ... YIELD ... RETURN ...")` currently targets row-returning procedure flows.
+  For graph-preserving enrich-then-match workflows, prefer `call()` / `let()` today.
 
 - **Community detection with Louvain:**
 

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -516,7 +516,7 @@ def _handle_boundary_calls(
                 message="Cannot mix call() operations with n()/e() traversals in interior of chain",
                 suggestion="call() operations are only allowed at chain boundaries (start/end). "
                           "For complex patterns, use either: "
-                          "(1) let() composition: let({'filtered': [n(...), e(...)], 'enriched': call('get_degrees', g=ref('filtered'))}), or "
+                          "(1) let() composition: let({'filtered': [n(...), e(...)], 'enriched': ref('filtered', [call('get_degrees', {'col': 'degree'})])}, output='enriched'), or "
                           "(2) explicit cascading: g1 = g.chain([call(...)]); g2 = g1.chain([n(), e()]); g3 = g2.chain([call(...)]). "
                           "See issues #791, #792"
             )

--- a/graphistry/tests/compute/test_astcall_topology.py
+++ b/graphistry/tests/compute/test_astcall_topology.py
@@ -164,6 +164,20 @@ class TestTopologicalChains:
                 n()
             ])
 
+    def test_topology_middle_call_error_points_to_supported_ref_pattern(self, rich_graph):
+        """Mixed-chain guidance should point to supported let()/ref() composition."""
+        with pytest.raises(GFQLValidationError) as exc_info:
+            rich_graph.gfql([
+                n({'type': 'person'}),
+                ASTCall('filter_edges_by_dict', {'filter_dict': {'weight': GE(5)}}),
+                e(),
+                n()
+            ])
+
+        suggestion = exc_info.value.context['suggestion']
+        assert "ref('filtered', [call('get_degrees', {'col': 'degree'})])" in suggestion
+        assert "g=ref('filtered')" not in suggestion
+
     def test_topology_call_at_chain_end(self, rich_graph):
         """Pattern: [n(), e(), n(), call(f1)]
 


### PR DESCRIPTION
## Summary
- fix the mixed-call guidance to point at the supported `let()/ref()` pattern instead of the unsupported `g=ref(...)` form
- document local `gfql(...)` vs remote `cypher(...)` entrypoints and the practical graph-state vs row-state mental model
- add supported current-workflow examples for graph-preserving call enrichment before continuing with more matching

## Validation
- `python3 -m py_compile graphistry/compute/chain.py graphistry/tests/compute/test_astcall_topology.py`
- `docker run --rm --security-opt seccomp=unconfined -v "$PWD:/opt/pygraphistry" -w /opt/pygraphistry --entrypoint python graphistry/test-gpu:latest -m pytest -q graphistry/tests/compute/test_astcall_topology.py`
- `docker run --rm --security-opt seccomp=unconfined -v "$PWD:/opt/pygraphistry" -w /opt/pygraphistry --entrypoint python graphistry/test-gpu:latest -m pytest -q graphistry/tests/compute/test_let_matchers.py`

## Notes
- this is the cleanup-first PR for C1/C2/C3
- the broader feature work stays deferred behind the current plan decision gates
