### PR TITLE
fix(cypher): tackle #1000 IC6 residual UNWIND/MATCH gap

### DIFF
--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -223,6 +223,25 @@ def _mk_collect_unwind_reentry_graph() -> _CypherTestGraph:
     )
 
 
+def _issue_1000_ic6_query() -> str:
+    return (
+        "MATCH (knownTag:Tag { name: $tagName }) "
+        "WITH knownTag.id as knownTagId "
+        "MATCH (person:Person { id: $personId })-[:KNOWS*1..2]-(friend) "
+        "WHERE NOT person=friend "
+        "WITH knownTagId, collect(distinct friend) as friends "
+        "UNWIND friends as f "
+        "MATCH (f)<-[:HAS_CREATOR]-(post:Post), "
+        "(post)-[:HAS_TAG]->(t:Tag{id: knownTagId}), "
+        "(post)-[:HAS_TAG]->(tag:Tag) "
+        "WHERE NOT t = tag "
+        "WITH tag.name as tagName, count(post) as postCount "
+        "RETURN tagName, postCount "
+        "ORDER BY postCount DESC, tagName ASC "
+        "LIMIT 10"
+    )
+
+
 def _mk_connected_multi_pattern_fanout_graph() -> _CypherTestGraph:
     return _mk_graph(
         pd.DataFrame(
@@ -3427,6 +3446,17 @@ def test_string_cypher_rejects_with_unwind_reentry_when_unwind_source_is_not_col
         "currently supports only a single WITH collect([distinct] alias) AS list "
         "UNWIND list AS alias MATCH ... RETURN shape"
     ) in exc_info.value.message
+
+
+def test_string_cypher_repro_issue_1000_ic6_current_parser_gap() -> None:
+    with pytest.raises(GFQLSyntaxError, match="Invalid Cypher query syntax"):
+        compile_cypher(
+            _issue_1000_ic6_query(),
+            params={
+                "personId": 4398046511333,
+                "tagName": "Carl_Gustaf_Emil_Mannerheim",
+            },
+        )
 
 
 def test_string_cypher_executes_exact_multihop_relationship_pattern() -> None:


### PR DESCRIPTION
## Summary
- keep the exact official `interactive-complex-6` direct-Cypher repro anchored in one umbrella branch
- record the decomposition and current stack for `#1000`
- keep implementation landing work on the narrower stacked PRs instead of trying to merge this umbrella branch

## Links
- Refs #1000
- Umbrella issue: https://github.com/graphistry/pygraphistry/issues/1000
- Residual repro comment: https://github.com/graphistry/pygraphistry/issues/1000#issuecomment-4175109382
- Phase 1 PR: https://github.com/graphistry/pygraphistry/pull/1027
- Phase 2 PR: https://github.com/graphistry/pygraphistry/pull/1028
- Phase 3 PR: https://github.com/graphistry/pygraphistry/pull/1029
- Phase 4 PR: https://github.com/graphistry/pygraphistry/pull/1032
- Phase 5 PR: https://github.com/graphistry/pygraphistry/pull/1034
- Phase 6 PR: https://github.com/graphistry/pygraphistry/pull/1035
- Phase 7 PR: https://github.com/graphistry/pygraphistry/pull/1036
- Phase 8 PR: https://github.com/graphistry/pygraphistry/pull/1037

## Current status
- still draft
- still the umbrella exploration / decomposition PR, not the merge vehicle
- exact benchmark-shaped RED repro remains anchored here
- the implementation stack has now advanced to a point where exact official IC6 is green on the top stacked PR

## Latest outcome
- exact official `interactive-complex-6` Cypher now passes in-tree on #1037
- dataset-backed `dgx-spark` host-CPU conformance rerun now reports `cypher = ok`
- targeted `dgx-spark` RAPIDS spot checks pass on the new multihop row-binding cuDF lane
- nothing in this umbrella PR is intended for merge while the stacked slices remain the real delivery path