### PR TITLE
docs(gfql): clarify remote typed-query compatibility contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Docs
 - **GFQL / Cypher docs**: Clarified the currently supported direct `g.gfql("MATCH ...")` Cypher surface, documented that `[*n]`, `[*m..n]`, and `[*]` multihop patterns are native-GFQL rewrites rather than accepted direct string syntax today, and added an internal hand-off note for aligning direct Cypher multihop support with existing GFQL hop semantics.
+- **GFQL / remote compatibility**: Clarified the intended typed remote GFQL rollout contract: new clients remain backward compatible with older servers for query forms that still lower to legacy `gfql_operations`; only genuinely new typed-only remote query forms require newer server support. Named/stored GFQL UDF typed transport remains server-gated until server CRUD/schema support lands.
 
 ## [0.51.3 - 2026-03-14]
 


### PR DESCRIPTION
## Summary
- clarify the intended typed remote GFQL compatibility contract in the unreleased changelog
- state that new clients stay backward compatible with older servers for legacy-lowerable remote GFQL forms
- state that only genuinely new typed-only remote query forms require newer server support, with named/stored GFQL UDF typed transport remaining server-gated

## Why
Recent design work around `gfql_query` versus legacy `gfql_operations` needed one point made explicitly in project-facing language:

- `new client -> old server` is expected to keep working for any remote GFQL form that can still lower to legacy `gfql_operations`
- only new typed-only remote query forms should require newer server support
- named/stored GFQL UDF typed transport is a separate migration because old server CRUD/schema paths currently only understand list-valued `gfql_operations`

This PR does not implement the typed transport. It only makes the intended rollout contract explicit so future implementation/review discussion stays aligned.

## Compatibility Contract
For direct remote execution:
- legacy-lowerable forms remain backward compatible on older servers
- typed-only forms should fail clearly on older servers with an upgrade-required message rather than silently degrading

For named/stored GFQL UDFs:
- legacy forms remain the only supported cross-version path until server CRUD/schema support for `gfql_query` lands
- typed-query UDF transport should not be treated as client-first compatible yet

## Validation
- changelog wording reviewed against the current client/server compatibility research and plan notes
- no runtime behavior changes in this PR
