### PR TITLE
feat: add pyright script for type checking with configuration

### DIFF
--- a/bin/pyright.sh
+++ b/bin/pyright.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# Run from project root
+# Non-zero exit code on fail
+
+# Resolve pyright command, then delegate with repo config.
+if command -v uvx >/dev/null 2>&1; then
+    PYRIGHT_CMD_ARR=(uvx --from pyright pyright)
+elif command -v pyright >/dev/null 2>&1; then
+    PYRIGHT_CMD_ARR=(pyright)
+elif command -v npx >/dev/null 2>&1; then
+    PYRIGHT_CMD_ARR=(npx pyright)
+else
+    echo "pyright not found. Install pyright, npm, or uvx."
+    exit 1
+fi
+
+PYRIGHT_EXTRA_ARGS_ARR=()
+if [ -n "${PYRIGHT_EXTRA_ARGS:-}" ]; then
+    read -r -a PYRIGHT_EXTRA_ARGS_ARR <<< "$PYRIGHT_EXTRA_ARGS"
+fi
+
+# Get the script directory and repo root
+SCRIPT_DIR="$( cd "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Change to repo root
+cd "$REPO_ROOT"
+
+# Check if specific files were passed as arguments
+if [ $# -eq 0 ]; then
+    TARGET_ARGS=("graphistry")
+else
+    TARGET_ARGS=("$@")
+fi
+CONFIG_ARGS=(-p pyrightconfig.json)
+
+echo "Running pyright..."
+echo "Checking: ${TARGET_ARGS[*]}"
+
+"${PYRIGHT_CMD_ARR[@]}" --version
+CMD=( "${PYRIGHT_CMD_ARR[@]}" "${PYRIGHT_EXTRA_ARGS_ARR[@]}" "${CONFIG_ARGS[@]}" )
+CMD+=( "${TARGET_ARGS[@]}" )
+"${CMD[@]}"
+
+echo "Pyright check completed!"

--- a/bin/pyright.sh
+++ b/bin/pyright.sh
@@ -5,14 +5,14 @@ set -e
 # Non-zero exit code on fail
 
 # Resolve pyright command, then delegate with repo config.
-if command -v pyright >/dev/null 2>&1; then
+if pyright --version >/dev/null 2>&1; then
     PYRIGHT_CMD_ARR=(pyright)
-elif command -v uvx >/dev/null 2>&1; then
+elif uvx --from pyright pyright --version >/dev/null 2>&1; then
     PYRIGHT_CMD_ARR=(uvx --from pyright pyright)
-elif command -v npx >/dev/null 2>&1; then
+elif npx pyright --version >/dev/null 2>&1; then
     PYRIGHT_CMD_ARR=(npx pyright)
 else
-    echo "pyright not found. Install pyright, npm, or uvx."
+    echo "pyright could not be executed via pyright, uvx, or npx."
     exit 1
 fi
 

--- a/bin/pyright.sh
+++ b/bin/pyright.sh
@@ -5,10 +5,10 @@ set -e
 # Non-zero exit code on fail
 
 # Resolve pyright command, then delegate with repo config.
-if command -v uvx >/dev/null 2>&1; then
-    PYRIGHT_CMD_ARR=(uvx --from pyright pyright)
-elif command -v pyright >/dev/null 2>&1; then
+if command -v pyright >/dev/null 2>&1; then
     PYRIGHT_CMD_ARR=(pyright)
+elif command -v uvx >/dev/null 2>&1; then
+    PYRIGHT_CMD_ARR=(uvx --from pyright pyright)
 elif command -v npx >/dev/null 2>&1; then
     PYRIGHT_CMD_ARR=(npx pyright)
 else

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,9 +1,20 @@
 {
+    "include": [
+        "graphistry"
+    ],
     "typeCheckingMode": "basic",
     "ignore": [],
     "reportArgumentType": "none",
+    "reportMissingImports": "none",
+    "reportMissingModuleSource": "none",
     "reportMissingTypeArgument": "none",
     "reportUnknownMemberType": "none",
     "reportIncompatibleMethodOverride": "error",
-    "exclude": []
+    "reportPossiblyUnboundVariable": "warning",
+    "exclude": [
+        "graphistry/tests",
+        "graphistry/_version.py",
+        "versioneer.py",
+        "**/graph_vector_pb2*"
+    ]
 }


### PR DESCRIPTION
## Summary
Adds pyright configuration and local runner script to catch conditionally-assigned variable bugs (like edge_map at hop.py:974) that ruff and mypy miss. No code changes — tooling only.

- [X] Linked issue(s): Ref #1075 
- [X] Scope is explicit (non-goals included when relevant)

Non-goals: CI integration, code fixes, rule enforcement — all follow-up PRs.

## Validation

- [X] Local lint/type/tests run for touched scope
- [ ] CI is green

`bin/pyright.sh graphistry/compute/hop.py` confirms `hop.py:974:122 - warning: "edge_map" is possibly unbound`

## Cypher Frontend CI Evidence (when PR touches cypher frontend / IR scope)

- [ ] `cypher-frontend-strict-typing (py3.12)` passed (strict typing gate)
- [ ] `cypher-frontend-differential-parity (py3.12)` passed (trust-but-verify gate)
- [ ] `cypher-frontend-ci-gates` passed (includes `test-minimal-python` sentinel)
- [ ] PR body includes links/screenshots/log snippets for any non-obvious gate evidence
