### PR TITLE
fix: uniform Arrow coercion in compute and hypergraph paths (closes #1132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,7 +1181,7 @@ jobs:
     - name: Install graphistry
       run: |
         source pygraphistry/bin/activate
-        pip install -e .[test] --no-deps
+        pip install -e .[test]
 
     - name: Run Spark tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1232,37 +1232,6 @@ jobs:
         cd docs && ./ci.sh
 
   
-  test-spark:
-    needs: [generate-lockfiles, test-minimal-python]
-    # TODO: replace 'dgx' with the actual self-hosted DGX-Spark runner label
-    runs-on: [self-hosted, dgx]
-    timeout-minutes: 15
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-
-    - uses: actions/download-artifact@v4
-      with:
-        name: lockfiles
-
-    - name: Install uv
-      run: pip install uv
-
-    - name: Install dependencies
-      run: uv pip install --system -r build-py3.12.lock
-
-    - name: Install pyspark
-      run: uv pip install --system pyspark
-
-    - name: Run Spark tests
-      run: |
-        python -B -m pytest graphistry/tests/test_df_types.py -v -k "spark" 2>&1 | tail -30
-
-
   test-readme:
     needs: [changes]
     # Run if docs changed OR infrastructure changed OR manual/scheduled run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1154,6 +1154,41 @@ jobs:
         ./bin/test-dgl.sh
 
 
+  test-spark:
+    needs: [changes, test-minimal-python, test-gfql-core]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PIP_EXCLUDE_NEWER: "6 days"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.14'
+
+    - name: Install pyspark stack
+      run: |
+        sudo apt-get install -y default-jdk
+        python -m venv pygraphistry
+        source pygraphistry/bin/activate
+        python -m pip install --upgrade pip
+        pip install pyspark pyarrow pandas requests pytest
+
+    - name: Install graphistry
+      run: |
+        source pygraphistry/bin/activate
+        pip install -e .[test] --no-deps
+
+    - name: Run Spark tests
+      run: |
+        source pygraphistry/bin/activate
+        python -B -m pytest graphistry/tests/test_df_types.py -v -k spark
+
+
   test-neo4j:
     needs: [ test-minimal-python, test-gfql-core ]
     # Inherit condition from test-minimal-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1232,6 +1232,37 @@ jobs:
         cd docs && ./ci.sh
 
   
+  test-spark:
+    needs: [generate-lockfiles, test-minimal-python]
+    # TODO: replace 'dgx' with the actual self-hosted DGX-Spark runner label
+    runs-on: [self-hosted, dgx]
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: lockfiles
+
+    - name: Install uv
+      run: pip install uv
+
+    - name: Install dependencies
+      run: uv pip install --system -r build-py3.12.lock
+
+    - name: Install pyspark
+      run: uv pip install --system pyspark
+
+    - name: Run Spark tests
+      run: |
+        python -B -m pytest graphistry/tests/test_df_types.py -v -k "spark" 2>&1 | tail -30
+
+
   test-readme:
     needs: [changes]
     # Run if docs changed OR infrastructure changed OR manual/scheduled run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **CI / build lane**: `test-build` now runs on Python 3.14 with `build-py3.14.lock` instead of a fixed Python 3.8 runner, reducing reliance on EOL interpreter setup while preserving explicit 3.8 compatibility test lanes elsewhere in CI.
 
 ### Fixed
-- **DataFrame input types**: `pa.Table` (Apache Arrow) now works in `materialize_nodes()`, `get_degrees()`, `get_indegrees()`, `get_outdegrees()`, and `hypergraph()` without crashing. Arrow tables are coerced to pandas at each entry boundary; pandas/cuDF paths are unaffected. Adds `test_df_types.py` covering Arrow compute and hypergraph paths (#1132).
+- **DataFrame input types**: `pa.Table` (Apache Arrow) and `pyspark.sql.DataFrame` (Spark) now work in `materialize_nodes()`, `get_degrees()`, `get_indegrees()`, `get_outdegrees()`, and `hypergraph()` without crashing. Both are coerced to pandas at each entry boundary; pandas/cuDF paths are unaffected. Mixed inputs (e.g. Arrow edges + pandas nodes) are handled correctly. Adds `test_df_types.py` with 22 tests covering Arrow compute, Arrow hypergraph, mixed-type boundaries, and Spark paths; adds a `test-spark` parallel CI job (Python 3.14, pyspark 4.x) (#1132).
 
 ### Added
 - **GFQL / Cypher**: Extracted `ASTNormalizer` into `graphistry/compute/gfql/cypher/ast_normalizer.py` and moved shortestPath + WHERE-pattern-predicate rewrite ownership out of `lowering.py`, with parity-preserving wiring in compile/lowering flows and focused regression coverage for rewrite behavior and invocation order (#1117).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **CI / docs**: `test-readme` no longer runs `actions/setup-python` with an EOL Python 3.8 pin. The job now runs markdown lint directly via its Docker image, removing an unnecessary setup step and avoiding intermittent Python toolcache fetch timeouts.
 - **CI / build lane**: `test-build` now runs on Python 3.14 with `build-py3.14.lock` instead of a fixed Python 3.8 runner, reducing reliance on EOL interpreter setup while preserving explicit 3.8 compatibility test lanes elsewhere in CI.
 
+### Fixed
+- **DataFrame input types**: `pa.Table` (Apache Arrow) now works in `materialize_nodes()`, `get_degrees()`, `get_indegrees()`, `get_outdegrees()`, and `hypergraph()` without crashing. Arrow tables are coerced to pandas at each entry boundary; pandas/cuDF paths are unaffected. Adds `test_df_types.py` covering Arrow compute and hypergraph paths (#1132).
+
 ### Added
 - **GFQL / Cypher**: Extracted `ASTNormalizer` into `graphistry/compute/gfql/cypher/ast_normalizer.py` and moved shortestPath + WHERE-pattern-predicate rewrite ownership out of `lowering.py`, with parity-preserving wiring in compile/lowering flows and focused regression coverage for rewrite behavior and invocation order (#1117).
 - **GFQL / Cypher compiler**: Lowering now functionally consumes `BoundIR` metadata for the M1 integration slice: binder-provided params are merged into effective lowering params (runtime overrides preserved) with binder metadata keys filtered out of runtime-param resolution, scope membership narrowing uses the active scope frame for WITH-boundary correctness, semantic-table entity kinds inform alias table routing, and nullable alias metadata is wired into optional-only alias detection. `_StageScope` duplicated table bookkeeping was reduced, binder now runs pre- and post-normalization in compile flow, and binder-path regression tests were added for these code paths (#1116).

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -2,6 +2,7 @@ from inspect import getmodule
 import warnings
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from typing import Any, List, Optional, Union
 from typing_extensions import Literal
 from enum import Enum
@@ -68,6 +69,10 @@ def resolve_engine(
             g_or_df = g_or_df._edges if g_or_df._edges is not None else g_or_df._nodes
     
         if isinstance(g_or_df, pd.DataFrame):
+            return Engine.PANDAS
+
+        # Arrow and Spark are input formats, not compute engines — coerce to pandas at call sites
+        if isinstance(g_or_df, pa.Table):
             return Engine.PANDAS
 
         if 'cudf.core.dataframe' in str(getmodule(g_or_df)):

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -75,6 +75,13 @@ def resolve_engine(
         if isinstance(g_or_df, pa.Table):
             return Engine.PANDAS
 
+        try:
+            from pyspark.sql import DataFrame as SparkDataFrame
+            if isinstance(g_or_df, SparkDataFrame):
+                return Engine.PANDAS
+        except ImportError:
+            pass
+
         if 'cudf.core.dataframe' in str(getmodule(g_or_df)):
             has_cudf_dependancy_, _, _ = lazy_cudf_import()
             if has_cudf_dependancy_:

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -165,6 +165,13 @@ class ComputeMixin(Plottable):
         if engine != EngineAbstract.AUTO:
             g = ensure_local_engine_match(g, Engine(engine.value))
 
+        # Coerce input-format types (Arrow, etc.) to pandas before any engine logic
+        import pyarrow as pa
+        if isinstance(g._edges, pa.Table):
+            g = g.edges(g._edges.to_pandas(), g._source, g._destination)
+        if g._nodes is not None and isinstance(g._nodes, pa.Table):
+            g = g.nodes(g._nodes.to_pandas(), g._node)
+
         if reuse:
             if g._nodes is not None and _safe_len(g._nodes) > 0:
                 if g._node is None:
@@ -219,7 +226,12 @@ class ComputeMixin(Plottable):
 
     def get_indegrees(self, col: str = "degree_in"):
         """See get_degrees"""
+        import pyarrow as pa
         g = self
+        if isinstance(g._edges, pa.Table):
+            g = g.edges(g._edges.to_pandas(), g._source, g._destination)
+            if g._nodes is not None and isinstance(g._nodes, pa.Table):
+                g = g.nodes(g._nodes.to_pandas(), g._node)
         g_nodes = g.materialize_nodes()
 
         if _safe_len(g._edges) == 0:
@@ -249,7 +261,12 @@ class ComputeMixin(Plottable):
 
     def get_outdegrees(self, col: str = "degree_out"):
         """See get_degrees"""
+        import pyarrow as pa
         g = self
+        if isinstance(g._edges, pa.Table):
+            g = g.edges(g._edges.to_pandas(), g._source, g._destination)
+            if g._nodes is not None and isinstance(g._nodes, pa.Table):
+                g = g.nodes(g._nodes.to_pandas(), g._node)
         g2 = g.edges(
             g._edges.rename(
                 columns={g._source: g._destination, g._destination: g._source}

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -187,7 +187,7 @@ class ComputeMixin(Plottable):
         if engine != EngineAbstract.AUTO:
             g = ensure_local_engine_match(g, Engine(engine.value))
 
-        # Coerce input-format types (Arrow, etc.) to pandas before any engine logic
+        # Coerce input-format types (Arrow, Spark) to pandas before any engine logic
         g = _coerce_to_pandas(g)
 
         if reuse:

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -69,6 +69,21 @@ def _safe_len(df: Any) -> int:
     return len(df)
 
 
+def _coerce_arrow_to_pandas(g: "Plottable") -> "Plottable":
+    """Coerce pa.Table edges/nodes on *g* to pandas DataFrames in-place (returns new Plottable).
+
+    Arrow is an input format, not a compute engine.  All compute methods that
+    operate on the raw DataFrame (materialize_nodes, get_indegrees, get_outdegrees)
+    call this at their entry point so the rest of their logic can assume pandas/cudf.
+    """
+    import pyarrow as pa
+    if isinstance(g._edges, pa.Table):
+        g = g.edges(g._edges.to_pandas(), g._source, g._destination)
+    if g._nodes is not None and isinstance(g._nodes, pa.Table):
+        g = g.nodes(g._nodes.to_pandas(), g._node)
+    return g
+
+
 class ComputeMixin(Plottable):
     
     def __init__(self, *a, **kw):
@@ -166,11 +181,7 @@ class ComputeMixin(Plottable):
             g = ensure_local_engine_match(g, Engine(engine.value))
 
         # Coerce input-format types (Arrow, etc.) to pandas before any engine logic
-        import pyarrow as pa
-        if isinstance(g._edges, pa.Table):
-            g = g.edges(g._edges.to_pandas(), g._source, g._destination)
-        if g._nodes is not None and isinstance(g._nodes, pa.Table):
-            g = g.nodes(g._nodes.to_pandas(), g._node)
+        g = _coerce_arrow_to_pandas(g)
 
         if reuse:
             if g._nodes is not None and _safe_len(g._nodes) > 0:
@@ -226,12 +237,7 @@ class ComputeMixin(Plottable):
 
     def get_indegrees(self, col: str = "degree_in"):
         """See get_degrees"""
-        import pyarrow as pa
-        g = self
-        if isinstance(g._edges, pa.Table):
-            g = g.edges(g._edges.to_pandas(), g._source, g._destination)
-            if g._nodes is not None and isinstance(g._nodes, pa.Table):
-                g = g.nodes(g._nodes.to_pandas(), g._node)
+        g = _coerce_arrow_to_pandas(self)
         g_nodes = g.materialize_nodes()
 
         if _safe_len(g._edges) == 0:
@@ -261,12 +267,7 @@ class ComputeMixin(Plottable):
 
     def get_outdegrees(self, col: str = "degree_out"):
         """See get_degrees"""
-        import pyarrow as pa
-        g = self
-        if isinstance(g._edges, pa.Table):
-            g = g.edges(g._edges.to_pandas(), g._source, g._destination)
-            if g._nodes is not None and isinstance(g._nodes, pa.Table):
-                g = g.nodes(g._nodes.to_pandas(), g._node)
+        g = _coerce_arrow_to_pandas(self)
         g2 = g.edges(
             g._edges.rename(
                 columns={g._source: g._destination, g._destination: g._source}

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -69,11 +69,10 @@ def _safe_len(df: Any) -> int:
     return len(df)
 
 
-def _coerce_arrow_to_pandas(g: "Plottable") -> "Plottable":
-    """Coerce pa.Table edges/nodes on *g* to pandas DataFrames in-place (returns new Plottable).
+def _coerce_to_pandas(g: "Plottable") -> "Plottable":
+    """Coerce input-format types (Arrow, Spark) on *g* to pandas DataFrames (returns new Plottable).
 
-    Arrow is an input format, not a compute engine.  All compute methods that
-    operate on the raw DataFrame (materialize_nodes, get_indegrees, get_outdegrees)
+    Arrow and Spark are input formats, not compute engines.  All compute methods
     call this at their entry point so the rest of their logic can assume pandas/cudf.
     """
     import pyarrow as pa
@@ -81,6 +80,14 @@ def _coerce_arrow_to_pandas(g: "Plottable") -> "Plottable":
         g = g.edges(g._edges.to_pandas(), g._source, g._destination)
     if g._nodes is not None and isinstance(g._nodes, pa.Table):
         g = g.nodes(g._nodes.to_pandas(), g._node)
+    try:
+        from pyspark.sql import DataFrame as SparkDataFrame
+        if isinstance(g._edges, SparkDataFrame):
+            g = g.edges(g._edges.toPandas(), g._source, g._destination)
+        if g._nodes is not None and isinstance(g._nodes, SparkDataFrame):
+            g = g.nodes(g._nodes.toPandas(), g._node)
+    except ImportError:
+        pass
     return g
 
 
@@ -181,7 +188,7 @@ class ComputeMixin(Plottable):
             g = ensure_local_engine_match(g, Engine(engine.value))
 
         # Coerce input-format types (Arrow, etc.) to pandas before any engine logic
-        g = _coerce_arrow_to_pandas(g)
+        g = _coerce_to_pandas(g)
 
         if reuse:
             if g._nodes is not None and _safe_len(g._nodes) > 0:
@@ -237,7 +244,7 @@ class ComputeMixin(Plottable):
 
     def get_indegrees(self, col: str = "degree_in"):
         """See get_degrees"""
-        g = _coerce_arrow_to_pandas(self)
+        g = _coerce_to_pandas(self)
         g_nodes = g.materialize_nodes()
 
         if _safe_len(g._edges) == 0:
@@ -267,7 +274,7 @@ class ComputeMixin(Plottable):
 
     def get_outdegrees(self, col: str = "degree_out"):
         """See get_degrees"""
-        g = _coerce_arrow_to_pandas(self)
+        g = _coerce_to_pandas(self)
         g2 = g.edges(
             g._edges.rename(
                 columns={g._source: g._destination, g._destination: g._source}

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -817,10 +817,17 @@ def hypergraph(
         engine_resolved = resolve_engine(engine, raw_events)
     else:
         engine_resolved = engine
-    # Coerce input-format types (Arrow, etc.) to the resolved engine's native type
+    # Coerce input-format types (Arrow, Spark) to the resolved engine's native type
     if raw_events is not None and engine_resolved == Engine.PANDAS and not isinstance(raw_events, pd.DataFrame):
         if isinstance(raw_events, pa.Table):
             raw_events = raw_events.to_pandas()
+        else:
+            try:
+                from pyspark.sql import DataFrame as SparkDataFrame
+                if isinstance(raw_events, SparkDataFrame):
+                    raw_events = raw_events.toPandas()
+            except ImportError:
+                pass
 
     defs = HyperBindings(**opts)
     entity_types = [i for i in screen_entities(raw_events, entity_types, defs) if i != defs.event_id]

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -818,7 +818,7 @@ def hypergraph(
     else:
         engine_resolved = engine
     # Coerce input-format types (Arrow, etc.) to the resolved engine's native type
-    if engine_resolved == Engine.PANDAS and not isinstance(raw_events, pd.DataFrame):
+    if raw_events is not None and engine_resolved == Engine.PANDAS and not isinstance(raw_events, pd.DataFrame):
         if isinstance(raw_events, pa.Table):
             raw_events = raw_events.to_pandas()
 

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -817,6 +817,11 @@ def hypergraph(
         engine_resolved = resolve_engine(engine, raw_events)
     else:
         engine_resolved = engine
+    # Coerce input-format types (Arrow, etc.) to the resolved engine's native type
+    if engine_resolved == Engine.PANDAS and not isinstance(raw_events, pd.DataFrame):
+        if isinstance(raw_events, pa.Table):
+            raw_events = raw_events.to_pandas()
+
     defs = HyperBindings(**opts)
     entity_types = [i for i in screen_entities(raw_events, entity_types, defs) if i != defs.event_id]
     events = clean_events(raw_events, defs, dropna=drop_na, engine=engine_resolved, npartitions=npartitions, chunksize=chunksize, debug=debug)  # type: ignore

--- a/graphistry/tests/test_df_types.py
+++ b/graphistry/tests/test_df_types.py
@@ -102,6 +102,40 @@ class TestArrowCompute(NoAuthTestCase):
         self.assertIsInstance(g._nodes, pd.DataFrame)
         self.assertIn("degree_out", g._nodes.columns)
 
+    def test_get_degrees_arrow_all_columns(self):
+        """get_degrees Arrow: degree = degree_in + degree_out for all nodes."""
+        g = CGFull().edges(EDGES_ARROW, "src", "dst").get_degrees()
+        self.assertIn("degree", g._nodes.columns)
+        self.assertIn("degree_in", g._nodes.columns)
+        self.assertIn("degree_out", g._nodes.columns)
+        self.assertTrue(
+            (g._nodes["degree"] == g._nodes["degree_in"] + g._nodes["degree_out"]).all()
+        )
+
+    def test_materialize_nodes_arrow_explicit_engine_pandas(self):
+        """Arrow edges + explicit engine='pandas' arg → still coerces and works."""
+        g = CGFull().edges(EDGES_ARROW, "src", "dst").materialize_nodes(engine="pandas")
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("id", g._nodes.columns)
+        self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+    def test_materialize_nodes_arrow_empty_edges(self):
+        """Empty pa.Table edges → materialize_nodes returns early without error.
+
+        Mirrors test_materialize_empty_edges in test_compute.py: empty edges →
+        early-return with _nodes=None (no node frame synthesized).
+        """
+        empty = pa.table({"src": pa.array([], type=pa.string()),
+                          "dst": pa.array([], type=pa.string())})
+        g = CGFull().edges(empty, "src", "dst").materialize_nodes()
+        self.assertIsNone(g._nodes)
+
+    def test_materialize_nodes_invalid_type_still_raises(self):
+        """Non-DataFrame, non-Arrow type still raises ValueError."""
+        g = CGFull().edges("not_a_dataframe", "src", "dst")
+        with self.assertRaises(Exception):
+            g.materialize_nodes()
+
 
 # ---------------------------------------------------------------------------
 # Arrow: hypergraph path

--- a/graphistry/tests/test_df_types.py
+++ b/graphistry/tests/test_df_types.py
@@ -3,7 +3,8 @@
 Tests for uniform DataFrame type handling across compute and hypergraph paths.
 Covers graphistry/pygraphistry#1132.
 
-pa.Table should work everywhere pd.DataFrame works for:
+pa.Table (Apache Arrow) and pyspark.DataFrame should work everywhere
+pd.DataFrame works for:
   - materialize_nodes()
   - get_degrees() / get_indegrees() / get_outdegrees()
   - hypergraph()
@@ -136,6 +137,41 @@ class TestArrowCompute(NoAuthTestCase):
         with self.assertRaises(Exception):
             g.materialize_nodes()
 
+    def test_materialize_nodes_arrow_edges_pandas_nodes(self):
+        """Arrow edges + pandas nodes (mixed) → coerce edges, reuse pandas nodes."""
+        g = (
+            CGFull()
+            .edges(EDGES_ARROW, "src", "dst")
+            .nodes(NODES_PD, "id")
+            .materialize_nodes()
+        )
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("v", g._nodes.columns)
+        self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+    def test_materialize_nodes_pandas_edges_arrow_nodes(self):
+        """pandas edges + Arrow nodes (mixed) → coerce nodes, reuse as pandas."""
+        g = (
+            CGFull()
+            .edges(EDGES_PD, "src", "dst")
+            .nodes(NODES_ARROW, "id")
+            .materialize_nodes()
+        )
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("v", g._nodes.columns)
+
+    def test_get_degrees_arrow_with_nodes(self):
+        """Arrow edges + Arrow nodes (pre-populated) → get_degrees coerces both."""
+        g = (
+            CGFull()
+            .edges(EDGES_ARROW, "src", "dst")
+            .nodes(NODES_ARROW, "id")
+            .get_degrees()
+        )
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("degree", g._nodes.columns)
+        self.assertIn("v", g._nodes.columns)
+
 
 # ---------------------------------------------------------------------------
 # Arrow: hypergraph path
@@ -178,6 +214,14 @@ class TestArrowHypergraph(NoAuthTestCase):
             len(h_arrow["graph"]._edges),
             "Edge count should match between pandas and Arrow inputs"
         )
+
+    def test_hypergraph_arrow_with_entity_types(self):
+        """Arrow events with explicit entity_types filter → correct subset of nodes."""
+        h = graphistry.hypergraph(EVENTS_ARROW, entity_types=["user"], verbose=False)
+        g = h["graph"]
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertGreater(len(g._nodes), 0)
+        self.assertGreater(len(g._edges), 0)
 
 
 # ---------------------------------------------------------------------------

--- a/graphistry/tests/test_df_types.py
+++ b/graphistry/tests/test_df_types.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for uniform DataFrame type handling across compute and hypergraph paths.
+Covers graphistry/pygraphistry#1132.
+
+pa.Table should work everywhere pd.DataFrame works for:
+  - materialize_nodes()
+  - get_degrees() / get_indegrees() / get_outdegrees()
+  - hypergraph()
+"""
+import importlib
+import pandas as pd
+import pyarrow as pa
+import pytest
+import unittest
+
+import graphistry
+from graphistry.tests.common import NoAuthTestCase
+from graphistry.tests.test_compute import CGFull
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+EDGES_PD = pd.DataFrame({"src": ["a", "b", "c"], "dst": ["b", "c", "a"]})
+EDGES_ARROW = pa.table({"src": ["a", "b", "c"], "dst": ["b", "c", "a"]})
+
+NODES_PD = pd.DataFrame({"id": ["a", "b", "c"], "v": [1, 2, 3]})
+NODES_ARROW = pa.table({"id": ["a", "b", "c"], "v": [1, 2, 3]})
+
+EVENTS_PD = pd.DataFrame({"user": ["alice", "bob", "alice"], "action": ["click", "view", "buy"]})
+EVENTS_ARROW = pa.table({"user": ["alice", "bob", "alice"], "action": ["click", "view", "buy"]})
+
+
+# ---------------------------------------------------------------------------
+# Regression: existing pandas behavior is unchanged
+# ---------------------------------------------------------------------------
+
+class TestRegressionPandas(NoAuthTestCase):
+
+    def test_materialize_nodes_pandas(self):
+        g = CGFull().edges(EDGES_PD, "src", "dst").materialize_nodes()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("id", g._nodes.columns)
+        self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+    def test_get_degrees_pandas(self):
+        g = CGFull().edges(EDGES_PD, "src", "dst").get_degrees()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("degree_in", g._nodes.columns)
+        self.assertIn("degree_out", g._nodes.columns)
+
+    def test_hypergraph_pandas(self):
+        h = graphistry.hypergraph(EVENTS_PD, verbose=False)
+        self.assertIn("graph", h)
+        g = h["graph"]
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIsInstance(g._edges, pd.DataFrame)
+        self.assertGreater(len(g._nodes), 0)
+        self.assertGreater(len(g._edges), 0)
+
+
+# ---------------------------------------------------------------------------
+# Arrow: compute path
+# ---------------------------------------------------------------------------
+
+class TestArrowCompute(NoAuthTestCase):
+
+    def test_materialize_nodes_arrow_edges_only(self):
+        """pa.Table edges → materialize_nodes produces pandas _nodes."""
+        g = CGFull().edges(EDGES_ARROW, "src", "dst").materialize_nodes()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("id", g._nodes.columns)
+        self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+    def test_materialize_nodes_arrow_edges_and_nodes(self):
+        """pa.Table edges + nodes → materialize_nodes reuses nodes, returns pandas."""
+        g = (
+            CGFull()
+            .edges(EDGES_ARROW, "src", "dst")
+            .nodes(NODES_ARROW, "id")
+            .materialize_nodes()
+        )
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+    def test_get_degrees_arrow(self):
+        """pa.Table edges → get_degrees produces degree columns."""
+        g = CGFull().edges(EDGES_ARROW, "src", "dst").get_degrees()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("degree_in", g._nodes.columns)
+        self.assertIn("degree_out", g._nodes.columns)
+
+    def test_get_indegrees_arrow(self):
+        g = CGFull().edges(EDGES_ARROW, "src", "dst").get_indegrees()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("degree_in", g._nodes.columns)
+
+    def test_get_outdegrees_arrow(self):
+        g = CGFull().edges(EDGES_ARROW, "src", "dst").get_outdegrees()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("degree_out", g._nodes.columns)
+
+
+# ---------------------------------------------------------------------------
+# Arrow: hypergraph path
+# ---------------------------------------------------------------------------
+
+class TestArrowHypergraph(NoAuthTestCase):
+
+    def test_hypergraph_arrow_returns_graph(self):
+        """pa.Table events → hypergraph returns a valid graph."""
+        h = graphistry.hypergraph(EVENTS_ARROW, verbose=False)
+        self.assertIn("graph", h)
+        g = h["graph"]
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIsInstance(g._edges, pd.DataFrame)
+        self.assertGreater(len(g._nodes), 0)
+        self.assertGreater(len(g._edges), 0)
+
+    def test_hypergraph_arrow_columns_preserved(self):
+        """Column names and unique values survive conversion."""
+        h = graphistry.hypergraph(EVENTS_ARROW, verbose=False)
+        nodes = h["graph"]._nodes
+        # Both 'user' and 'action' entity types should appear as node types
+        node_types = nodes["type"].unique().tolist() if "type" in nodes.columns else []
+        self.assertTrue(
+            any("user" in str(t) or "action" in str(t) for t in node_types),
+            f"Expected user/action entity types in nodes, got: {node_types}"
+        )
+
+    def test_hypergraph_arrow_matches_pandas(self):
+        """Arrow and pandas inputs to hypergraph produce same node/edge counts."""
+        h_pd = graphistry.hypergraph(EVENTS_PD, verbose=False)
+        h_arrow = graphistry.hypergraph(EVENTS_ARROW, verbose=False)
+        self.assertEqual(
+            len(h_pd["graph"]._nodes),
+            len(h_arrow["graph"]._nodes),
+            "Node count should match between pandas and Arrow inputs"
+        )
+        self.assertEqual(
+            len(h_pd["graph"]._edges),
+            len(h_arrow["graph"]._edges),
+            "Edge count should match between pandas and Arrow inputs"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Spark: stubs (skipped without pyspark)
+# ---------------------------------------------------------------------------
+
+_pyspark_available = importlib.util.find_spec("pyspark") is not None
+
+
+@pytest.mark.skipif(not _pyspark_available, reason="pyspark not installed")
+class TestSparkCompute(NoAuthTestCase):
+
+    def _make_spark_edges(self):
+        from pyspark.sql import SparkSession
+        spark = SparkSession.builder.master("local").appName("test").getOrCreate()
+        return spark.createDataFrame(
+            [("a", "b"), ("b", "c"), ("c", "a")], ["src", "dst"]
+        )
+
+    def test_materialize_nodes_spark(self):
+        sdf = self._make_spark_edges()
+        g = CGFull().edges(sdf, "src", "dst").materialize_nodes()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("id", g._nodes.columns)
+
+    def test_get_degrees_spark(self):
+        sdf = self._make_spark_edges()
+        g = CGFull().edges(sdf, "src", "dst").get_degrees()
+        self.assertIsInstance(g._nodes, pd.DataFrame)
+        self.assertIn("degree_in", g._nodes.columns)
+
+
+@pytest.mark.skipif(not _pyspark_available, reason="pyspark not installed")
+class TestSparkHypergraph(NoAuthTestCase):
+
+    def test_hypergraph_spark(self):
+        from pyspark.sql import SparkSession
+        spark = SparkSession.builder.master("local").appName("test").getOrCreate()
+        sdf = spark.createDataFrame(
+            [("alice", "click"), ("bob", "view")], ["user", "action"]
+        )
+        h = graphistry.hypergraph(sdf, verbose=False)
+        self.assertIn("graph", h)
+        self.assertGreater(len(h["graph"]._nodes), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `pa.Table` (PyArrow) now works in `materialize_nodes()`, `get_degrees()`, and `hypergraph()` — the same way it already worked in `plot()`
- `Engine.py:resolve_engine()` now has an explicit `pa.Table → Engine.PANDAS` branch instead of a silent fallthrough
- Coerce-at-entry applied before engine detection in each affected path

## Changes

- `graphistry/Engine.py`: explicit `pa.Table → Engine.PANDAS` in `resolve_engine()`
- `graphistry/compute/ComputeMixin.py`: Arrow coerce at top of `materialize_nodes()`, `get_indegrees()`, `get_outdegrees()` — before reuse check and engine detection
- `graphistry/hyper_dask.py`: Arrow coerce after `resolve_engine()`, before `screen_entities()`
- `graphistry/tests/test_df_types.py`: new test file — 11 tests covering Arrow compute path, Arrow hypergraph, pandas regression, Spark stubs (skipped without pyspark)

## Test plan

- [x] New `test_df_types.py`: 11 passed, 3 skipped (Spark — no pyspark in env)
- [x] Existing `test_compute.py` + `test_hypergraph.py`: 28 passed, 0 regressions
- [x] Full suite smoke: 401 passed, 1 pre-existing unrelated failure (lark/Cypher optional dep)

## Notes

- Spark paths not tested (no pyspark in CI); stubs added with `skipif` guard
- This is a prerequisite for #1133 (Polars support) — once `_table_to_pandas` gains a Polars branch, the same coerce-at-entry points cover Polars automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)