### PR TITLE
docs: prepare v0.53.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+## [0.53.13 - 2026-04-01]
+
 ### Added
 - **GFQL / Cypher**: Support connected multi-alias row bindings for direct Cypher scalar projections and bounded `WITH ... MATCH` reentry. Connected single-path and connected multi-pattern shapes like `MATCH (a)-[:R]->(b), (b)-[:S]->(c) RETURN a.id, c.id` and the benchmark-facing `WITH ... MATCH` continuation behind `interactive-short-2` now materialize row bindings correctly while branching multihop and connected relationship-alias projection shapes remain explicit fail-fast boundaries.
 


### PR DESCRIPTION
## Summary
- convert the current `Development` changelog entry into the `0.53.13` release section
- leave a fresh empty `Development` stub at the top of `CHANGELOG.md`

## Scope
Release metadata only. No product code changes.

## Validation
- `sed -n '1,24p' CHANGELOG.md`
- hosted CI on this changelog-only PR
