### PR TITLE
Add official RAPIDS image matrix runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Added
+- **Docker / RAPIDS**: Added `docker/test-rapids-official-matrix.sh` to run the official RAPIDS compatibility matrix sequentially across `25.02` and `26.02` for `basic`, `gfql`, and `ai`.
+
+### Changed
+- **Docker / RAPIDS AI**: Official RAPIDS `ai` validation now preinstalls `torch==2.11.0+cpu` from the PyTorch CPU index before `-e .[test,testai,ai]`, preventing pip from layering CUDA 13 Torch wheels onto CUDA 12 RAPIDS images.
+
+### Tests
+- **Docker / RAPIDS matrix**: Validated no-GPU official-image cells for `25.02/basic`, `25.02/gfql`, `25.02/ai`, `26.02/basic`, `26.02/gfql`, and `26.02/ai`, using smoke imports of `cudf`, `cugraph`, `cuml`, `dask_cudf`, and `graphistry` plus focused `basic`, `gfql`, and `ai` test slices.
+
 ## [0.53.6 - 2026-03-28]
 
 ### Fixed

--- a/docker/test-rapids-official-local.sh
+++ b/docker/test-rapids-official-local.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -ex
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+resolve_default_image() {
+    local rapids_version="$1"
+    case "$rapids_version" in
+        25.02)
+            echo "nvcr.io/nvidia/rapidsai/base:25.02-cuda12.8-py3.12"
+            ;;
+        26.02)
+            echo "nvcr.io/nvidia/rapidsai/base:26.02-cuda12-py3.13"
+            ;;
+        *)
+            echo "Unsupported RAPIDS_VERSION: ${rapids_version}" >&2
+            return 1
+            ;;
+    esac
+}
+
+resolve_profile_pip_deps() {
+    local profile="$1"
+    case "$profile" in
+        basic|gfql)
+            echo "-e .[test]"
+            ;;
+        ai)
+            echo "-e .[test,testai,ai]"
+            ;;
+        *)
+            echo "Unsupported PROFILE: ${profile}" >&2
+            return 1
+            ;;
+    esac
+}
+
+resolve_profile_pip_pre_deps() {
+    local profile="$1"
+    case "$profile" in
+        basic|gfql)
+            echo ""
+            ;;
+        ai)
+            echo "--index-url https://download.pytorch.org/whl/cpu torch==2.11.0+cpu"
+            ;;
+        *)
+            echo "Unsupported PROFILE: ${profile}" >&2
+            return 1
+            ;;
+    esac
+}
+
+resolve_profile_test_files() {
+    local profile="$1"
+    local with_gpu="${2:-1}"
+    case "$profile" in
+        basic)
+            cat <<'EOF'
+graphistry/tests/test_hyper_dask.py::test_HyperBindings_mt
+graphistry/tests/test_hyper_dask.py::test_HyperBindings_override
+EOF
+            ;;
+        gfql)
+            if [[ "$with_gpu" == "1" ]]; then
+                cat <<'EOF'
+graphistry/tests/compute/gfql/cypher/test_parser.py
+graphistry/tests/compute/gfql/test_row_pipeline_ops.py
+graphistry/tests/compute/gfql/cypher/test_lowering.py::test_graph_constructor_cudf_support
+graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_formats_filtered_edge_entity_projection_on_cudf
+graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_executes_real_cugraph_node_row_call_on_cudf
+EOF
+            else
+                cat <<'EOF'
+graphistry/tests/compute/gfql/cypher/test_parser.py
+graphistry/tests/compute/gfql/test_row_pipeline_ops.py::test_row_pipeline_select_supports_range_scalar_function
+graphistry/tests/compute/gfql/test_row_pipeline_ops.py::test_row_pipeline_select_supports_range_with_constant_series_bounds
+EOF
+            fi
+            ;;
+        ai)
+            if [[ "$with_gpu" == "1" ]]; then
+                cat <<'EOF'
+graphistry/tests/test_umap_utils.py
+graphistry/tests/test_embed_utils.py::TestEmbedCUDF::test_embed_out_basic
+EOF
+            else
+                cat <<'EOF'
+graphistry/tests/test_umap_utils.py
+EOF
+            fi
+            ;;
+        *)
+            echo "Unsupported PROFILE: ${profile}" >&2
+            return 1
+            ;;
+    esac
+}
+
+echo "CONFIG"
+
+RAPIDS_VERSION=${RAPIDS_VERSION:-26.02}
+RAPIDS_IMAGE=${RAPIDS_IMAGE:-}
+PROFILE=${PROFILE:-basic}
+WITH_GPU=${WITH_GPU:-1}
+WITH_IMAGE_BUILD=${WITH_IMAGE_BUILD:-1}
+WITH_LINT=${WITH_LINT:-0}
+WITH_TYPECHECK=${WITH_TYPECHECK:-0}
+WITH_TEST=${WITH_TEST:-1}
+WITH_BUILD=${WITH_BUILD:-0}
+LOG_LEVEL=${LOG_LEVEL:-DEBUG}
+SENTENCE_TRANSFORMER=${SENTENCE_TRANSFORMER:-}
+IMAGE_TAG=${IMAGE_TAG:-graphistry/test-rapids-official:${RAPIDS_VERSION}-${PROFILE}}
+PIP_DEPS=${PIP_DEPS:-}
+PIP_PRE_DEPS=${PIP_PRE_DEPS:-}
+TEST_FILES=${TEST_FILES:-}
+
+if [[ -z "${IMPORT_SMOKE:-}" ]]; then
+    IMPORT_SMOKE='python -c "import cudf, cugraph, cuml, dask_cudf, graphistry; print({\"cudf\": cudf.__version__, \"cuml\": cuml.__version__, \"graphistry\": graphistry.__version__, \"cugraph_module\": cugraph.__name__, \"dask_cudf_module\": dask_cudf.__name__})"'
+fi
+
+if [[ -z "$RAPIDS_IMAGE" ]]; then
+    RAPIDS_IMAGE="$(resolve_default_image "$RAPIDS_VERSION")"
+fi
+
+if [[ -z "$PIP_DEPS" ]]; then
+    PIP_DEPS="$(resolve_profile_pip_deps "$PROFILE")"
+fi
+
+if [[ -z "$PIP_PRE_DEPS" ]]; then
+    PIP_PRE_DEPS="$(resolve_profile_pip_pre_deps "$PROFILE")"
+fi
+
+if [[ -z "$TEST_FILES" ]]; then
+    TEST_FILES="$(resolve_profile_test_files "$PROFILE" "$WITH_GPU" | tr '\n' ' ')"
+fi
+
+echo "RAPIDS_VERSION=${RAPIDS_VERSION}"
+echo "RAPIDS_IMAGE=${RAPIDS_IMAGE}"
+echo "PROFILE=${PROFILE}"
+echo "WITH_GPU=${WITH_GPU}"
+echo "IMAGE_TAG=${IMAGE_TAG}"
+echo "PIP_PRE_DEPS=${PIP_PRE_DEPS}"
+echo "PIP_DEPS=${PIP_DEPS}"
+echo "TEST_FILES=${TEST_FILES}"
+
+if [[ "$WITH_IMAGE_BUILD" == "1" ]]; then
+    DOCKER_BUILDKIT=1 docker build \
+        -f "${SCRIPT_DIR}/test-rapids-official.Dockerfile" \
+        -t "${IMAGE_TAG}" \
+        --build-arg RAPIDS_IMAGE="${RAPIDS_IMAGE}" \
+        --build-arg PIP_PRE_DEPS="${PIP_PRE_DEPS}" \
+        --build-arg PIP_DEPS="${PIP_DEPS}" \
+        --build-arg SENTENCE_TRANSFORMER="${SENTENCE_TRANSFORMER}" \
+        "${REPO_ROOT}"
+fi
+
+DOCKER_GPU_ARGS=()
+if [[ "$WITH_GPU" == "1" ]]; then
+    DOCKER_GPU_ARGS+=(--gpus all)
+fi
+
+docker run \
+    "${DOCKER_GPU_ARGS[@]}" \
+    --security-opt seccomp=unconfined \
+    -e PYTEST_CURRENT_TEST=TRUE \
+    -e WITH_LINT="${WITH_LINT}" \
+    -e WITH_TYPECHECK="${WITH_TYPECHECK}" \
+    -e WITH_TEST="${WITH_TEST}" \
+    -e WITH_BUILD="${WITH_BUILD}" \
+    -e LOG_LEVEL="${LOG_LEVEL}" \
+    -v "${REPO_ROOT}/graphistry:/opt/pygraphistry/graphistry:ro" \
+    -v "/tmp:/tmp" \
+    --rm \
+    --entrypoint /bin/bash \
+    "${IMAGE_TAG}" \
+    -lc "${IMPORT_SMOKE} && /entrypoint/test-cpu-entrypoint.sh --maxfail=1 ${TEST_FILES}"

--- a/docker/test-rapids-official-matrix.sh
+++ b/docker/test-rapids-official-matrix.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+VERSIONS=${RAPIDS_VERSIONS:-"25.02 26.02"}
+PROFILES=${PROFILES:-"basic gfql ai"}
+WITH_GPU=${WITH_GPU:-0}
+WITH_IMAGE_BUILD=${WITH_IMAGE_BUILD:-1}
+WITH_LINT=${WITH_LINT:-0}
+WITH_TYPECHECK=${WITH_TYPECHECK:-0}
+WITH_TEST=${WITH_TEST:-1}
+WITH_BUILD=${WITH_BUILD:-0}
+LOG_LEVEL=${LOG_LEVEL:-DEBUG}
+MATRIX_CELLS=${MATRIX_CELLS:-}
+
+cells=()
+if [[ -n "${MATRIX_CELLS}" ]]; then
+    for cell in ${MATRIX_CELLS}; do
+        cells+=("${cell}")
+    done
+else
+    for version in ${VERSIONS}; do
+        for profile in ${PROFILES}; do
+            cells+=("${version}:${profile}")
+        done
+    done
+fi
+
+if [[ ${#cells[@]} -eq 0 ]]; then
+    echo "No matrix cells selected" >&2
+    exit 1
+fi
+
+results=()
+failures=0
+
+echo "CONFIG"
+echo "VERSIONS=${VERSIONS}"
+echo "PROFILES=${PROFILES}"
+echo "WITH_GPU=${WITH_GPU}"
+echo "WITH_IMAGE_BUILD=${WITH_IMAGE_BUILD}"
+echo "WITH_LINT=${WITH_LINT}"
+echo "WITH_TYPECHECK=${WITH_TYPECHECK}"
+echo "WITH_TEST=${WITH_TEST}"
+echo "WITH_BUILD=${WITH_BUILD}"
+echo "LOG_LEVEL=${LOG_LEVEL}"
+echo "MATRIX_CELLS=${MATRIX_CELLS:-<default>}"
+
+for cell in "${cells[@]}"; do
+    version="${cell%%:*}"
+    profile="${cell##*:}"
+
+    echo
+    echo "=== CELL ${version}/${profile} ==="
+
+    if RAPIDS_VERSION="${version}" \
+        PROFILE="${profile}" \
+        WITH_GPU="${WITH_GPU}" \
+        WITH_IMAGE_BUILD="${WITH_IMAGE_BUILD}" \
+        WITH_LINT="${WITH_LINT}" \
+        WITH_TYPECHECK="${WITH_TYPECHECK}" \
+        WITH_TEST="${WITH_TEST}" \
+        WITH_BUILD="${WITH_BUILD}" \
+        LOG_LEVEL="${LOG_LEVEL}" \
+        "${SCRIPT_DIR}/test-rapids-official-local.sh"; then
+        results+=("${version}/${profile}:PASS")
+    else
+        results+=("${version}/${profile}:FAIL")
+        failures=$((failures + 1))
+    fi
+done
+
+echo
+echo "SUMMARY"
+for result in "${results[@]}"; do
+    cell="${result%%:*}"
+    status="${result##*:}"
+    printf '%-18s %s\n' "${cell}" "${status}"
+done
+
+if [[ "${failures}" -ne 0 ]]; then
+    echo
+    echo "Matrix failed: ${failures} cell(s) failed" >&2
+    exit 1
+fi
+
+echo
+echo "Matrix passed"

--- a/docker/test-rapids-official.Dockerfile
+++ b/docker/test-rapids-official.Dockerfile
@@ -1,0 +1,69 @@
+# NOTE: context is ..
+
+ARG RAPIDS_IMAGE=nvcr.io/nvidia/rapidsai/base:26.02-cuda12-py3.13
+FROM ${RAPIDS_IMAGE}
+ARG PIP_PRE_DEPS=""
+ARG PIP_DEPS="-e .[test]"
+ARG SENTENCE_TRANSFORMER=""
+
+SHELL ["/bin/bash", "-lc"]
+USER root
+
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update \
+    && apt-get install -y \
+        unzip \
+        wget \
+        zip
+
+RUN mkdir /opt/pygraphistry
+WORKDIR /opt/pygraphistry
+
+# Install the package and selected non-RAPIDS extras on top of an official RAPIDS image.
+COPY README.md setup.py setup.cfg versioneer.py MANIFEST.in ./
+COPY graphistry/_version.py ./graphistry/_version.py
+
+RUN --mount=type=cache,target=/root/.cache \
+    if command -v conda >/dev/null 2>&1; then \
+        conda_base="$(conda info --base 2>/dev/null || true)"; \
+        if [[ -n "$conda_base" && -f "$conda_base/etc/profile.d/conda.sh" ]]; then source "$conda_base/etc/profile.d/conda.sh" && conda activate base || true; fi; \
+    fi \
+    && python --version \
+    && pip --version \
+    && touch graphistry/__init__.py \
+    && echo "PIP_PRE_DEPS: $PIP_PRE_DEPS" \
+    && echo "PIP_DEPS: $PIP_DEPS" \
+    && pip install --upgrade pip build \
+    && if [[ -n "$PIP_PRE_DEPS" ]]; then pip install $PIP_PRE_DEPS; fi \
+    && pip install $PIP_DEPS \
+    && pip list
+
+RUN --mount=type=cache,target=/root/.cache \
+    mkdir -p /models \
+    && cd /models \
+    && if [[ "${SENTENCE_TRANSFORMER}" == "" ]]; then \
+        echo "No sentence transformer specified, skipping"; \
+    else \
+        ( \
+            wget --no-check-certificate \
+            "https://public.ukp.informatik.tu-darmstadt.de/reimers/sentence-transformers/v0.2/${SENTENCE_TRANSFORMER}.zip" \
+            && unzip "${SENTENCE_TRANSFORMER}.zip" -d "${SENTENCE_TRANSFORMER}" \
+        ); \
+    fi
+
+COPY docker/test-cpu-entrypoint.sh /entrypoint/test-cpu-entrypoint.sh
+COPY bin ./bin
+COPY mypy.ini .
+COPY pytest.ini .
+COPY graphistry ./graphistry
+COPY demos/data ./demos/data
+
+ENV \
+    RAPIDS=1 \
+    TEST_CUDF=1 \
+    TEST_DASK=1 \
+    TEST_DASK_CUDF=1 \
+    TEST_PANDAS=1 \
+    TEST_CUGRAPH=1
+
+ENTRYPOINT ["/entrypoint/test-cpu-entrypoint.sh"]


### PR DESCRIPTION
# PR Description Draft

## Summary

- add official RAPIDS-image runners for PyGraphistry validation instead of relying only on Graphistry-owned GPU images
- add a sequential RAPIDS matrix wrapper covering `25.02` and `26.02` across `basic`, `gfql`, and `ai`
- fix RAPIDS `ai` image install behavior by preinstalling CPU-only `torch==2.11.0+cpu` before `-e .[test,testai,ai]` so pip does not pull CUDA 13 Torch wheels into CUDA 12 RAPIDS bases

## What Changed

- added [`docker/test-rapids-official.Dockerfile`](/home/lmeyerov/Work/pygraphistry3/docker/test-rapids-official.Dockerfile) for building on official RAPIDS base images
- added [`docker/test-rapids-official-local.sh`](/home/lmeyerov/Work/pygraphistry3/docker/test-rapids-official-local.sh) for single-cell RAPIDS validation
- added [`docker/test-rapids-official-matrix.sh`](/home/lmeyerov/Work/pygraphistry3/docker/test-rapids-official-matrix.sh) for sequential full-matrix execution
- for `PROFILE=ai`, the runner now preinstalls `torch==2.11.0+cpu` from `https://download.pytorch.org/whl/cpu`
- updated planning notes with the matrix outcomes, root cause, and remaining GPU-validation gap

## Why

- the earlier `ai` install path allowed unconstrained `torch` to resolve to `torch 2.11.0+cu130`, which pulled CUDA 13 wheels on top of CUDA 12 RAPIDS images
- on RAPIDS `25.02`, that changed `cudf` startup from warning-only missing-driver behavior into a fatal `cudaErrorInsufficientDriver`, and `cugraph -> torch` could also fail with `undefined symbol: ncclCommWindowDeregister`
- preinstalling CPU Torch keeps RAPIDS CUDA plumbing intact and makes the no-GPU official-image matrix reproducible for `ai` as well

## Tested

- `25.02/basic`: pass
- `25.02/gfql`: pass
- `25.02/ai`: pass after CPU-Torch preinstall
- `26.02/basic`: pass
- `26.02/gfql`: pass
- `26.02/ai`: pass after CPU-Torch preinstall

Focused test coverage exercised by the runner:

- `basic`: `graphistry/tests/test_hyper_dask.py::test_HyperBindings_mt`, `graphistry/tests/test_hyper_dask.py::test_HyperBindings_override`
- `gfql`: parser + CPU-safe row-pipeline slice
- `ai`: `graphistry/tests/test_umap_utils.py`

Validated smoke import:

```python
import cudf, cugraph, cuml, dask_cudf, graphistry
```

## Caveats

- current validation is no-GPU only on this host; Docker still rejects `--gpus all`
- the RAPIDS-aware AI strategy currently lives in the runner, not yet in package metadata such as `setup.py` extras or a constraints file
- if GPU-backed Torch is required inside the same RAPIDS image, that needs a separate compatibility strategy
