### PR TITLE
feat(cypher): support WITH collect/UNWIND/MATCH reentry (#1000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Fixed
+- **GFQL / Cypher**: Support `WITH scalar, collect(alias) AS list UNWIND list AS alias MATCH ... RETURN` queries where carried scalars accompany the `collect()`. Previously only the single-item `WITH collect(alias) AS list` shape was supported (#1000).
 - **GFQL / bindings rows**: Native `rows()` and direct `rows(binding_ops=...)` now preserve open-range / fixed-point edge semantics during bindings serialization instead of collapsing those segments back to a single hop. This restores IS6-style multihop continuation row shaping from native GFQL chains under `#880`.
 - **GFQL / Cypher**: Removed guard that rejected multi-hop connected patterns with edge alias projections (e.g., `MATCH (a)-[r:R]->(b)-[s:S]->(c) RETURN r.since, c.id`). The runtime bindings table already handles this correctly (#880).
 

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -5974,36 +5974,51 @@ def _rewrite_collect_unwind_reentry_query(query: CypherQuery) -> Optional[Cypher
         or prefix_stage.order_by is not None
         or prefix_stage.skip is not None
         or prefix_stage.limit is not None
-        or len(prefix_stage.clause.items) != 1
+        or len(prefix_stage.clause.items) < 1
     ):
         return None
-    collected_item = prefix_stage.clause.items[0]
-    collected_output_name = collected_item.alias or collected_item.expression.text
     unwind_clause = query.unwinds[0]
-    if unwind_clause.expression.text != collected_output_name:
-        return None
-    collected_match = re.fullmatch(
-        r"collect\(\s*(distinct\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\)",
-        collected_item.expression.text,
-        flags=re.IGNORECASE,
-    )
-    if collected_match is None:
+    # Find the collect(...) item that feeds the UNWIND
+    collected_idx: Optional[int] = None
+    collected_match_result: Optional[re.Match[str]] = None
+    for idx, item in enumerate(prefix_stage.clause.items):
+        output_name = item.alias or item.expression.text
+        if output_name != unwind_clause.expression.text:
+            continue
+        m = re.fullmatch(
+            r"collect\(\s*(distinct\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\)",
+            item.expression.text,
+            flags=re.IGNORECASE,
+        )
+        if m is not None:
+            collected_idx = idx
+            collected_match_result = m
+            break
+    if collected_idx is None or collected_match_result is None:
         return None
     reentry_alias = _first_pattern_node_alias(query.reentry_matches[0])
     if reentry_alias is None or reentry_alias != unwind_clause.alias:
         return None
-    source_alias = collected_match.group(2)
+    collected_item = prefix_stage.clause.items[collected_idx]
+    source_alias = collected_match_result.group(2)
     rewritten_item = replace(
         collected_item,
         expression=ExpressionText(text=source_alias, span=collected_item.expression.span),
         alias=unwind_clause.alias,
     )
+    # Rebuild items: put the whole-row alias first, then carried scalars.
+    # The reentry machinery expects the whole-row alias to be the primary
+    # projection source, so it must come first.
+    other_items = tuple(
+        item for i, item in enumerate(prefix_stage.clause.items) if i != collected_idx
+    )
+    rewritten_items = (rewritten_item,) + other_items
     rewritten_prefix_stage = replace(
         prefix_stage,
         clause=replace(
             prefix_stage.clause,
-            items=(rewritten_item,),
-            distinct=bool(collected_match.group(1)),
+            items=rewritten_items,
+            distinct=bool(collected_match_result.group(1)),
         ),
     )
     return replace(query, with_stages=(rewritten_prefix_stage,), unwinds=())

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -188,6 +188,28 @@ def _mk_connected_multi_pattern_reentry_graph() -> _CypherTestGraph:
     )
 
 
+def _mk_collect_unwind_reentry_graph() -> _CypherTestGraph:
+    """Graph for WITH collect(...) UNWIND ... MATCH tests: s->b1->c1, s->b2->c2."""
+    return _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["s", "b1", "b2", "c1", "c2"],
+                "label__S": [True, False, False, False, False],
+                "label__B": [False, True, True, False, False],
+                "label__C": [False, False, False, True, True],
+                "val": [0, 10, 20, 100, 200],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["s", "s", "b1", "b2"],
+                "d": ["b1", "b2", "c1", "c2"],
+                "type": ["X", "X", "Y", "Y"],
+            }
+        ),
+    )
+
+
 def _mk_connected_multi_pattern_fanout_graph() -> _CypherTestGraph:
     return _mk_graph(
         pd.DataFrame(
@@ -3000,6 +3022,41 @@ def test_string_cypher_executes_graph_backed_distinct_unwind_after_with_into_pos
 
 def test_string_cypher_executes_graph_backed_unwind_with_carried_scalar_into_post_with_match() -> None:
     """IC-6 shape: WITH scalar, collect(alias) AS list UNWIND list AS alias MATCH ... RETURN (#1000)."""
+    graph = _mk_collect_unwind_reentry_graph()
+    _assert_query_rows(
+        "MATCH (root:S)-[:X]->(b1:B) "
+        "WITH root.val AS rv, collect(b1) AS bees "
+        "UNWIND bees AS b2 "
+        "MATCH (b2)-[:Y]->(c:C) "
+        "RETURN rv, c.id AS cid "
+        "ORDER BY cid",
+        [{"rv": 0, "cid": "c1"}, {"rv": 0, "cid": "c2"}],
+        nodes_df=graph._nodes,
+        edges_df=graph._edges,
+    )
+
+
+def test_string_cypher_executes_graph_backed_unwind_with_multiple_carried_scalars() -> None:
+    """Multiple carried scalars alongside collect (#1000)."""
+    graph = _mk_collect_unwind_reentry_graph()
+    _assert_query_rows(
+        "MATCH (root:S)-[:X]->(b1:B) "
+        "WITH root.id AS rid, root.val AS rv, collect(b1) AS bees "
+        "UNWIND bees AS b2 "
+        "MATCH (b2)-[:Y]->(c:C) "
+        "RETURN rid, rv, c.id AS cid "
+        "ORDER BY cid",
+        [{"rid": "s", "rv": 0, "cid": "c1"}, {"rid": "s", "rv": 0, "cid": "c2"}],
+        nodes_df=graph._nodes,
+        edges_df=graph._edges,
+    )
+
+
+def test_string_cypher_executes_graph_backed_distinct_unwind_with_carried_scalar() -> None:
+    """DISTINCT collect with carried scalar (#1000).
+
+    Uses a graph with duplicate s->b1 edges to exercise the DISTINCT path.
+    """
     graph = _mk_graph(
         pd.DataFrame(
             {
@@ -3012,16 +3069,15 @@ def test_string_cypher_executes_graph_backed_unwind_with_carried_scalar_into_pos
         ),
         pd.DataFrame(
             {
-                "s": ["s", "s", "b1", "b2"],
-                "d": ["b1", "b2", "c1", "c2"],
-                "type": ["X", "X", "Y", "Y"],
+                "s": ["s", "s", "s", "b1", "b2"],
+                "d": ["b1", "b1", "b2", "c1", "c2"],
+                "type": ["X", "X", "X", "Y", "Y"],
             }
         ),
     )
-
     _assert_query_rows(
         "MATCH (root:S)-[:X]->(b1:B) "
-        "WITH root.val AS rv, collect(b1) AS bees "
+        "WITH root.val AS rv, collect(DISTINCT b1) AS bees "
         "UNWIND bees AS b2 "
         "MATCH (b2)-[:Y]->(c:C) "
         "RETURN rv, c.id AS cid "


### PR DESCRIPTION
## Summary

Support `WITH scalar, collect(alias) AS list UNWIND list AS alias MATCH ... RETURN` Cypher queries where carried scalars accompany the `collect()`. Previously only the single-item `WITH collect(alias) AS list` shape was supported.

Closes #1000

## Benchmark impact

Unblocks LDBC SNB Interactive:
- **interactive-complex-9** (recent messages by friends/friends-of-friends)
- **interactive-complex-6** (tag co-occurrence)

## Fix

`_rewrite_collect_unwind_reentry_query()` in `lowering.py` now:
1. Scans all WITH items to find the `collect()` (not just the first/only)
2. Rewrites the collect item and preserves other items as carried scalars
3. Places the whole-row alias first so `_compile_bounded_reentry_query()` correctly identifies it

## Test plan

- [x] 3 new tests: single scalar, multiple scalars, DISTINCT collect with scalar
- [x] 510 lowering tests pass, 0 failures
- [x] Lint clean
- [ ] CI green