### PR TITLE
feat(#1133): add Polars DataFrame and LazyFrame support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **CI / GPU lockdown**: Temporarily disabled `ci-gpu.yml` GPU execution path (including `gpu_public` jobs) while runner availability and PR-D security hardening are addressed; attempted GPU-triggered runs now fail fast with re-enable guidance referencing issue #1130.
 - **CI / release permissions**: `publish-pypi.yml` now explicitly declares `contents: read` alongside `id-token: write` for the publish job, keeping release workflow permissions least-privilege and resilient after repository default token permissions were tightened under issue #1130.
 
+### Added
+- **Polars support**: `polars.DataFrame` and `polars.LazyFrame` now work in `plot()`, `materialize_nodes()`, `get_degrees()`, `get_indegrees()`, `get_outdegrees()`, and `hypergraph()`. Polars is an optional dependency — no behavior change when not installed. Upload path uses efficient Arrow conversion (`to_arrow()` with schema-metadata stripping and memoization); compute/hypergraph paths coerce to pandas at entry. `LazyFrame` is materialized via `.collect()` at each boundary. Adds `test_polars.py` with 17 tests; skips gracefully when polars is absent (#1133).
+
 ### Fixed
 - **DataFrame input types**: `pa.Table` (Apache Arrow) and `pyspark.sql.DataFrame` (Spark) now work in `materialize_nodes()`, `get_degrees()`, `get_indegrees()`, `get_outdegrees()`, and `hypergraph()` without crashing. Both are coerced to pandas at each entry boundary; pandas/cuDF paths are unaffected. Mixed inputs (e.g. Arrow edges + pandas nodes) are handled correctly. Adds `test_df_types.py` with 22 tests covering Arrow compute, Arrow hypergraph, mixed-type boundaries, and Spark paths; adds a `test-spark` parallel CI job (Python 3.14, pyspark 4.x) (#1132).
 

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -82,6 +82,13 @@ def resolve_engine(
         except ImportError:
             pass
 
+        try:
+            import polars as pl
+            if isinstance(g_or_df, (pl.DataFrame, pl.LazyFrame)):
+                return Engine.PANDAS
+        except ImportError:
+            pass
+
         if 'cudf.core.dataframe' in str(getmodule(g_or_df)):
             has_cudf_dependancy_, _, _ = lazy_cudf_import()
             if has_cudf_dependancy_:

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -141,6 +141,17 @@ def maybe_spark():
         logger.warning('Runtime error import pyspark: Available but failed to initialize', exc_info=True)
     return None
 
+@lru_cache(maxsize=1)
+def maybe_polars():
+    try:
+        import polars
+        return polars
+    except ImportError:
+        1
+    except RuntimeError:
+        logger.warning('Runtime error importing polars', exc_info=True)
+    return None
+
 # #####################################
 
 
@@ -164,13 +175,15 @@ class PlotterBase(Plottable):
     
     _pd_hash_to_arrow : WeakValueDictionary = WeakValueDictionary()
     _cudf_hash_to_arrow : WeakValueDictionary = WeakValueDictionary()
+    _polars_hash_to_arrow : WeakValueDictionary = WeakValueDictionary()
     _umap_param_to_g : WeakValueDictionary = WeakValueDictionary()
     _feat_param_to_g : WeakValueDictionary = WeakValueDictionary()
 
-    def reset_caches(self): 
+    def reset_caches(self):
         """Reset memoization caches"""
         self._pd_hash_to_arrow.clear()
         self._cudf_hash_to_arrow.clear()
+        self._polars_hash_to_arrow.clear()
         self._umap_param_to_g.clear()
         self._feat_param_to_g.clear()
         cache_coercion_helper.cache_clear()
@@ -2702,7 +2715,8 @@ class PlotterBase(Plottable):
                 or ( not (maybe_cudf() is None) and isinstance(graph, maybe_cudf().DataFrame) ) \
                 or ( not (maybe_dask_cudf() is None) and isinstance(graph, maybe_dask_cudf().DataFrame) ) \
                 or ( not (maybe_dask_dataframe() is None) and isinstance(graph, maybe_dask_dataframe().DataFrame) ) \
-                or ( not (maybe_spark() is None) and isinstance(graph, maybe_spark().sql.dataframe.DataFrame) ):
+                or ( not (maybe_spark() is None) and isinstance(graph, maybe_spark().sql.dataframe.DataFrame) ) \
+                or ( not (maybe_polars() is None) and isinstance(graph, (maybe_polars().DataFrame, maybe_polars().LazyFrame)) ):
             return g._make_dataset(graph, nodes, name, description, mode, metadata, memoize, validate_mode, emit_warnings)
 
         try:
@@ -2830,6 +2844,11 @@ class PlotterBase(Plottable):
 
         if not (maybe_dask_dataframe() is None) and isinstance(table, maybe_dask_dataframe().DataFrame):
             return self._table_to_pandas(table.compute())
+
+        if not (maybe_polars() is None) and isinstance(table, (maybe_polars().DataFrame, maybe_polars().LazyFrame)):
+            if isinstance(table, maybe_polars().LazyFrame):
+                table = table.collect()
+            return table.to_pandas()
 
         raise Exception('Unknown type %s: Could not convert data to Pandas dataframe' % str(type(table)))
 
@@ -2983,6 +3002,27 @@ class PlotterBase(Plottable):
             df = table.toPandas()
             #TODO push the hash check to Spark
             return self._table_to_arrow(df, memoize, validate_mode, emit_warnings)
+
+        if not (maybe_polars() is None) and isinstance(table, (maybe_polars().DataFrame, maybe_polars().LazyFrame)):
+            if isinstance(table, maybe_polars().LazyFrame):
+                table = table.collect()
+            hashed = None
+            if memoize:
+                try:
+                    hashed = (
+                        hashlib.sha256(table.hash_rows().to_numpy().tobytes()).hexdigest()
+                        + hashlib.sha256(str(table.columns).encode('utf-8')).hexdigest()
+                    )
+                    if hashed in PlotterBase._polars_hash_to_arrow:
+                        return PlotterBase._polars_hash_to_arrow[hashed].v
+                except Exception:
+                    logger.debug('Failed to hash polars frame', exc_info=True)
+            out = table.to_arrow().replace_schema_metadata({})
+            if memoize and hashed is not None:
+                w = WeakValueWrapper(out)
+                cache_coercion(hashed, w)
+                PlotterBase._polars_hash_to_arrow[hashed] = w
+            return out
 
         raise Exception('Unknown type %s: Could not convert data to Arrow' % str(type(table)))
 

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -88,6 +88,16 @@ def _coerce_to_pandas(g: "Plottable") -> "Plottable":
             g = g.nodes(g._nodes.toPandas(), g._node)
     except ImportError:
         pass
+    try:
+        import polars as pl
+        if isinstance(g._edges, (pl.DataFrame, pl.LazyFrame)):
+            edges_pdf = g._edges.collect().to_pandas() if isinstance(g._edges, pl.LazyFrame) else g._edges.to_pandas()
+            g = g.edges(edges_pdf, g._source, g._destination)
+        if g._nodes is not None and isinstance(g._nodes, (pl.DataFrame, pl.LazyFrame)):
+            nodes_pdf = g._nodes.collect().to_pandas() if isinstance(g._nodes, pl.LazyFrame) else g._nodes.to_pandas()
+            g = g.nodes(nodes_pdf, g._node)
+    except ImportError:
+        pass
     return g
 
 

--- a/graphistry/hyper_dask.py
+++ b/graphistry/hyper_dask.py
@@ -817,7 +817,7 @@ def hypergraph(
         engine_resolved = resolve_engine(engine, raw_events)
     else:
         engine_resolved = engine
-    # Coerce input-format types (Arrow, Spark) to the resolved engine's native type
+    # Coerce input-format types (Arrow, Spark, Polars) to the resolved engine's native type
     if raw_events is not None and engine_resolved == Engine.PANDAS and not isinstance(raw_events, pd.DataFrame):
         if isinstance(raw_events, pa.Table):
             raw_events = raw_events.to_pandas()
@@ -826,6 +826,14 @@ def hypergraph(
                 from pyspark.sql import DataFrame as SparkDataFrame
                 if isinstance(raw_events, SparkDataFrame):
                     raw_events = raw_events.toPandas()
+            except ImportError:
+                pass
+            try:
+                import polars as pl
+                if isinstance(raw_events, (pl.DataFrame, pl.LazyFrame)):
+                    if isinstance(raw_events, pl.LazyFrame):
+                        raw_events = raw_events.collect()
+                    raw_events = raw_events.to_pandas()
             except ImportError:
                 pass
 

--- a/graphistry/tests/test_polars.py
+++ b/graphistry/tests/test_polars.py
@@ -13,14 +13,14 @@ import pandas as pd
 import pyarrow as pa
 import unittest
 
-polars = pytest = None
+pl = None
 try:
     import polars as pl
     import pytest
 except ImportError:
     pass
 
-if pl is None or pytest is None:
+if pl is None:
     import sys
     print("polars not installed — skipping test_polars.py", file=sys.stderr)
     # Make the module importable but empty when polars is absent

--- a/graphistry/tests/test_polars.py
+++ b/graphistry/tests/test_polars.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Polars DataFrame support across plot, compute, and hypergraph paths.
+Covers graphistry/pygraphistry#1133.
+
+polars.DataFrame and polars.LazyFrame should work everywhere pd.DataFrame works for:
+  - plot() upload path (via _table_to_arrow)
+  - _table_to_pandas()
+  - materialize_nodes() / get_degrees() / get_indegrees() / get_outdegrees()
+  - hypergraph()
+"""
+import pandas as pd
+import pyarrow as pa
+import unittest
+
+polars = pytest = None
+try:
+    import polars as pl
+    import pytest
+except ImportError:
+    pass
+
+if pl is None or pytest is None:
+    import sys
+    print("polars not installed — skipping test_polars.py", file=sys.stderr)
+    # Make the module importable but empty when polars is absent
+    class _Skip(unittest.TestCase):
+        @unittest.skip("polars not installed")
+        def test_placeholder(self):
+            pass
+else:
+    import graphistry
+    from graphistry.PlotterBase import PlotterBase
+    from graphistry.tests.common import NoAuthTestCase
+    from graphistry.tests.test_compute import CGFull
+
+    # ------------------------------------------------------------------
+    # Fixtures
+    # ------------------------------------------------------------------
+
+    EDGES_PL = pl.DataFrame({"src": ["a", "b", "c"], "dst": ["b", "c", "a"]})
+    EDGES_LAZY = EDGES_PL.lazy()
+
+    NODES_PL = pl.DataFrame({"id": ["a", "b", "c"], "v": [1, 2, 3]})
+    NODES_LAZY = NODES_PL.lazy()
+
+    EVENTS_PL = pl.DataFrame({"user": ["alice", "bob", "alice"], "action": ["click", "view", "buy"]})
+    EVENTS_LAZY = EVENTS_PL.lazy()
+
+    EDGES_PD = pd.DataFrame({"src": ["a", "b", "c"], "dst": ["b", "c", "a"]})
+    NODES_PD = pd.DataFrame({"id": ["a", "b", "c"], "v": [1, 2, 3]})
+
+    # ------------------------------------------------------------------
+    # PlotterBase internals — _table_to_arrow and _table_to_pandas
+    # ------------------------------------------------------------------
+
+    class TestPolarsInternals(NoAuthTestCase):
+
+        def _plotter(self):
+            return CGFull()
+
+        def test_table_to_pandas_dataframe(self):
+            g = self._plotter()
+            result = g._table_to_pandas(EDGES_PL)
+            self.assertIsInstance(result, pd.DataFrame)
+            self.assertEqual(list(result.columns), ["src", "dst"])
+
+        def test_table_to_pandas_lazyframe(self):
+            g = self._plotter()
+            result = g._table_to_pandas(EDGES_LAZY)
+            self.assertIsInstance(result, pd.DataFrame)
+            self.assertEqual(list(result.columns), ["src", "dst"])
+
+        def test_table_to_arrow_dataframe(self):
+            g = self._plotter()
+            result = g._table_to_arrow(EDGES_PL, memoize=False)
+            self.assertIsInstance(result, pa.Table)
+            self.assertFalse(result.schema.metadata)  # empty dict or None — no polars metadata
+
+        def test_table_to_arrow_lazyframe(self):
+            g = self._plotter()
+            result = g._table_to_arrow(EDGES_LAZY, memoize=False)
+            self.assertIsInstance(result, pa.Table)
+
+        def test_table_to_arrow_memoization(self):
+            """Same polars frame → same Arrow object returned (memoized)."""
+            g = self._plotter()
+            r1 = g._table_to_arrow(EDGES_PL, memoize=True)
+            r2 = g._table_to_arrow(EDGES_PL, memoize=True)
+            self.assertIs(r1, r2)
+
+        def test_table_to_arrow_schema_metadata_stripped(self):
+            """Polars attaches polars-specific schema metadata; it must be stripped."""
+            g = self._plotter()
+            result = g._table_to_arrow(NODES_PL, memoize=False)
+            self.assertIsInstance(result, pa.Table)
+            self.assertFalse(result.schema.metadata)  # empty dict or None — no polars metadata
+
+    # ------------------------------------------------------------------
+    # Compute path
+    # ------------------------------------------------------------------
+
+    class TestPolarsCompute(NoAuthTestCase):
+
+        def test_materialize_nodes_polars_edges(self):
+            g = CGFull().edges(EDGES_PL, "src", "dst").materialize_nodes()
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIn("id", g._nodes.columns)
+            self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+        def test_materialize_nodes_polars_lazy_edges(self):
+            g = CGFull().edges(EDGES_LAZY, "src", "dst").materialize_nodes()
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertEqual(sorted(g._nodes["id"].tolist()), ["a", "b", "c"])
+
+        def test_materialize_nodes_polars_edges_and_nodes(self):
+            g = (CGFull()
+                 .edges(EDGES_PL, "src", "dst")
+                 .nodes(NODES_PL, "id")
+                 .materialize_nodes())
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIn("v", g._nodes.columns)
+
+        def test_materialize_nodes_polars_edges_pandas_nodes(self):
+            """Mixed: Polars edges + pandas nodes."""
+            g = (CGFull()
+                 .edges(EDGES_PL, "src", "dst")
+                 .nodes(NODES_PD, "id")
+                 .materialize_nodes())
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIn("v", g._nodes.columns)
+
+        def test_get_degrees_polars(self):
+            g = CGFull().edges(EDGES_PL, "src", "dst").get_degrees()
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIn("degree", g._nodes.columns)
+            self.assertIn("degree_in", g._nodes.columns)
+            self.assertIn("degree_out", g._nodes.columns)
+            self.assertTrue(
+                (g._nodes["degree"] == g._nodes["degree_in"] + g._nodes["degree_out"]).all()
+            )
+
+        def test_get_indegrees_polars(self):
+            g = CGFull().edges(EDGES_PL, "src", "dst").get_indegrees()
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIn("degree_in", g._nodes.columns)
+
+        def test_get_outdegrees_polars(self):
+            g = CGFull().edges(EDGES_PL, "src", "dst").get_outdegrees()
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIn("degree_out", g._nodes.columns)
+
+    # ------------------------------------------------------------------
+    # Hypergraph path
+    # ------------------------------------------------------------------
+
+    class TestPolarsHypergraph(NoAuthTestCase):
+
+        def test_hypergraph_polars_dataframe(self):
+            h = graphistry.hypergraph(EVENTS_PL, verbose=False)
+            self.assertIn("graph", h)
+            g = h["graph"]
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertIsInstance(g._edges, pd.DataFrame)
+            self.assertGreater(len(g._nodes), 0)
+            self.assertGreater(len(g._edges), 0)
+
+        def test_hypergraph_polars_lazy(self):
+            h = graphistry.hypergraph(EVENTS_LAZY, verbose=False)
+            g = h["graph"]
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertGreater(len(g._nodes), 0)
+
+        def test_hypergraph_polars_matches_pandas(self):
+            import pandas as pd_mod
+            events_pd = EVENTS_PL.to_pandas()
+            h_pd = graphistry.hypergraph(events_pd, verbose=False)
+            h_pl = graphistry.hypergraph(EVENTS_PL, verbose=False)
+            self.assertEqual(len(h_pd["graph"]._nodes), len(h_pl["graph"]._nodes))
+            self.assertEqual(len(h_pd["graph"]._edges), len(h_pl["graph"]._edges))
+
+        def test_hypergraph_polars_with_entity_types(self):
+            h = graphistry.hypergraph(EVENTS_PL, entity_types=["user"], verbose=False)
+            g = h["graph"]
+            self.assertIsInstance(g._nodes, pd.DataFrame)
+            self.assertGreater(len(g._nodes), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mypy.ini
+++ b/mypy.ini
@@ -70,6 +70,9 @@ ignore_missing_imports = True
 [mypy-pyarrow-stubs.*]
 ignore_errors = True
 
+[mypy-polars.*]
+ignore_missing_imports = True
+
 [mypy-pyspark.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Summary
- `pl.DataFrame` and `pl.LazyFrame` now work in `plot()`, `materialize_nodes()`, `get_degrees()`, `get_indegrees()`, `get_outdegrees()`, and `hypergraph()` without crashing
- Polars is an optional dependency — zero behavior change when not installed
- Results stay pandas-backed (same as Arrow/Spark from #1132)

## Changes
- **`PlotterBase.py`**: `maybe_polars()` lazy import; `_polars_hash_to_arrow` memoization cache; `_table_to_arrow()` Polars branch (LazyFrame collect + `to_arrow()`, polars schema metadata stripped); `_table_to_pandas()` Polars branch; `_plot_dispatch()` type guard
- **`Engine.py`**: `resolve_engine()` Polars → `Engine.PANDAS` explicit branch
- **`ComputeMixin.py`**: `_coerce_to_pandas()` Polars arm (handles both `DataFrame` and `LazyFrame` for edges + nodes)
- **`hyper_dask.py`**: inline coerce block Polars arm
- **`test_polars.py`**: 17 tests — `_table_to_arrow`/`_table_to_pandas` internals, memoization, metadata stripping, compute path (DataFrame + LazyFrame, mixed polars/pandas), hypergraph (DataFrame + LazyFrame, `entity_types` filter, parity with pandas)

## Depends on
#1132 ✅ (merged) — coerce-at-boundary pattern for Arrow + Spark

## Test plan
- [ ] `pytest graphistry/tests/test_polars.py` — 17 passed locally
- [ ] `pytest graphistry/tests/test_df_types.py test_compute.py test_hypergraph.py` — 47 passed, 5 skipped (no regression)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)