### PR TITLE
test(gfql/m1): enforce binder semantic conformance gate (#1114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **CI / docs**: `test-readme` no longer runs `actions/setup-python` with an EOL Python 3.8 pin. The job now runs markdown lint directly via its Docker image, removing an unnecessary setup step and avoiding intermittent Python toolcache fetch timeouts.
 - **CI / build lane**: `test-build` now runs on Python 3.14 with `build-py3.14.lock` instead of a fixed Python 3.8 runner, reducing reliance on EOL interpreter setup while preserving explicit 3.8 compatibility test lanes elsewhere in CI.
 
+### Tests
+- **GFQL / Cypher binder**: Added PR-4 white-box binder semantic conformance coverage for name resolution success/failure (including unresolved alias errors), WITH scope-reset visibility, OPTIONAL MATCH `null_extended_from` lineage as `frozenset` clause ids, label narrowing from MATCH labels + conjunctive `WHERE alias:Label` checks, and SchemaConfidence rules (min-rule propagation, operand inheritance, and strong literal/`COUNT` behavior). Parser/lowering regression lanes remain green.
+
 ## [0.54.1 - 2026-04-08]
 
 ### Infrastructure

--- a/graphistry/compute/gfql/frontends/cypher/binder.py
+++ b/graphistry/compute/gfql/frontends/cypher/binder.py
@@ -17,6 +17,7 @@ from graphistry.compute.gfql.cypher.ast import (
     CypherUnionQuery,
     ExpressionText,
     GraphConstructor,
+    LabelRef,
     MatchClause,
     NodePattern,
     ParameterRef,
@@ -28,7 +29,9 @@ from graphistry.compute.gfql.cypher.ast import (
     ReturnItem,
     UnwindClause,
     WhereClause,
+    WherePredicate,
 )
+from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 from graphistry.compute.gfql.ir.bound_ir import BoundIR, BoundQueryPart, BoundVariable, ScopeFrame, SemanticTable
 from graphistry.compute.gfql.ir.compilation import PlanContext
 from graphistry.compute.gfql.ir.logical_plan import RowSchema
@@ -80,6 +83,8 @@ _KEYWORDS: FrozenSet[str] = frozenset(
 _IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _PROPERTY_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
 _PARAMETER_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
+_COUNT_CALL_RE = re.compile(r"(?i)^count\s*\(")
+_WHERE_LABEL_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([A-Za-z_][A-Za-z0-9_]*)")
 
 
 @dataclass
@@ -93,12 +98,13 @@ class _BindState:
     parameter_names: Set[str] = field(default_factory=set)
     next_scope_id: int = 1
     optional_arm_count: int = 0
+    strict_name_resolution: bool = False
 
 
 class FrontendBinder:
     """Typed binder interface for Cypher frontend ASTs."""
 
-    def bind(self, ast: CypherAST, ctx: PlanContext) -> BoundIR:
+    def bind(self, ast: CypherAST, ctx: PlanContext, *, strict_name_resolution: bool = False) -> BoundIR:
         """Bind frontend AST into frontend-neutral IR.
 
         Binder semantics are intentionally conservative in this stage: when a
@@ -106,13 +112,13 @@ class FrontendBinder:
         scalar types and nullable=True.
         """
         if isinstance(ast, CypherUnionQuery):
-            return self._bind_union_query(ast=ast, ctx=ctx)
+            return self._bind_union_query(ast=ast, ctx=ctx, strict_name_resolution=strict_name_resolution)
         if isinstance(ast, CypherGraphQuery):
-            return self._bind_graph_query(ast=ast, ctx=ctx)
-        return self._bind_query(ast=ast, ctx=ctx)
+            return self._bind_graph_query(ast=ast, ctx=ctx, strict_name_resolution=strict_name_resolution)
+        return self._bind_query(ast=ast, ctx=ctx, strict_name_resolution=strict_name_resolution)
 
-    def _bind_query(self, ast: CypherQuery, ctx: PlanContext) -> BoundIR:
-        state = _BindState()
+    def _bind_query(self, ast: CypherQuery, ctx: PlanContext, *, strict_name_resolution: bool) -> BoundIR:
+        state = _BindState(strict_name_resolution=strict_name_resolution)
         _collect_parameter_names(ast, out=state.parameter_names)
 
         if ast.row_sequence and not ast.matches and not ast.reentry_matches:
@@ -126,8 +132,8 @@ class FrontendBinder:
 
         return _finalize_bound_ir(state=state, ctx=ctx)
 
-    def _bind_union_query(self, ast: CypherUnionQuery, ctx: PlanContext) -> BoundIR:
-        branch_irs = [self._bind_query(branch, ctx=ctx) for branch in ast.branches]
+    def _bind_union_query(self, ast: CypherUnionQuery, ctx: PlanContext, *, strict_name_resolution: bool) -> BoundIR:
+        branch_irs = [self._bind_query(branch, ctx=ctx, strict_name_resolution=strict_name_resolution) for branch in ast.branches]
         union_scope: Dict[str, BoundVariable] = {}
         union_conf: Dict[str, SchemaConfidence] = {}
 
@@ -204,12 +210,16 @@ class FrontendBinder:
             params=merged_params,
         )
 
-    def _bind_graph_query(self, ast: CypherGraphQuery, ctx: PlanContext) -> BoundIR:
+    def _bind_graph_query(self, ast: CypherGraphQuery, ctx: PlanContext, *, strict_name_resolution: bool) -> BoundIR:
         graph_binding_parts: List[BoundQueryPart] = []
         graph_binding_params: Set[str] = set()
 
         for binding in ast.graph_bindings:
-            bound = self._bind_graph_constructor(binding.constructor, ctx=ctx)
+            bound = self._bind_graph_constructor(
+                binding.constructor,
+                ctx=ctx,
+                strict_name_resolution=strict_name_resolution,
+            )
             graph_binding_parts.extend(bound.query_parts)
             graph_binding_parts.append(
                 BoundQueryPart(
@@ -225,7 +235,11 @@ class FrontendBinder:
             )
             graph_binding_params.update(_parameter_name_set(bound))
 
-        constructor_bound = self._bind_graph_constructor(ast.constructor, ctx=ctx)
+        constructor_bound = self._bind_graph_constructor(
+            ast.constructor,
+            ctx=ctx,
+            strict_name_resolution=strict_name_resolution,
+        )
         final_params = dict(constructor_bound.params)
         param_names = set(_parameter_name_set(constructor_bound))
         param_names.update(graph_binding_params)
@@ -238,8 +252,14 @@ class FrontendBinder:
             params=final_params,
         )
 
-    def _bind_graph_constructor(self, constructor: GraphConstructor, ctx: PlanContext) -> BoundIR:
-        state = _BindState()
+    def _bind_graph_constructor(
+        self,
+        constructor: GraphConstructor,
+        ctx: PlanContext,
+        *,
+        strict_name_resolution: bool,
+    ) -> BoundIR:
+        state = _BindState(strict_name_resolution=strict_name_resolution)
         _collect_parameter_names(constructor, out=state.parameter_names)
 
         for clause in constructor.matches:
@@ -346,6 +366,7 @@ class FrontendBinder:
         if clause.where is not None:
             predicates.extend(_where_predicates(clause.where))
             _collect_parameter_names(clause.where, out=state.parameter_names)
+            changed_aliases.update(_apply_where_label_narrowing(state=state, where=clause.where))
 
         outputs = frozenset(state.scope.keys())
         schema_update = {name: state.scope_confidence[name] for name in sorted(changed_aliases) if name in state.scope_confidence}
@@ -401,6 +422,7 @@ class FrontendBinder:
             expression=clause.expression,
             scope=state.scope,
             confidence=state.scope_confidence,
+            strict_name_resolution=state.strict_name_resolution,
         )
         _collect_parameter_names(clause.expression, out=state.parameter_names)
 
@@ -477,6 +499,7 @@ class FrontendBinder:
                 expression=item.expression,
                 scope=state.scope,
                 confidence=state.scope_confidence,
+                strict_name_resolution=state.strict_name_resolution,
             )
             _collect_parameter_names(item.expression, out=state.parameter_names)
             next_scope[out_name] = BoundVariable(
@@ -669,8 +692,18 @@ def _infer_expression_binding(
     expression: ExpressionText,
     scope: Mapping[str, BoundVariable],
     confidence: Mapping[str, SchemaConfidence],
+    strict_name_resolution: bool,
 ) -> _ExpressionBinding:
     text = expression.text.strip()
+    if _COUNT_CALL_RE.match(text):
+        return _ExpressionBinding(
+            logical_type=ScalarType(kind="int64", nullable=False),
+            entity_kind="scalar",
+            nullable=False,
+            null_extended_from=frozenset(),
+            schema_confidence="declared",
+        )
+
     direct = scope.get(text)
     if direct is not None:
         return _ExpressionBinding(
@@ -685,14 +718,26 @@ def _infer_expression_binding(
     if prop_match is not None:
         alias = prop_match.group(1)
         source = scope.get(alias)
-        if source is not None:
+        if source is None and strict_name_resolution:
+            raise _unresolved_name_error(identifier=alias, visible_scope=scope)
+        if source is None:
             return _ExpressionBinding(
                 logical_type=ScalarType(kind="unknown", nullable=True),
                 entity_kind="scalar",
                 nullable=True,
-                null_extended_from=source.null_extended_from,
-                schema_confidence=_demote_confidence(confidence.get(alias, "propagated")),
+                null_extended_from=frozenset(),
+                schema_confidence="inferred",
             )
+        return _ExpressionBinding(
+            logical_type=ScalarType(kind="unknown", nullable=True),
+            entity_kind="scalar",
+            nullable=True,
+            null_extended_from=source.null_extended_from,
+            schema_confidence=_demote_confidence(confidence.get(alias, "propagated")),
+        )
+
+    if strict_name_resolution and _is_bare_identifier(text) and text not in scope:
+        raise _unresolved_name_error(identifier=text, visible_scope=scope)
 
     if _is_bool_literal(text):
         return _ExpressionBinding(
@@ -759,13 +804,15 @@ def _infer_expression_binding(
     refs = _referenced_aliases(text=text, scope=scope)
     null_extended_from: FrozenSet[str] = frozenset()
     nullable = True
-    schema_conf: SchemaConfidence = "inferred"
+    schema_conf: SchemaConfidence = "declared"
 
     if refs:
         nullable = any(scope[ref].nullable for ref in refs)
         for ref in refs:
             null_extended_from |= scope[ref].null_extended_from
-            schema_conf = _merge_confidence(schema_conf, confidence.get(ref, "inferred"))
+            schema_conf = _min_rule_confidence(schema_conf, confidence.get(ref, "inferred"))
+    else:
+        schema_conf = "inferred"
 
     return _ExpressionBinding(
         logical_type=ScalarType(kind="unknown", nullable=nullable),
@@ -781,8 +828,14 @@ def _infer_unwind_binding(
     expression: ExpressionText,
     scope: Mapping[str, BoundVariable],
     confidence: Mapping[str, SchemaConfidence],
+    strict_name_resolution: bool,
 ) -> _ExpressionBinding:
-    expr_binding = _infer_expression_binding(expression=expression, scope=scope, confidence=confidence)
+    expr_binding = _infer_expression_binding(
+        expression=expression,
+        scope=scope,
+        confidence=confidence,
+        strict_name_resolution=strict_name_resolution,
+    )
     expr_type = expr_binding.logical_type
     if isinstance(expr_type, ListType):
         return _ExpressionBinding(
@@ -883,6 +936,41 @@ def _where_predicates(where: WhereClause) -> List[BoundPredicate]:
     return predicates
 
 
+def _apply_where_label_narrowing(state: _BindState, where: WhereClause) -> Set[str]:
+    narrowed: Dict[str, Set[str]] = {}
+
+    for term in where.predicates:
+        if isinstance(term, WherePredicate) and term.op == "has_labels" and isinstance(term.left, LabelRef):
+            labels = narrowed.setdefault(term.left.alias, set())
+            labels.update(term.left.labels)
+
+    if where.expr is not None:
+        for alias, label in _WHERE_LABEL_RE.findall(where.expr.text):
+            labels = narrowed.setdefault(alias, set())
+            labels.add(label)
+
+    changed: Set[str] = set()
+    for alias, labels in narrowed.items():
+        existing = state.scope.get(alias)
+        if existing is None:
+            continue
+        if existing.entity_kind != "node" or not isinstance(existing.logical_type, NodeRef):
+            continue
+        updated_labels = existing.logical_type.labels | frozenset(labels)
+        state.scope[alias] = BoundVariable(
+            name=existing.name,
+            logical_type=NodeRef(labels=updated_labels),
+            nullable=existing.nullable,
+            null_extended_from=existing.null_extended_from,
+            entity_kind=existing.entity_kind,
+            scope_id=existing.scope_id,
+        )
+        state.scope_confidence[alias] = _min_rule_confidence(state.scope_confidence.get(alias, "declared"), "declared")
+        changed.add(alias)
+
+    return changed
+
+
 def _referenced_aliases(text: str, scope: Mapping[str, BoundVariable]) -> Set[str]:
     refs: Set[str] = set()
 
@@ -949,6 +1037,10 @@ def _merge_entity_kind(
 
 
 def _merge_confidence(left: SchemaConfidence, right: SchemaConfidence) -> SchemaConfidence:
+    return _min_rule_confidence(left, right)
+
+
+def _min_rule_confidence(left: SchemaConfidence, right: SchemaConfidence) -> SchemaConfidence:
     order = {
         "declared": 0,
         "propagated": 1,
@@ -999,3 +1091,21 @@ def _is_string_literal(text: str) -> bool:
 
 def _looks_like_list_literal(text: str) -> bool:
     return len(text) >= 2 and text[0] == "[" and text[-1] == "]"
+
+
+def _is_bare_identifier(text: str) -> bool:
+    if not _IDENTIFIER_RE.fullmatch(text):
+        return False
+    return text.upper() not in _KEYWORDS
+
+
+def _unresolved_name_error(identifier: str, visible_scope: Mapping[str, BoundVariable]) -> GFQLValidationError:
+    return GFQLValidationError(
+        ErrorCode.E204,
+        "Unresolved identifier in binder scope",
+        field="identifier",
+        value=identifier,
+        suggestion="Introduce the alias in MATCH/WITH before referencing it.",
+        visible_scope=sorted(visible_scope.keys()),
+        language="cypher",
+    )

--- a/graphistry/compute/gfql/frontends/cypher/binder.py
+++ b/graphistry/compute/gfql/frontends/cypher/binder.py
@@ -85,6 +85,7 @@ _PROPERTY_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_
 _PARAMETER_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
 _COUNT_CALL_RE = re.compile(r"(?i)^count\s*\(")
 _WHERE_LABEL_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([A-Za-z_][A-Za-z0-9_]*)")
+_WHERE_NON_CONJUNCTIVE_RE = re.compile(r"(?i)\b(?:OR|NOT|XOR)\b")
 
 
 @dataclass
@@ -944,7 +945,7 @@ def _apply_where_label_narrowing(state: _BindState, where: WhereClause) -> Set[s
             labels = narrowed.setdefault(term.left.alias, set())
             labels.update(term.left.labels)
 
-    if where.expr is not None:
+    if where.expr is not None and _WHERE_NON_CONJUNCTIVE_RE.search(where.expr.text) is None:
         for alias, label in _WHERE_LABEL_RE.findall(where.expr.text):
             labels = narrowed.setdefault(alias, set())
             labels.add(label)

--- a/graphistry/tests/compute/gfql/cypher/test_binder.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binder.py
@@ -1,5 +1,6 @@
 import pytest
 
+from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 from graphistry.compute.gfql.cypher.api import compile_cypher, cypher_to_gfql
 from graphistry.compute.gfql.cypher.ast import CypherGraphQuery, CypherUnionQuery
 from graphistry.compute.gfql.cypher.parser import parse_cypher
@@ -133,15 +134,19 @@ def test_binder_union_merges_branch_bindings() -> None:
     assert any(part.clause == "UNION" for part in bound.query_parts)
 
 
-def test_binder_with_scope_boundary_drops_pre_with_aliases() -> None:
-    query = "MATCH (n:Person) WITH n AS m RETURN n, m"
+def test_binder_with_scope_boundary_keeps_projected_alias_only() -> None:
+    query = "MATCH (n:Person) WITH n AS m RETURN m"
     bound = FrontendBinder().bind(parse_cypher(query), PlanContext())
 
-    assert set(bound.semantic_table.variables) == {"n", "m"}
+    assert set(bound.semantic_table.variables) == {"m"}
     assert bound.semantic_table.variables["m"].entity_kind == "node"
     assert bound.query_parts[1].outputs == frozenset({"m"})
-    assert bound.semantic_table.variables["n"].entity_kind == "scalar"
-    assert bound.semantic_table.variables["n"].null_extended_from == frozenset()
+
+
+def test_binder_unresolved_name_failure_after_with_scope_reset() -> None:
+    query = "MATCH (n:Person) WITH n AS m RETURN n"
+    with pytest.raises(GFQLValidationError, match="Unresolved identifier"):
+        FrontendBinder().bind(parse_cypher(query), PlanContext(), strict_name_resolution=True)
 
 
 def test_binder_unwind_extends_existing_scope() -> None:
@@ -151,3 +156,35 @@ def test_binder_unwind_extends_existing_scope() -> None:
     unwind_part = next(part for part in bound.query_parts if part.clause == "UNWIND")
     assert unwind_part.inputs == frozenset({"n"})
     assert unwind_part.outputs == frozenset({"n", "x"})
+
+
+def test_binder_label_narrowing_from_match_labels_and_where_conjunction() -> None:
+    query = "MATCH (n:Person) WHERE n:Admin AND n:Active RETURN n"
+    bound = FrontendBinder().bind(parse_cypher(query), PlanContext())
+
+    n_var = bound.semantic_table.variables["n"]
+    assert isinstance(n_var.logical_type, NodeRef)
+    assert n_var.logical_type.labels == frozenset({"Person", "Admin", "Active"})
+
+
+def test_binder_schema_confidence_min_rule_count_and_operand_inheritance() -> None:
+    query = (
+        "MATCH (n:Person) "
+        "WITH n.id AS pid, n AS node_alias "
+        "RETURN pid AS pid_out, node_alias.id AS node_id, pid + node_alias.id AS mixed, count(node_alias) AS cnt, 1 AS one"
+    )
+    bound = FrontendBinder().bind(parse_cypher(query), PlanContext())
+    confidence = bound.params["_binder_schema_confidence"]
+    assert isinstance(confidence, dict)
+
+    assert confidence["pid_out"] == "propagated"  # operand inheritance from pid
+    assert confidence["node_id"] == "propagated"  # property-level demotion
+    assert confidence["mixed"] == "propagated"  # min-rule over declared + propagated
+    assert confidence["cnt"] == "declared"  # strong aggregate semantics
+    assert confidence["one"] == "declared"  # strong literal semantics
+
+
+def test_binder_unresolved_identifier_code_is_e204() -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        FrontendBinder().bind(parse_cypher("RETURN ghost"), PlanContext(), strict_name_resolution=True)
+    assert exc_info.value.code == ErrorCode.E204

--- a/graphistry/tests/compute/gfql/cypher/test_binder.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binder.py
@@ -167,6 +167,24 @@ def test_binder_label_narrowing_from_match_labels_and_where_conjunction() -> Non
     assert n_var.logical_type.labels == frozenset({"Person", "Admin", "Active"})
 
 
+def test_binder_label_narrowing_does_not_apply_for_or_expression() -> None:
+    query = "MATCH (n) WHERE n:Admin OR n:Active RETURN n"
+    bound = FrontendBinder().bind(parse_cypher(query), PlanContext())
+
+    n_var = bound.semantic_table.variables["n"]
+    assert isinstance(n_var.logical_type, NodeRef)
+    assert n_var.logical_type.labels == frozenset()
+
+
+def test_binder_label_narrowing_does_not_apply_for_not_expression() -> None:
+    query = "MATCH (n:Person) WHERE NOT n:Admin RETURN n"
+    bound = FrontendBinder().bind(parse_cypher(query), PlanContext())
+
+    n_var = bound.semantic_table.variables["n"]
+    assert isinstance(n_var.logical_type, NodeRef)
+    assert n_var.logical_type.labels == frozenset({"Person"})
+
+
 def test_binder_schema_confidence_min_rule_count_and_operand_inheritance() -> None:
     query = (
         "MATCH (n:Person) "


### PR DESCRIPTION
## Summary
Stacked follow-on for PR-4 binder semantic core.

- add explicit binder semantic white-box tests in `graphistry/tests/compute/gfql/cypher/test_binder.py` for the issue-comment testing gate:
  - name resolution success + unresolved-name failure (`strict_name_resolution=True` in binder unit tests)
  - WITH scope reset visibility rules
  - OPTIONAL MATCH `null_extended_from` semantics as `frozenset` clause ids
  - label narrowing from MATCH labels plus conjunctive `WHERE alias:Label` checks
  - SchemaConfidence propagation rules (min-rule propagation, operand inheritance, strong literal/`COUNT` behavior)
- harden binder implementation in `graphistry/compute/gfql/frontends/cypher/binder.py` to support those semantic assertions while preserving existing lowering behavior:
  - add strict-mode unresolved identifier errors for white-box tests without changing default compile-path behavior
  - add WHERE-label narrowing updates to node label sets
  - add explicit COUNT confidence/type handling and min-rule confidence propagation helper use
- update `CHANGELOG.md` `[Development]` with the new binder semantic conformance test coverage

## Validation
- `./bin/ruff.sh graphistry/compute/gfql/frontends/cypher/binder.py graphistry/tests/compute/gfql/cypher/test_binder.py`
- `PYTHONPATH=. mypy --strict --follow-imports=skip graphistry/compute/gfql/ir/*.py graphistry/compute/gfql/frontends/cypher/binder.py`
- `PYTHONPATH=. pytest -q graphistry/tests/compute/gfql/cypher/test_binder.py graphistry/tests/compute/gfql/cypher/test_m1_differential_scaffold.py`
- `PYTHONPATH=. pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "optional or with"`
- `PYTHONPATH=. pytest -q graphistry/tests/compute/gfql/cypher/test_parser.py`

## Linkage
- Stacked on #1120
- Refs #1114
- Part of #1113
