### PR TITLE
PR-B: Explicit workflow permissions + disable checkout credential persistence

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -8,6 +8,9 @@ on:
     types:
       - trigger-ci-gpu
 
+permissions:
+  contents: read
+
 jobs:
 
   stub_mt:
@@ -33,6 +36,8 @@ jobs:
       github.event_name == 'workflow_dispatch' || 
       (github.event_name == 'pull_request' && contains(github.event.label.name, 'gpu-ci'))
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     timeout-minutes: 10
     steps:
       - name: Cancel Previous Runs
@@ -57,6 +62,8 @@ jobs:
 
     - name: Checkout repo
       uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '0 1 1-31/2 * *'
 
+permissions:
+  contents: read
+
 env:
   # 6-day dependency cooldown: refuse packages uploaded less than 6 days ago
   # to mitigate supply chain attacks. Belt-and-suspenders with lockfile --exclude-newer.
@@ -41,6 +44,8 @@ jobs:
       docs_only_latest: ${{ steps.docs_only_latest.outputs.docs_only_latest }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - uses: dorny/paths-filter@v3
       id: filter
       with:
@@ -143,6 +148,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
+        persist-credentials: false
     - name: Reject plans/ files added by this PR
       run: |
         merge_base=$(git merge-base origin/${{ github.base_ref }} HEAD)
@@ -162,6 +168,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
@@ -196,6 +203,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
@@ -269,6 +277,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
     - name: Download lockfiles
       uses: actions/download-artifact@v4
@@ -328,6 +337,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
     - name: Download lockfiles
       uses: actions/download-artifact@v4
@@ -480,6 +490,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Download lockfiles
@@ -545,6 +556,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Download lockfiles
@@ -596,6 +608,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
     - name: Download lockfiles
       uses: actions/download-artifact@v4
@@ -657,6 +670,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Download lockfiles
@@ -715,6 +729,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
     - name: Download lockfiles
       uses: actions/download-artifact@v4
@@ -769,6 +784,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Download lockfiles
@@ -812,6 +828,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -879,6 +896,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -1001,6 +1019,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -1121,6 +1140,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
@@ -1168,6 +1188,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Neo4j connector tests
@@ -1186,6 +1207,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         lfs: true
+        persist-credentials: false
 
 
     - name: Download lockfiles
@@ -1224,6 +1246,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Test building docs
       env:
@@ -1241,6 +1265,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Lint README markdown
       continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Infrastructure
 - **CI / docs**: `test-readme` no longer runs `actions/setup-python` with an EOL Python 3.8 pin. The job now runs markdown lint directly via its Docker image, removing an unnecessary setup step and avoiding intermittent Python toolcache fetch timeouts.
 - **CI / build lane**: `test-build` now runs on Python 3.14 with `build-py3.14.lock` instead of a fixed Python 3.8 runner, reducing reliance on EOL interpreter setup while preserving explicit 3.8 compatibility test lanes elsewhere in CI.
+- **CI / token hardening**: CI workflows now declare explicit least-privilege default token scope (`permissions: contents: read`) and set `persist-credentials: false` on all checkout steps in `ci.yml` and `ci-gpu.yml`; GPU cancel job keeps a scoped `actions: write` override for run cancellation (#1130).
 
 ### Added
 - **GFQL / Cypher**: Extracted `ASTNormalizer` into `graphistry/compute/gfql/cypher/ast_normalizer.py` and moved shortestPath + WHERE-pattern-predicate rewrite ownership out of `lowering.py`, with parity-preserving wiring in compile/lowering flows and focused regression coverage for rewrite behavior and invocation order (#1117).


### PR DESCRIPTION
## Summary
Implements PR-B from #1130 by tightening GitHub Actions token/credential behavior in CI workflows.

### Changes
- Add top-level `permissions: { contents: read }` to:
  - `.github/workflows/ci.yml`
  - `.github/workflows/ci-gpu.yml`
- Add `persist-credentials: false` to all `actions/checkout` steps in both workflows.
- Add targeted job-level elevation in `ci-gpu.yml` cancel job:
  - `permissions: { actions: write }`
- Add changelog entry under `## [Development]` / `### Infrastructure` documenting CI token/checkout credential hardening.

## Why
- Enforces explicit least privilege for `GITHUB_TOKEN` in untrusted PR contexts.
- Prevents checkout from persisting repo credentials to local git config by default.
- Keeps required write scope only where needed (`cancel-workflow-action`).

## Scope
This PR intentionally touches only workflow permission/checkout credential controls + changelog note.

Refs #1130