### PR TITLE
PR-D: Temporarily disable ci-gpu gpu_public lane with fail-fast guard

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -21,10 +21,25 @@ jobs:
       - name: Do nothing
         run: echo "Do nothing"
 
-  gpu-permission:
-    if: >
+  gpu-disabled-guard:
+    name: GPU lane temporarily disabled
+    if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && contains(fromJson('["lmeyerov", "tanmoyio", "aucahuasi", "silkspace", "DataBoyTx"]'), github.actor))
+      github.event_name == 'repository_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'gpu-ci'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Fail with re-enable guidance
+        run: |
+          echo "::error::ci-gpu is temporarily disabled while gpu_public is unavailable and PR-D hardening is pending."
+          echo "::error::Re-enable only after issue #1130 acceptance criteria are satisfied."
+          exit 1
+
+  gpu-permission:
+    # Temporarily disabled while gpu_public is unavailable and PR-D hardening is pending.
+    # Re-enable only after issue #1130 criteria are met.
+    if: ${{ false }}  # see #1130
     runs-on: ubuntu-latest
     steps:
       - name: Do nothing
@@ -32,9 +47,9 @@ jobs:
 
   cancel_outstanding:  
     name: Detect and cancel outstanding runs of this workflow
-    if: |
-      github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'pull_request' && contains(github.event.label.name, 'gpu-ci'))
+    # Temporarily disabled while gpu_public is unavailable and PR-D hardening is pending.
+    # Re-enable only after issue #1130 criteria are met.
+    if: ${{ false }}  # see #1130
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -47,10 +62,9 @@ jobs:
           access_token: ${{ github.token }}
 
   test-full-ai:
-    needs: [ gpu-permission ]
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && contains(github.event.label.name, 'gpu-ci'))
+    # Temporarily disabled while gpu_public is unavailable and PR-D hardening is pending.
+    # Re-enable only after issue #1130 criteria are met.
+    if: ${{ false }}  # see #1130
     runs-on: gpu_public
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **CI / docs**: `test-readme` no longer runs `actions/setup-python` with an EOL Python 3.8 pin. The job now runs markdown lint directly via its Docker image, removing an unnecessary setup step and avoiding intermittent Python toolcache fetch timeouts.
 - **CI / build lane**: `test-build` now runs on Python 3.14 with `build-py3.14.lock` instead of a fixed Python 3.8 runner, reducing reliance on EOL interpreter setup while preserving explicit 3.8 compatibility test lanes elsewhere in CI.
 - **CI / token hardening**: CI workflows now declare explicit least-privilege default token scope (`permissions: contents: read`) and set `persist-credentials: false` on all checkout steps in `ci.yml` and `ci-gpu.yml`; GPU cancel job keeps a scoped `actions: write` override for run cancellation (#1130).
+- **CI / GPU lockdown**: Temporarily disabled `ci-gpu.yml` GPU execution path (including `gpu_public` jobs) while runner availability and PR-D security hardening are addressed; attempted GPU-triggered runs now fail fast with re-enable guidance referencing issue #1130.
 
 ### Added
 - **GFQL / Cypher**: Extracted `ASTNormalizer` into `graphistry/compute/gfql/cypher/ast_normalizer.py` and moved shortestPath + WHERE-pattern-predicate rewrite ownership out of `lowering.py`, with parity-preserving wiring in compile/lowering flows and focused regression coverage for rewrite behavior and invocation order (#1117).


### PR DESCRIPTION
Summary:
Temporarily lock down the GPU CI workflow while gpu_public is unavailable and PR-D hardening is pending.

Changes:
- Add gpu-disabled-guard job that fails fast when GPU-triggered paths are invoked (workflow_dispatch, repository_dispatch, labeled PRs with gpu-ci)
- Temporarily disable gpu-permission, cancel_outstanding, and test-full-ai jobs via if: ${{ false }}
- Add explicit inline comments in ci-gpu.yml referencing issue #1130 for re-enable criteria
- Add changelog entry documenting temporary GPU lockdown

Why:
- Prevent untrusted or accidental execution on unavailable or non-hardened gpu_public runners
- Keep trigger path visible with actionable failure instead of silent skip

Re-enable criteria:
Re-enable only after issue #1130 acceptance criteria are met (self-hosted/GPU isolation plus promotion gate).

Closes part of #1130.