### PR TITLE
feat(cypher): support multi-stage reentry read queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Added
+- **GFQL / Cypher**: Support bounded alternating multi-stage reentry read shapes in direct local Cypher, including `MATCH ... WITH ... MATCH ... WITH ... MATCH ... RETURN` for connected vectorized pipelines, plus nested reentry runtime composition and bindings-backed whole-row/scalar projection handling needed by this shape (#999).
+
 ## [0.53.13 - 2026-04-01]
 
 ### Added

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -3123,12 +3123,13 @@ def _build_projection_plan(
         available_columns.add(output_name)
         if simple_ref and prop is not None:
             projected_property_outputs.setdefault(prop, output_name)
-            output_to_source_property[output_name] = prop
+            source_property_name = prop if alias_name == source_alias else f"{alias_name}.{prop}"
+            output_to_source_property[output_name] = source_property_name
             projection_columns.append(
                 ResultProjectionColumn(
                     output_name=output_name,
                     kind="property",
-                    source_name=prop,
+                    source_name=source_property_name,
                 )
             )
         else:
@@ -3174,6 +3175,31 @@ def _build_projection_plan(
         output_to_expr_source=output_to_expr_source,
         all_source_aliases=all_source_aliases,
     )
+
+
+def _can_lower_multi_alias_projection_bindings(
+    plan: _ProjectionPlan,
+    *,
+    alias_targets: Mapping[str, ASTObject],
+) -> bool:
+    all_refs = (plan.all_source_aliases or set()) | {plan.source_alias}
+    all_are_edges = all(isinstance(alias_targets.get(alias_name), ASTEdge) for alias_name in all_refs)
+    has_non_scalar = bool(plan.whole_row_output_names) or bool(plan.output_to_expr_source)
+    if not has_non_scalar:
+        return not all_are_edges
+    if len(plan.whole_row_output_names) != 1:
+        return False
+    if isinstance(alias_targets.get(plan.source_alias), ASTEdge):
+        return False
+    simple_qualified_ref = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*$")
+    for source_name in plan.output_to_expr_source.values():
+        match = simple_qualified_ref.fullmatch(source_name)
+        if match is None:
+            return False
+        alias_name = source_name.split(".", 1)[0]
+        if isinstance(alias_targets.get(alias_name), ASTEdge):
+            return False
+    return True
 
 
 def _result_projection_plan(
@@ -3640,11 +3666,7 @@ def _lower_projection_chain(
             params=params,
         )
         if _multi_alias_exc is not None:
-            # Only allow bindings path for pure scalar node alias.prop projections
-            has_non_scalar = bool(plan.whole_row_output_names) or bool(plan.output_to_expr_source)
-            all_refs = (plan.all_source_aliases or set()) | {plan.source_alias}
-            all_are_edges = all(isinstance(alias_targets.get(a), ASTEdge) for a in all_refs)
-            if has_non_scalar or all_are_edges:
+            if not _can_lower_multi_alias_projection_bindings(plan, alias_targets=alias_targets):
                 raise _multi_alias_exc
 
     if plan.all_source_aliases is not None and len(lowered.query) > 3:
@@ -5912,11 +5934,59 @@ def _first_pattern_node_alias(clause: MatchClause) -> Optional[str]:
     return pattern[0].variable
 
 
-def _reentry_query_clone(query: CypherQuery, **overrides: Any) -> CypherQuery:
+def _attach_reentry_prefix_query(
+    compiled_query: CompiledCypherQuery,
+    prefix_query: CompiledCypherQuery,
+) -> CompiledCypherQuery:
+    if compiled_query.start_nodes_query is None:
+        return replace(compiled_query, start_nodes_query=prefix_query)
     return replace(
-        query, call=None, row_sequence=(), reentry_matches=(), reentry_where=None,
-        graph_bindings=(), use=None,
-        **overrides,
+        compiled_query,
+        start_nodes_query=_attach_reentry_prefix_query(compiled_query.start_nodes_query, prefix_query),
+    )
+
+
+def _rewrite_reentry_projection_clause(
+    clause: ReturnClause,
+    *,
+    rewrite_expr: Callable[[ExpressionText, str], ExpressionText],
+) -> ReturnClause:
+    return replace(
+        clause,
+        items=tuple(
+            replace(
+                item,
+                expression=rewritten_expr,
+                alias=item.alias or (item.expression.text if rewritten_expr.text != item.expression.text else None),
+            )
+            for item in clause.items
+            for rewritten_expr in (rewrite_expr(item.expression, clause.kind),)
+        ),
+    )
+
+
+def _rewrite_reentry_projection_stage(
+    stage: ProjectionStage,
+    *,
+    rewrite_expr: Callable[[ExpressionText, str], ExpressionText],
+) -> ProjectionStage:
+    rewritten_order_by = None
+    if stage.order_by is not None:
+        rewritten_order_by = replace(
+            stage.order_by,
+            items=tuple(
+                replace(
+                    item,
+                    expression=rewrite_expr(item.expression, "order_by"),
+                )
+                for item in stage.order_by.items
+            ),
+        )
+    return replace(
+        stage,
+        clause=_rewrite_reentry_projection_clause(stage.clause, rewrite_expr=rewrite_expr),
+        where=None if stage.where is None else rewrite_expr(stage.where, "where"),
+        order_by=rewritten_order_by,
     )
 
 
@@ -5980,9 +6050,9 @@ def _compile_bounded_reentry_query(
                 span=first_unwind.span,
             )
         query = rewritten_query
-    if len(query.with_stages) != 1 or len(query.reentry_matches) != 1:
+    if not query.reentry_matches or len(query.with_stages) != len(query.reentry_matches):
         raise _unsupported_at_span(
-            "Cypher MATCH after WITH is only supported for a single MATCH ... WITH ... MATCH ... RETURN shape in the local compiler",
+            "Cypher MATCH after WITH is only supported for alternating MATCH ... WITH ... MATCH ... [WITH ... MATCH ...] ... RETURN read shapes in the local compiler",
             field="match",
             value=len(query.reentry_matches),
             span=query.return_.span,
@@ -5996,8 +6066,14 @@ def _compile_bounded_reentry_query(
             value=prefix_stage.where.text,
             span=prefix_stage.span,
         )
-    prefix_query = _reentry_query_clone(
+    prefix_query = replace(
         query,
+        call=None,
+        row_sequence=(),
+        reentry_matches=(),
+        reentry_where=None,
+        graph_bindings=(),
+        use=None,
         with_stages=(),
         return_=replace(prefix_stage.clause, kind="return"),
         order_by=prefix_stage.order_by,
@@ -6055,6 +6131,8 @@ def _compile_bounded_reentry_query(
         )
 
     reentry_match = query.reentry_matches[0]
+    remaining_with_stages = query.with_stages[1:]
+    remaining_reentry_matches = query.reentry_matches[1:]
     first_alias = _first_pattern_node_alias(reentry_match)
     if first_alias is None or first_alias != reentry_alias:
         raise _unsupported_at_span(
@@ -6074,46 +6152,54 @@ def _compile_bounded_reentry_query(
             field=field,
         )
 
-    reentry_where = query.reentry_where
-    if reentry_where is not None and reentry_where.expr is not None and hidden_columns:
-        reentry_where = replace(
-            reentry_where,
-            expr=rewrite_expr(reentry_where.expr, "where"),
-        )
+    reentry_where = None
     reentry_return = query.return_
-    if hidden_columns:
-        reentry_return = replace(
-            query.return_,
-            items=tuple(
-                replace(
-                    item,
-                    expression=rewritten_expr,
-                    alias=item.alias or (item.expression.text if rewritten_expr.text != item.expression.text else None),
-                )
-                for item in query.return_.items
-                for rewritten_expr in (rewrite_expr(item.expression, query.return_.kind),)
-            ),
-        )
     reentry_order_by = query.order_by
-    if reentry_order_by is not None and hidden_columns:
-        reentry_order_by = replace(
-            reentry_order_by,
-            items=tuple(
-                replace(
-                    item,
-                    expression=rewrite_expr(item.expression, "order_by"),
-                )
-                for item in reentry_order_by.items
-            ),
+    rewritten_with_stages = remaining_with_stages
+    rewritten_reentry_where = query.reentry_where if remaining_reentry_matches else None
+    if hidden_columns:
+        rewritten_with_stages = tuple(
+            _rewrite_reentry_projection_stage(stage, rewrite_expr=rewrite_expr)
+            for stage in remaining_with_stages
         )
-    suffix_query = _reentry_query_clone(
+        if remaining_reentry_matches:
+            reentry_where = None
+        elif query.reentry_where is not None and query.reentry_where.expr is not None:
+            reentry_where = replace(
+                query.reentry_where,
+                expr=rewrite_expr(query.reentry_where.expr, "where"),
+            )
+        else:
+            reentry_where = query.reentry_where
+        if not remaining_reentry_matches:
+            reentry_return = _rewrite_reentry_projection_clause(query.return_, rewrite_expr=rewrite_expr)
+            if reentry_order_by is not None:
+                reentry_order_by = replace(
+                    reentry_order_by,
+                    items=tuple(
+                        replace(
+                            item,
+                            expression=rewrite_expr(item.expression, "order_by"),
+                        )
+                        for item in reentry_order_by.items
+                    ),
+                )
+    else:
+        reentry_where = None if remaining_reentry_matches else query.reentry_where
+    suffix_query = replace(
         query,
-        matches=query.reentry_matches,
+        call=None,
+        row_sequence=(),
+        graph_bindings=(),
+        use=None,
+        matches=(reentry_match,),
         where=reentry_where,
         unwinds=(),
-        with_stages=(),
+        with_stages=rewritten_with_stages,
         return_=reentry_return,
         order_by=reentry_order_by,
+        reentry_matches=remaining_reentry_matches,
+        reentry_where=rewritten_reentry_where,
     )
     suffix_compiled = compile_cypher_query(suffix_query, params=params)
     if not isinstance(suffix_compiled, CompiledCypherQuery):
@@ -6134,9 +6220,8 @@ def _compile_bounded_reentry_query(
             ),
         )
     return replace(
-        suffix_compiled,
+        _attach_reentry_prefix_query(suffix_compiled, prefix_compiled),
         result_projection=result_projection,
-        start_nodes_query=prefix_compiled,
     )
 
 
@@ -6442,10 +6527,7 @@ def compile_cypher_query(
                 params=params,
             )
             if _multi_alias_exc2 is not None:
-                has_non_scalar = bool(plan.whole_row_output_names) or bool(plan.output_to_expr_source)
-                all_refs = (plan.all_source_aliases or set()) | {plan.source_alias}
-                all_are_edges = all(isinstance(alias_targets.get(a), ASTEdge) for a in all_refs)
-                if has_non_scalar or all_are_edges:
+                if not _can_lower_multi_alias_projection_bindings(plan, alias_targets=alias_targets):
                     raise _multi_alias_exc2
             seed_alias = _single_node_seed_alias(query.matches[0]) if len(query.matches) == 2 else None
             if (

--- a/graphistry/compute/gfql/cypher/parser.py
+++ b/graphistry/compute/gfql/cypher/parser.py
@@ -1322,6 +1322,12 @@ def _build_transformer(source: str) -> _TransformerLike:
                         )
                     use_clause_node = item
                 elif isinstance(item, MatchClause):
+                    if reentry_where_clause is not None:
+                        raise _to_syntax_error(
+                            "Cypher MATCH after post-WITH WHERE is not yet supported in the current GFQL Cypher compiler",
+                            line=item.span.line,
+                            column=item.span.column,
+                        )
                     if seen_stage:
                         reentry_match_clauses.append(item)
                     else:
@@ -1375,7 +1381,13 @@ def _build_transformer(source: str) -> _TransformerLike:
                             line=item.span.line,
                             column=item.span.column,
                         )
-                    if reentry_match_clauses and item.clause.kind != "return":
+                    if reentry_where_clause is not None and item.clause.kind != "return":
+                        raise _to_syntax_error(
+                            "Cypher WITH after post-WITH MATCH WHERE is not yet supported in the current GFQL Cypher compiler",
+                            line=item.span.line,
+                            column=item.span.column,
+                        )
+                    if reentry_match_clauses and item.clause.kind != "return" and item.clause.kind != "with":
                         raise _to_syntax_error(
                             "Cypher WITH after post-WITH MATCH is not yet supported in the current GFQL Cypher compiler",
                             line=item.span.line,
@@ -1404,10 +1416,15 @@ def _build_transformer(source: str) -> _TransformerLike:
                 elif idx != len(stages) - 1:
                     with_stages.append(stage)
             if reentry_match_clauses:
-                if len(stages) != 2 or stages[0].clause.kind != "with" or stages[-1].clause.kind != "return":
+                if (
+                    stages[0].clause.kind != "with"
+                    or stages[-1].clause.kind != "return"
+                    or any(stage.clause.kind != "with" for stage in stages[:-1])
+                    or len(with_stages) != len(reentry_match_clauses)
+                ):
                     first_match = reentry_match_clauses[0]
                     raise _to_syntax_error(
-                        "Cypher MATCH after WITH is only supported for a single MATCH ... WITH ... MATCH ... RETURN shape in the current GFQL Cypher compiler",
+                        "Cypher MATCH after WITH is only supported for alternating MATCH ... WITH ... MATCH ... [WITH ... MATCH ...] ... RETURN read shapes in the current GFQL Cypher compiler",
                         line=first_match.span.line,
                         column=first_match.span.column,
                     )

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Sequence, TypedDict, cast
+from typing import Any, Literal, Optional, Sequence, TypedDict, cast
 
 import pandas as pd
 
@@ -433,6 +433,8 @@ def _project_expr_column(
 ) -> SeriesT:
     if column.source_name is None:
         raise ValueError(f"projection expression not found: {column.output_name!r}")
+    if column.source_name in rows_df.columns:
+        return cast(SeriesT, rows_df[column.source_name])
     adapter = _RowPipelineAdapter(result)
     value = adapter._gfql_eval_string_expr(rows_df, column.source_name)
     return cast(SeriesT, value if hasattr(value, "astype") else _broadcast_projected_scalar(adapter, rows_df, value))
@@ -454,18 +456,40 @@ def _whole_row_projection_meta(
     }
 
 
+def _binding_alias_projection_rows(
+    rows_df: DataFrameT,
+    *,
+    alias: str,
+) -> Optional[DataFrameT]:
+    prefix = f"{alias}."
+    alias_columns = [column for column in rows_df.columns if str(column).startswith(prefix)]
+    if not alias_columns:
+        return None
+    return cast(
+        DataFrameT,
+        rows_df[alias_columns].rename(columns={column: str(column)[len(prefix):] for column in alias_columns}),
+    )
+
+
 def apply_result_projection(result: Plottable, projection: ResultProjectionPlan) -> Plottable:
     rows_df = cast(DataFrameT, getattr(result, "_nodes", None))
-    if rows_df is None or projection.alias not in rows_df.columns:
+    if rows_df is None:
+        return result
+    alias_rows_df = (
+        rows_df
+        if projection.alias in rows_df.columns
+        else _binding_alias_projection_rows(rows_df, alias=projection.alias)
+    )
+    if alias_rows_df is None or projection.alias not in alias_rows_df.columns:
         return result
 
     entity_series = (
-        _format_node_entities(rows_df, projection)
+        _format_node_entities(alias_rows_df, projection)
         if projection.table == "nodes"
-        else _format_edge_entities(rows_df, projection)
+        else _format_edge_entities(alias_rows_df, projection)
     )
     projected_data: dict[str, SeriesT] = {}
-    whole_row_meta = _whole_row_projection_meta(result, rows_df, projection)
+    whole_row_meta = _whole_row_projection_meta(result, alias_rows_df, projection)
     projected_entity_meta: dict[str, WholeRowProjectionMeta] = {}
     for column in projection.columns:
         if column.kind == "whole_row":
@@ -478,14 +502,20 @@ def apply_result_projection(result: Plottable, projection: ResultProjectionPlan)
                     "ids": whole_row_meta["ids"],
                 }
         else:
-            projected_data[column.output_name] = (
-                _project_property_column(rows_df, column=column)
-                if column.kind == "property"
-                else _project_expr_column(result, rows_df, column=column)
-            )
-    projected_rows = rows_df
+            if column.kind == "property":
+                property_rows_df = alias_rows_df
+                if (
+                    column.source_name is not None
+                    and column.source_name not in alias_rows_df.columns
+                    and column.source_name in rows_df.columns
+                ):
+                    property_rows_df = rows_df
+                projected_data[column.output_name] = _project_property_column(property_rows_df, column=column)
+            else:
+                projected_data[column.output_name] = _project_expr_column(result, rows_df, column=column)
+    projected_rows = alias_rows_df
     if rows_df.__class__.__module__.startswith("cudf") and any(isinstance(value, pd.Series) for value in projected_data.values()):
-        projected_rows = cast(DataFrameT, cast(Any, rows_df).to_pandas())
+        projected_rows = cast(DataFrameT, cast(Any, alias_rows_df).to_pandas())
         projected_data = {
             key: cast(SeriesT, value.to_pandas() if hasattr(value, "to_pandas") else value)
             for key, value in projected_data.items()

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -458,6 +458,49 @@ def _execute_compiled_query(
     return result
 
 
+def _execute_compiled_query_with_reentry(
+    base_graph: Plottable,
+    *,
+    compiled_query: Union[CompiledCypherQuery, CompiledCypherUnionQuery],
+    engine: Union[EngineAbstract, str],
+    policy: Optional[PolicyDict],
+    context: ExecutionContext,
+) -> Plottable:
+    if isinstance(compiled_query, CompiledCypherUnionQuery):
+        return _execute_compiled_query(
+            base_graph,
+            compiled_query=compiled_query,
+            engine=engine,
+            policy=policy,
+            context=context,
+        )
+
+    compiled_base_graph = base_graph
+    start_nodes = None
+    if compiled_query.start_nodes_query is not None:
+        prefix_result = _execute_compiled_query_with_reentry(
+            base_graph,
+            compiled_query=compiled_query.start_nodes_query,
+            engine=engine,
+            policy=policy,
+            context=context,
+        )
+        compiled_base_graph, start_nodes = _compiled_query_reentry_state(
+            base_graph,
+            compiled_query,
+            prefix_result,
+            engine=engine,
+        )
+    return _execute_compiled_query(
+        compiled_base_graph,
+        compiled_query=compiled_query,
+        engine=engine,
+        policy=policy,
+        context=context,
+        start_nodes=start_nodes,
+    )
+
+
 def _compiled_query_reentry_state(
     base_graph: Plottable,
     compiled_query: CompiledCypherQuery,
@@ -1027,29 +1070,12 @@ def gfql(self: Plottable,
                         raise ValueError("where provided for Chain that already includes where")
                     query = Chain(query.chain, where=where_param)
                 if compiled_query is not None:
-                    compiled_base_graph = self
-                    start_nodes = None
-                    if compiled_query.start_nodes_query is not None:
-                        prefix_result = _execute_compiled_query(
-                            self,
-                            compiled_query=compiled_query.start_nodes_query,
-                            engine=engine,
-                            policy=expanded_policy,
-                            context=context,
-                        )
-                        compiled_base_graph, start_nodes = _compiled_query_reentry_state(
-                            self,
-                            compiled_query,
-                            prefix_result,
-                            engine=engine,
-                        )
-                    return _execute_compiled_query(
-                        compiled_base_graph,
+                    return _execute_compiled_query_with_reentry(
+                        self,
                         compiled_query=compiled_query,
                         engine=engine,
                         policy=expanded_policy,
                         context=context,
-                        start_nodes=start_nodes,
                     )
                 return _chain_dispatch(dispatch_self, query, engine, expanded_policy, context)
             elif isinstance(query, ASTObject):

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -230,6 +230,50 @@ def _mk_connected_multi_pattern_fanout_graph_cudf() -> _CypherTestGraph:
     )
 
 
+def _mk_multi_stage_reentry_graph() -> _CypherTestGraph:
+    return _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["a", "b", "c", "d", "e"],
+                "label__A": [True, False, False, False, False],
+                "label__B": [False, True, False, False, False],
+                "label__C": [False, False, True, False, False],
+                "label__D": [False, False, False, True, False],
+                "label__E": [False, False, False, False, True],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["a", "b", "c", "a", "b"],
+                "d": ["b", "c", "d", "e", "e"],
+                "type": ["R", "S", "T", "R", "S"],
+            }
+        ),
+    )
+
+
+def _mk_multi_stage_reentry_graph_cudf() -> _CypherTestGraph:
+    return _mk_cudf_graph(
+        pd.DataFrame(
+            {
+                "id": ["a", "b", "c", "d", "e"],
+                "label__A": [True, False, False, False, False],
+                "label__B": [False, True, False, False, False],
+                "label__C": [False, False, True, False, False],
+                "label__D": [False, False, False, True, False],
+                "label__E": [False, False, False, False, True],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["a", "b", "c", "a", "b"],
+                "d": ["b", "c", "d", "e", "e"],
+                "type": ["R", "S", "T", "R", "S"],
+            }
+        ),
+    )
+
+
 def _mk_multi_alias_edge_projection_graph() -> _CypherTestGraph:
     return _mk_graph(
         pd.DataFrame(
@@ -5847,7 +5891,7 @@ def test_string_cypher_failfast_rejects_with_match_reentry_multiple_trailing_mat
         "RETURN bid, d.id AS did"
     )
 
-    with pytest.raises(GFQLValidationError, match="single MATCH \\.\\.\\. WITH \\.\\.\\. MATCH \\.\\.\\. RETURN shape"):
+    with pytest.raises(GFQLSyntaxError, match="alternating MATCH \\.\\.\\. WITH \\.\\.\\. MATCH"):
         _mk_connected_multi_pattern_reentry_graph().gfql(query, params={"seed": "a1"})
 
 
@@ -5876,7 +5920,7 @@ def test_string_cypher_failfast_rejects_with_match_reentry_multiple_whole_row_al
         _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
 
 
-def test_string_cypher_failfast_rejects_with_match_reentry_cross_alias_carried_scalars_from_connected_prefix_shape() -> None:
+def test_string_cypher_executes_with_match_reentry_cross_alias_carried_scalars_from_connected_prefix_shape() -> None:
     query = (
         "MATCH (a:A {id: $seed})-[:R]->(b:B) "
         "WITH b, a.id AS aid "
@@ -5884,8 +5928,9 @@ def test_string_cypher_failfast_rejects_with_match_reentry_cross_alias_carried_s
         "RETURN aid, c.id AS cid"
     )
 
-    with pytest.raises(GFQLValidationError, match="one MATCH source alias at a time"):
-        _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
+    result = _mk_connected_reentry_carried_scalar_graph().gfql(query, params={"seed": "a1"})
+
+    assert result._nodes.to_dict(orient="records") == [{"aid": "a1", "cid": "c1"}]
 
 
 def test_string_cypher_reentry_carried_scalars_ignore_internal_hidden_column_collisions() -> None:
@@ -5990,26 +6035,17 @@ def test_string_cypher_executes_seeded_multihop_then_with_optional_match_reentry
     assert result._nodes.to_dict(orient="records") == [{"id": "d"}]
 
 
-def test_string_cypher_executes_multi_stage_with_match_reentry_connected_shape() -> None:
-    nodes = pd.DataFrame(
-        {
-            "id": ["a", "b", "c", "d", "e"],
-            "label__A": [True, False, False, False, False],
-            "label__B": [False, True, False, False, False],
-            "label__C": [False, False, True, False, False],
-            "label__D": [False, False, False, True, False],
-            "label__E": [False, False, False, False, True],
-        }
-    )
-    edges = pd.DataFrame(
-        {
-            "s": ["a", "b", "c", "a", "b"],
-            "d": ["b", "c", "d", "e", "e"],
-            "type": ["R", "S", "T", "R", "S"],
-        }
+def test_string_cypher_executes_connected_whole_row_plus_scalar_projection() -> None:
+    result = _mk_multi_stage_reentry_graph().gfql(
+        "MATCH (b:B)-[:S]->(c:C) "
+        "RETURN c, b.id AS bid"
     )
 
-    result = _mk_graph(nodes, edges).gfql(
+    assert result._nodes.to_dict(orient="records") == [{"c": "(:C)", "bid": "b"}]
+
+
+def test_string_cypher_executes_multi_stage_with_match_reentry_connected_shape() -> None:
+    result = _mk_multi_stage_reentry_graph().gfql(
         "MATCH (a:A)-[:R]->(b:B) "
         "WITH b "
         "MATCH (b)-[:S]->(c:C) "
@@ -6022,25 +6058,7 @@ def test_string_cypher_executes_multi_stage_with_match_reentry_connected_shape()
 
 
 def test_string_cypher_executes_multi_stage_with_match_reentry_carried_scalar_shape() -> None:
-    nodes = pd.DataFrame(
-        {
-            "id": ["a", "b", "c", "d", "e"],
-            "label__A": [True, False, False, False, False],
-            "label__B": [False, True, False, False, False],
-            "label__C": [False, False, True, False, False],
-            "label__D": [False, False, False, True, False],
-            "label__E": [False, False, False, False, True],
-        }
-    )
-    edges = pd.DataFrame(
-        {
-            "s": ["a", "b", "c", "a", "b"],
-            "d": ["b", "c", "d", "e", "e"],
-            "type": ["R", "S", "T", "R", "S"],
-        }
-    )
-
-    result = _mk_graph(nodes, edges).gfql(
+    result = _mk_multi_stage_reentry_graph().gfql(
         "MATCH (a:A)-[:R]->(b:B) "
         "WITH b, b.id AS bid "
         "MATCH (b)-[:S]->(c:C) "
@@ -6050,6 +6068,54 @@ def test_string_cypher_executes_multi_stage_with_match_reentry_carried_scalar_sh
     )
 
     assert result._nodes.to_dict(orient="records") == [{"bid": "b", "id": "d"}]
+
+
+def test_string_cypher_executes_multi_stage_with_match_reentry_connected_shape_on_cudf() -> None:
+    pytest.importorskip("cudf")
+
+    result = _mk_multi_stage_reentry_graph_cudf().gfql(
+        "MATCH (a:A)-[:R]->(b:B) "
+        "WITH b "
+        "MATCH (b)-[:S]->(c:C) "
+        "WITH c "
+        "MATCH (c)-[:T]->(d:D) "
+        "RETURN d.id AS id",
+        engine="cudf",
+    )
+
+    assert type(result._nodes).__module__.startswith("cudf")
+    assert result._nodes.to_pandas().to_dict(orient="records") == [{"id": "d"}]
+
+
+def test_string_cypher_executes_multi_stage_with_match_reentry_empty_result_shape() -> None:
+    result = _mk_multi_stage_reentry_graph().gfql(
+        "MATCH (a:A)-[:R]->(b:B) "
+        "WITH b "
+        "MATCH (b)-[:S]->(c:C) "
+        "WITH c "
+        "MATCH (c)-[:X]->(z:D) "
+        "RETURN z.id AS id"
+    )
+
+    assert result._nodes.to_dict(orient="records") == []
+
+
+def test_string_cypher_failfast_rejects_multi_stage_with_match_reentry_with_intermediate_where() -> None:
+    query = (
+        "MATCH (a:A)-[:R]->(b:B) "
+        "WITH b "
+        "MATCH (b)-[:S]->(c:C) "
+        "WHERE c.id = 'c' "
+        "WITH c "
+        "MATCH (c)-[:T]->(d:D) "
+        "RETURN d.id AS id"
+    )
+
+    with pytest.raises(
+        GFQLSyntaxError,
+        match="Cypher WITH after post-WITH MATCH WHERE is not yet supported",
+    ):
+        _mk_multi_stage_reentry_graph().gfql(query)
 
 
 def test_cypher_to_gfql_supports_multi_alias_scalar_projection() -> None:


### PR DESCRIPTION
## Summary
- add bounded support for alternating multi-stage reentry read shapes in direct Cypher:
  - `MATCH ... WITH ... MATCH ... WITH ... MATCH ... RETURN`
- extend bounded reentry lowering/runtime composition to recurse through nested `start_nodes_query` chains
- harden bindings-backed projection postprocessing so whole-row and qualified scalar carry columns remain recoverable across reentry stages
- add focused positive/negative amplification coverage, including cuDF validation

## Scope
Refs #999

This PR stays in the bounded reentry lane. It does not implement a broad row-carrier redesign (`#989`).

## Behavior
### Added
- parser now admits bounded alternating `MATCH/WITH` post-reentry chains ending in `RETURN`
- multi-stage connected whole-row reentry executes in local Cypher
- multi-stage carried-scalar reentry executes in the bounded connected subset

### Kept Failfast
- intermediate post-reentry `WHERE` followed by further `WITH/MATCH` remains explicit syntax failfast
- broader out-of-scope row-shaping remains failfast outside the bounded admitted subset

## Validation
### Local static
- `python -m py_compile` on touched files: pass
- `ruff check` on touched files: pass
- `./bin/typecheck.sh`: pass

### Local tests
- focused `#999` + amplification slice: `5 passed, 1 skipped`
- broader reentry slice: `37 passed, 8 skipped, 490 deselected`
- full lowering file: `486 passed, 49 skipped`

### DGX / cuDF
- host: `NVIDIA GB10, driver 580.126.09`
- official RAPIDS: `nvcr.io/nvidia/rapidsai/base:26.02-cuda13-py3.13`
- targeted cuDF slice:
  - `test_string_cypher_executes_with_match_reentry_carried_scalars_from_connected_prefix_shape_on_cudf`
  - `test_string_cypher_executes_multi_stage_with_match_reentry_connected_shape_on_cudf`
- result: `2 passed in 3.10s`

## Plan Record
- `plans/cypher-multi-stage-reentry/plan.md`
- `plans/cypher-multi-stage-reentry/rounds/round-002/execution-report.md`