### PR TITLE
fix(cypher): support connected-prefix carried-scalar reentry (#1004)

### DIFF
--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -5878,14 +5878,6 @@ def _bounded_reentry_carry_columns(
     carried_columns = tuple(column.output_name for column in prefix_projection.columns if column.kind != "whole_row")
     if not carried_columns:
         return whole_row_columns[0], ()
-    seed_alias = _single_node_seed_alias(query.matches[0]) if len(query.matches) == 1 else None
-    if seed_alias is None or seed_alias != prefix_projection.alias:
-        raise _unsupported_at_span(
-            "Cypher MATCH after WITH carried scalar columns currently require a single-node prefix MATCH seed",
-            field="with",
-            value=projection_items,
-            span=prefix_stage.span,
-        )
     invalid_output = next((name for name in carried_columns if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)), None)
     if invalid_output is not None:
         raise _unsupported_at_span(

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -125,6 +125,48 @@ def _mk_reentry_carried_scalar_graph_cudf() -> _CypherTestGraph:
     )
 
 
+def _mk_connected_reentry_carried_scalar_graph() -> _CypherTestGraph:
+    return _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["a1", "a2", "b1", "b2", "c1", "c2"],
+                "label__A": [True, True, False, False, False, False],
+                "label__B": [False, False, True, True, False, False],
+                "label__C": [False, False, False, False, True, True],
+                "score": [None, None, 10, 20, None, None],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["a1", "a2", "b1", "b2"],
+                "d": ["b1", "b2", "c1", "c2"],
+                "type": ["R", "R", "S", "S"],
+            }
+        ),
+    )
+
+
+def _mk_connected_reentry_carried_scalar_graph_cudf() -> _CypherTestGraph:
+    return _mk_cudf_graph(
+        pd.DataFrame(
+            {
+                "id": ["a1", "a2", "b1", "b2", "c1", "c2"],
+                "label__A": [True, True, False, False, False, False],
+                "label__B": [False, False, True, True, False, False],
+                "label__C": [False, False, False, False, True, True],
+                "score": [None, None, 10, 20, None, None],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["a1", "a2", "b1", "b2"],
+                "d": ["b1", "b2", "c1", "c2"],
+                "type": ["R", "R", "S", "S"],
+            }
+        ),
+    )
+
+
 def _compiled_reentry_projection_outputs(compiled: CompiledCypherQuery) -> Tuple[str, Tuple[str, ...]]:
     assert compiled.start_nodes_query is not None
     projection = compiled.start_nodes_query.result_projection
@@ -5329,6 +5371,72 @@ def test_string_cypher_executes_with_match_reentry_carried_scalar_shapes_on_cudf
 
     assert type(result._nodes).__module__.startswith("cudf")
     assert result._nodes.to_pandas().to_dict(orient="records") == expected
+
+
+def test_string_cypher_executes_with_match_reentry_carried_scalars_from_connected_prefix_shape() -> None:
+    query = (
+        "MATCH (a:A {id: $seed})-[:R]->(b:B) "
+        "WITH b, b.id AS bid "
+        "MATCH (b)-[:S]->(c:C) "
+        "RETURN bid, c.id AS cid"
+    )
+
+    result = _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
+
+    assert result._nodes.to_dict(orient="records") == [{"bid": "b1", "cid": "c1"}]
+
+
+def test_string_cypher_executes_with_match_reentry_multiple_carried_scalars_from_connected_prefix_shape() -> None:
+    query = (
+        "MATCH (a:A {id: $seed})-[:R]->(b:B) "
+        "WITH b, b.id AS bid, b.score AS bscore "
+        "MATCH (b)-[:S]->(c:C) "
+        "RETURN bid, bscore, c.id AS cid"
+    )
+
+    result = _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
+
+    assert result._nodes.to_dict(orient="records") == [{"bid": "b1", "bscore": 10, "cid": "c1"}]
+
+
+def test_string_cypher_executes_with_match_reentry_carried_scalars_from_connected_prefix_shape_on_cudf() -> None:
+    pytest.importorskip("cudf")
+
+    query = (
+        "MATCH (a:A {id: $seed})-[:R]->(b:B) "
+        "WITH b, b.id AS bid "
+        "MATCH (b)-[:S]->(c:C) "
+        "RETURN bid, c.id AS cid"
+    )
+
+    result = _mk_connected_reentry_carried_scalar_graph_cudf().gfql(query, params={"seed": "a1"}, engine="cudf")
+
+    assert type(result._nodes).__module__.startswith("cudf")
+    assert result._nodes.to_pandas().to_dict(orient="records") == [{"bid": "b1", "cid": "c1"}]
+
+
+def test_string_cypher_failfast_rejects_with_match_reentry_multiple_whole_row_aliases_with_carried_scalars() -> None:
+    query = (
+        "MATCH (a:A {id: $seed})-[:R]->(b:B) "
+        "WITH a, b, b.id AS bid "
+        "MATCH (b)-[:S]->(c:C) "
+        "RETURN bid, c.id AS cid"
+    )
+
+    with pytest.raises(GFQLValidationError, match="one MATCH source alias at a time"):
+        _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
+
+
+def test_string_cypher_failfast_rejects_with_match_reentry_cross_alias_carried_scalars_from_connected_prefix_shape() -> None:
+    query = (
+        "MATCH (a:A {id: $seed})-[:R]->(b:B) "
+        "WITH b, a.id AS aid "
+        "MATCH (b)-[:S]->(c:C) "
+        "RETURN aid, c.id AS cid"
+    )
+
+    with pytest.raises(GFQLValidationError, match="one MATCH source alias at a time"):
+        _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
 
 
 def test_string_cypher_reentry_carried_scalars_ignore_internal_hidden_column_collisions() -> None:


### PR DESCRIPTION
## Summary

Support the narrow direct-Cypher `MATCH ... WITH ... MATCH ...` continuation where the `WITH` carries one whole-row alias plus scalar outputs derived from that same alias, even when the prefix `MATCH` is not a literal single-node seed.

Closes #1004.

## Scope

This PR intentionally stays narrow:
- supports connected-prefix carried-scalar reentry such as `MATCH (a)-[:R]->(b) WITH b, b.id AS bid MATCH (b)-[:S]->(c) ...`
- preserves the existing out-of-scope boundaries for broader multi-alias row lowering
- does not attempt the broader `#981` multi-binding projection family
- does not attempt the broader `#999` multi-stage row-carrier architecture

## Implementation

- remove the over-strict lowering guard that required carried-scalar reentry to come from a literal single-node prefix `MATCH` seed
- add focused coverage for:
  - connected-prefix carried-scalar reentry
  - multiple carried scalar columns from the same connected prefix
  - cross-alias / multi-alias nearby failfast boundaries
  - cudf execution for the exact new connected-prefix shape

## Validation

Local:
- `PYTHONPATH=. pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py` -> `456 passed, 46 skipped`
- `PYTHONPATH=. pytest -q graphistry/tests/compute/test_gfql.py -k "reentry"` -> `6 passed, 3 skipped, 41 deselected`
- `ruff check graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py` -> pass
- `./bin/typecheck.sh` -> pass

DGX / cuDF:
- official RAPIDS `26.02` `cuda13` targeted run on `dgx-spark`
- `graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_executes_with_match_reentry_carried_scalars_from_connected_prefix_shape_on_cudf` -> passed

## Benchmark-facing result

Fresh `origin/master` still hits `#973` earlier on official `interactive-short-2`, so this PR by itself does not change current master benchmark status yet.

But when this change is combined with the closed connected-multihop PR head (`6b17cf642`), the motivating official query moves past the old `single-node prefix MATCH seed` blocker and reaches the next boundary:
- `Cypher MATCH after WITH currently supports a single trailing MATCH pattern`

So this lane is still a real benchmark unblocker; it just needs the connected-multihop lane underneath it.
