### PR TITLE
test(cypher): update xfail issue ref #1045 → #1054

### DIFF
--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -10231,7 +10231,7 @@ def test_string_cypher_multi_alias_with_extend_scalar_in_case() -> None:
 
 
 @pytest.mark.xfail(
-    reason="WITH aggregate uses entity blob for whole-row alias, losing per-alias column access in subsequent RETURN (#1045)",
+    reason="WITH aggregate uses entity blob for whole-row alias, losing per-alias column access in subsequent RETURN (#1054)",
     strict=True,
 )
 def test_string_cypher_multi_alias_with_four_stage_chain() -> None:


### PR DESCRIPTION
Updates the xfail reason on `test_string_cypher_multi_alias_with_four_stage_chain` to reference the new dedicated issue #1054 (entity-blob group key bug) rather than the now-closed umbrella #1045.

One-line change, no logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)