### PR TITLE
fix(gfql): preserve open-range bindings serialization (#880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Fixed
+- **GFQL / bindings rows**: Native `rows()` and direct `rows(binding_ops=...)` now preserve open-range / fixed-point edge semantics during bindings serialization instead of collapsing those segments back to a single hop. This restores IS6-style multihop continuation row shaping from native GFQL chains under `#880`.
+
+### Tests
+- **GFQL / bindings rows**: Added benchmark-shaped regressions for native IS6-style multihop continuation plus direct Cypher IS1 / IS3 / IS6 projection shapes.
+
 ## [0.53.16 - 2026-04-01]
 
 ### Added

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -507,9 +507,24 @@ class ASTEdge(ASTObject):
     def to_json(self, validate=True) -> Dict[str, Any]:
         if validate:
             self.validate()
+        # Range and fixed-point edges carry their traversal bounds via
+        # min/max/to_fixed_point. Keeping the constructor default hops=1 in the
+        # serialized form narrows downstream binding-op replay back to a single hop.
+        serialized_hops = self.hops
+        if (
+            serialized_hops == DEFAULT_HOPS
+            and (
+                self.min_hops is not None
+                or self.max_hops is not None
+                or self.output_min_hops is not None
+                or self.output_max_hops is not None
+                or self.to_fixed_point
+            )
+        ):
+            serialized_hops = None
         return {
             'type': 'Edge',
-            'hops': self.hops,
+            'hops': serialized_hops,
             **({'min_hops': self.min_hops} if self.min_hops is not None else {}),
             **({'max_hops': self.max_hops} if self.max_hops is not None else {}),
             **({'output_min_hops': self.output_min_hops} if self.output_min_hops is not None else {}),

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -1270,6 +1270,82 @@ def test_string_cypher_formats_single_node_entity_projection_with_alias() -> Non
     assert entity_meta["ColumnName"]["ids"].tolist() == ["a"]
 
 
+def test_string_cypher_supports_is1_seed_city_projection_shape() -> None:
+    nodes = pd.DataFrame(
+        [
+            {"id": "p1", "labels": ["Person"], "label__Person": True, "firstName": "A"},
+            {"id": "c1", "labels": ["Place"], "label__Place": True, "name": "City"},
+        ]
+    )
+    edges = pd.DataFrame([{"s": "p1", "d": "c1", "type": "IS_LOCATED_IN"}])
+
+    result = _mk_graph(nodes, edges).gfql(
+        "MATCH (person:Person {id: 'p1'}) "
+        "MATCH (person)-[:IS_LOCATED_IN]->(city:Place) "
+        "RETURN person.id AS personId, city.id AS cityId, person.firstName AS firstName"
+    )
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"personId": "p1", "cityId": "c1", "firstName": "A"}
+    ]
+
+
+def test_string_cypher_supports_is3_seed_expand_projection_shape() -> None:
+    nodes = pd.DataFrame(
+        [
+            {"id": "p1", "labels": ["Person"], "label__Person": True, "firstName": "Seed"},
+            {"id": "p2", "labels": ["Person"], "label__Person": True, "firstName": "Friend"},
+        ]
+    )
+    edges = pd.DataFrame([{"s": "p2", "d": "p1", "type": "KNOWS", "creationDate": 123}])
+
+    result = _mk_graph(nodes, edges).gfql(
+        "MATCH (person:Person {id: 'p1'}) "
+        "MATCH (person)-[k:KNOWS]-(friend:Person) "
+        "RETURN friend.id AS friendId, friend.firstName AS firstName, k.creationDate AS friendshipCreationDate"
+    )
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"friendId": "p2", "firstName": "Friend", "friendshipCreationDate": 123}
+    ]
+
+
+def test_string_cypher_supports_is6_open_range_continuation_projection_shape() -> None:
+    nodes = pd.DataFrame(
+        [
+            {"id": "c1", "labels": ["Comment"], "label__Comment": True},
+            {"id": "m1", "labels": ["Message"], "label__Message": True},
+            {"id": "p1", "labels": ["Post"], "label__Post": True},
+            {"id": "f1", "labels": ["Forum"], "label__Forum": True, "title": "Forum"},
+            {
+                "id": "u1",
+                "labels": ["Person"],
+                "label__Person": True,
+                "firstName": "Mod",
+                "lastName": "Erator",
+            },
+        ]
+    )
+    edges = pd.DataFrame(
+        [
+            {"s": "c1", "d": "m1", "type": "REPLY_OF"},
+            {"s": "m1", "d": "p1", "type": "REPLY_OF"},
+            {"s": "f1", "d": "p1", "type": "CONTAINER_OF"},
+            {"s": "f1", "d": "u1", "type": "HAS_MODERATOR"},
+        ]
+    )
+
+    result = _mk_graph(nodes, edges).gfql(
+        "MATCH (message:Comment {id: 'c1'})-[:REPLY_OF*0..]->(post:Post)"
+        "<-[:CONTAINER_OF]-(forum:Forum)-[:HAS_MODERATOR]->(moderator:Person) "
+        "RETURN forum.id AS forumId, moderator.id AS moderatorId"
+    )
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"forumId": "f1", "moderatorId": "u1"}
+    ]
+
+
 def test_compile_cypher_records_mixed_whole_row_projection_plan() -> None:
     compiled = _compile_query("MATCH (p:Person) RETURN p AS person, p.name AS person_name")
 

--- a/graphistry/tests/compute/test_ast.py
+++ b/graphistry/tests/compute/test_ast.py
@@ -21,3 +21,18 @@ def test_serialization_edge():
     assert edge2._name == 'abc'
     o2 = edge2.to_json()
     assert o == o2
+
+
+def test_serialization_edge_open_range_does_not_collapse_to_single_hop():
+
+    edge = e_forward({"type": "REPLY_OF"}, min_hops=0, to_fixed_point=True)
+    o = edge.to_json(validate=False)
+    assert o["hops"] is None
+    assert o["min_hops"] == 0
+    assert o["to_fixed_point"] is True
+
+    edge2 = from_json(o, validate=False)
+    assert isinstance(edge2, ASTEdge)
+    assert edge2.hops is None
+    assert edge2.min_hops == 0
+    assert edge2.to_fixed_point is True

--- a/graphistry/tests/test_compute_chain.py
+++ b/graphistry/tests/test_compute_chain.py
@@ -1309,6 +1309,91 @@ class TestChainBindingsTable(NoAuthTestCase):
             {"personId": "b", "created": 123}
         ]
 
+    def test_native_chain_rows_bindings_open_range_continues_after_multihop(self):
+        """IS6-style open-range reply chains should continue into downstream bindings."""
+        g = self._mk_graph(
+            pd.DataFrame(
+                [
+                    {"id": "c1", "labels": ["Comment"], "label__Comment": True},
+                    {"id": "m1", "labels": ["Message"], "label__Message": True},
+                    {"id": "p1", "labels": ["Post"], "label__Post": True},
+                    {"id": "f1", "labels": ["Forum"], "label__Forum": True, "title": "Forum"},
+                    {
+                        "id": "u1",
+                        "labels": ["Person"],
+                        "label__Person": True,
+                        "firstName": "Mod",
+                        "lastName": "Erator",
+                    },
+                ]
+            ),
+            pd.DataFrame(
+                [
+                    {"s": "c1", "d": "m1", "type": "REPLY_OF"},
+                    {"s": "m1", "d": "p1", "type": "REPLY_OF"},
+                    {"s": "f1", "d": "p1", "type": "CONTAINER_OF"},
+                    {"s": "f1", "d": "u1", "type": "HAS_MODERATOR"},
+                ]
+            ),
+        )
+        records = self._rows_records(
+            g,
+            [
+                n({"id": "c1", "label__Comment": True}, name="message"),
+                e_forward({"type": "REPLY_OF"}, min_hops=0, to_fixed_point=True),
+                n({"label__Post": True}, name="post"),
+                e_reverse({"type": "CONTAINER_OF"}),
+                n({"label__Forum": True}, name="forum"),
+                e_forward({"type": "HAS_MODERATOR"}),
+                n({"label__Person": True}, name="moderator"),
+            ],
+            items=[("forumId", "forum.id"), ("moderatorId", "moderator.id")],
+        )
+        assert records == [{"forumId": "f1", "moderatorId": "u1"}]
+
+    def test_direct_rows_binding_ops_supports_open_range_multihop_continuation(self):
+        """Direct rows(binding_ops=...) should preserve open-range multihop semantics."""
+        g = self._mk_graph(
+            pd.DataFrame(
+                [
+                    {"id": "c1", "labels": ["Comment"], "label__Comment": True},
+                    {"id": "m1", "labels": ["Message"], "label__Message": True},
+                    {"id": "p1", "labels": ["Post"], "label__Post": True},
+                    {"id": "f1", "labels": ["Forum"], "label__Forum": True, "title": "Forum"},
+                    {
+                        "id": "u1",
+                        "labels": ["Person"],
+                        "label__Person": True,
+                        "firstName": "Mod",
+                        "lastName": "Erator",
+                    },
+                ]
+            ),
+            pd.DataFrame(
+                [
+                    {"s": "c1", "d": "m1", "type": "REPLY_OF"},
+                    {"s": "m1", "d": "p1", "type": "REPLY_OF"},
+                    {"s": "f1", "d": "p1", "type": "CONTAINER_OF"},
+                    {"s": "f1", "d": "u1", "type": "HAS_MODERATOR"},
+                ]
+            ),
+        )
+        binding_ops = [
+            n({"id": "c1", "label__Comment": True}, name="message").to_json(validate=False),
+            e_forward({"type": "REPLY_OF"}, min_hops=0, to_fixed_point=True).to_json(validate=False),
+            n({"label__Post": True}, name="post").to_json(validate=False),
+            e_reverse({"type": "CONTAINER_OF"}).to_json(validate=False),
+            n({"label__Forum": True}, name="forum").to_json(validate=False),
+            e_forward({"type": "HAS_MODERATOR"}).to_json(validate=False),
+            n({"label__Person": True}, name="moderator").to_json(validate=False),
+        ]
+        records = self._binding_rows_records(
+            g,
+            binding_ops,
+            items=[("forumId", "forum.id"), ("moderatorId", "moderator.id")],
+        )
+        assert records == [{"forumId": "f1", "moderatorId": "u1"}]
+
     def test_direct_rows_binding_ops_rejects_duplicate_alias_names(self):
         """Direct rows(binding_ops=...) should reject duplicate aliases."""
         g = self._mk_graph(


### PR DESCRIPTION
## Summary
Fix the native GFQL bindings-table serialization bug that was collapsing open-range/fixed-point edge segments back to a single hop during rows() / rows(binding_ops=...) replay.

## What changed
- normalize edge JSON serialization so range/fixed-point segments do not emit the constructor default hops=1
- add native GFQL regressions for the IS6-style multihop continuation shape in both bare rows() and direct rows(binding_ops=...)
- add benchmark-shaped Cypher regressions for IS1 / IS3 / IS6 shapes that currently work on master
- add a Development changelog entry

## Scope note
This clears the confirmed residual #880 multihop bindings bug behind IS6-style native/workaround paths.
IS7 remains the separate #996 OPTIONAL MATCH lane; this PR does not claim to solve it.

## Verification
- python3.12 -B -m pytest -q graphistry/tests/compute/test_ast.py graphistry/tests/test_compute_chain.py -k "open_range or ChainBindingsTable"
- python3.12 -B -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "is1_seed_city_projection_shape or is3_seed_expand_projection_shape or is6_open_range_continuation_projection_shape"
