### PR TITLE
ci: cache generate-lockfiles to skip ~47s on unchanged deps (#1076)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 
   #Enable UI-driven branch testing
   workflow_dispatch:
+    inputs:
+      cooldown_days:
+        description: 'Lockfile cooldown days (0 = no cooldown/force-refresh, default 6)'
+        required: false
+        default: '6'
 
   #Test main bidaily @ 1a
   schedule:
@@ -155,13 +160,13 @@ jobs:
       uses: actions/cache@v4
       with:
         path: requirements/*.lock
-        key: lockfiles-${{ hashFiles('setup.py', 'pyproject.toml', 'requirements/*.txt', 'bin/generate-lockfiles.sh') }}
+        key: lockfiles-cd${{ inputs.cooldown_days || '6' }}-${{ hashFiles('setup.py', 'pyproject.toml', 'requirements/*.txt', 'bin/generate-lockfiles.sh') }}
     - name: Install uv
       if: steps.lockfile-cache.outputs.cache-hit != 'true'
       run: pip install "uv==0.11.3"  # pinned version; bump periodically
     - name: Generate lockfiles
       if: steps.lockfile-cache.outputs.cache-hit != 'true'
-      run: ./bin/generate-lockfiles.sh
+      run: COOLDOWN_DAYS=${{ inputs.cooldown_days || '6' }} ./bin/generate-lockfiles.sh
     - name: Upload lockfiles
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Summary
- Adds \`actions/cache@v4\` to the \`generate-lockfiles\` job, keyed on \`setup.py\`, \`pyproject.toml\`, \`requirements/*.txt\`, and \`bin/generate-lockfiles.sh\`
- On cache hit, the \`uv\` install and lockfile generation steps are skipped entirely
- \`upload-artifact\` always runs so downstream jobs always receive the lockfiles (from cache or freshly generated)
- Adds \`cooldown_days\` \`workflow_dispatch\` input (default \`6\`) — pass \`0\` to force-refresh all lockfiles; value is included in the cache key so a \`cd0\` run always misses and stores its own entry

## Observed speedup
| Run type | \`generate-lockfiles\` duration |
|---|---|
| Cold miss (first run / deps changed) | ~26s |
| Cache hit (same deps) | ~6s |

**~20s saved on cache hit** (issue estimated ~47s; actual varies by runner load).

## Test plan
- [x] Cold miss: CI run 24055215908 — Install uv + Generate lockfiles ran, cache stored
- [x] Cache hit: CI run 24055236377 — Install uv + Generate lockfiles skipped, Upload lockfiles succeeded
- [x] Cache bust (\`cooldown_days=0\`): CI run 24055315814 — new key \`cd0-<hash>\` missed, generation ran
- [x] All PR checks green

Closes #1076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)