### PR TITLE
fix(gfql/m3): tighten unknown-alias MATCH route contract (#1158)

### DIFF
--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -7733,6 +7733,7 @@ def _compile_graph_constructor(
         synthetic,
         bound_ir=constructor_bound_ir,
         params=params,
+        allow_unknown_match_aliases=True,
     )
     return CompiledCypherQuery(
         Chain(lowered.query, where=lowered.where),
@@ -8321,6 +8322,7 @@ def _logical_plan_route_for_query(
     *,
     bound_ir: BoundIR,
     params: Optional[Mapping[str, Any]] = None,
+    allow_unknown_match_aliases: bool = False,
 ) -> Tuple[Optional[LogicalPlan], Optional[str]]:
     if query.call is not None:
         compiled_call = compile_cypher_call(query.call, params=params)
@@ -8328,7 +8330,9 @@ def _logical_plan_route_for_query(
         _verify_selected_logical_plan(logical_plan)
         return logical_plan, None
     try:
-        logical_plan = LogicalPlanner().plan(bound_ir, PlanContext())
+        logical_plan = LogicalPlanner(
+            allow_unknown_match_aliases=allow_unknown_match_aliases
+        ).plan(bound_ir, PlanContext())
     except GFQLValidationError as exc:
         return None, str(exc.message)
     _verify_selected_logical_plan(logical_plan)

--- a/graphistry/compute/gfql/logical_planner.py
+++ b/graphistry/compute/gfql/logical_planner.py
@@ -37,6 +37,9 @@ class IdGen:
 class LogicalPlanner:
     """Initial planner skeleton from BoundIR to LogicalPlan."""
 
+    def __init__(self, *, allow_unknown_match_aliases: bool = False) -> None:
+        self._allow_unknown_match_aliases = allow_unknown_match_aliases
+
     def plan(self, bound_ir: BoundIR, ctx: PlanContext) -> LogicalPlan:
         """Build a minimal logical plan root for supported M2 skeleton shapes."""
         _ = ctx
@@ -45,7 +48,7 @@ class LogicalPlanner:
         vars_by_name = bound_ir.semantic_table.variables
         seen_match = False
 
-        for part in bound_ir.query_parts:
+        for part_index, part in enumerate(bound_ir.query_parts):
             clause = part.clause.upper()
             if clause == "OPTIONAL MATCH":
                 raise GFQLValidationError(
@@ -64,7 +67,16 @@ class LogicalPlanner:
                         value=part.clause,
                         suggestion="Use a single MATCH stage until chained pattern planning is implemented.",
                     )
-                self._reject_unsupported_match_shape(part=part, vars_by_name=vars_by_name)
+                scope_visible_aliases = (
+                    bound_ir.scope_stack[part_index].visible_vars
+                    if part_index < len(bound_ir.scope_stack)
+                    else frozenset()
+                )
+                self._reject_unsupported_match_shape(
+                    part=part,
+                    vars_by_name=vars_by_name,
+                    scope_visible_aliases=scope_visible_aliases,
+                )
                 current = self._plan_match(part=part, vars_by_name=vars_by_name, id_gen=id_gen)
                 current = self._apply_predicates(part=part, current=current, vars_by_name=vars_by_name, id_gen=id_gen)
                 seen_match = True
@@ -124,6 +136,7 @@ class LogicalPlanner:
         *,
         part: BoundQueryPart,
         vars_by_name: Mapping[str, BoundVariable],
+        scope_visible_aliases: FrozenSet[str] = frozenset(),
     ) -> None:
         alias_names = part.outputs or part.inputs
         if not alias_names:
@@ -137,22 +150,33 @@ class LogicalPlanner:
         has_known_alias = False
         for alias in alias_names:
             variable = vars_by_name.get(alias)
-            if variable is None:
+            if variable is not None:
+                has_known_alias = True
+                if variable.entity_kind not in {"node", "edge"}:
+                    raise GFQLValidationError(
+                        ErrorCode.E108,
+                        "LogicalPlanner skeleton only supports MATCH outputs bound to node/edge aliases",
+                        field="clause",
+                        value=part.clause,
+                        suggestion="Use MATCH with node/edge aliases only until richer pattern planning is implemented.",
+                    )
                 continue
-            has_known_alias = True
-            if variable.entity_kind not in {"node", "edge"}:
-                raise GFQLValidationError(
-                    ErrorCode.E108,
-                    "LogicalPlanner skeleton only supports MATCH outputs bound to node/edge aliases",
-                    field="clause",
-                    value=part.clause,
-                    suggestion="Use MATCH with node/edge aliases only until richer pattern planning is implemented.",
-                )
+            if alias in scope_visible_aliases:
+                has_known_alias = True
+                continue
         if not has_known_alias:
-            # Some synthetic compile paths (for example, graph constructors
-            # lowered to MATCH + empty RETURN) may not materialize alias
-            # entries in SemanticTable. Allow these through as skeleton plans.
-            return
+            if self._allow_unknown_match_aliases:
+                # Some synthetic compile paths (for example, graph constructors
+                # lowered to MATCH + empty RETURN) may not materialize alias
+                # entries in SemanticTable. Keep this as an explicit opt-in.
+                return
+            raise GFQLValidationError(
+                ErrorCode.E108,
+                "LogicalPlanner skeleton requires MATCH aliases to be present in semantic scope",
+                field="clause",
+                value=part.clause,
+                suggestion="Use query shapes whose MATCH aliases are bound in semantic scope.",
+            )
 
     def _plan_where(
         self,

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -23,6 +23,8 @@ from graphistry.compute.gfql.cypher import (
     WherePatternPredicate,
 )
 from graphistry.compute.gfql.cypher.lowering import CompiledCypherGraphQuery
+from graphistry.compute.gfql.cypher.lowering import _logical_plan_route_for_query
+from graphistry.compute.gfql.ir.bound_ir import BoundIR, BoundQueryPart, SemanticTable
 from graphistry.compute.gfql.ir.logical_plan import ProcedureCall as LogicalProcedureCall
 from graphistry.tests.test_compute import CGFull
 
@@ -742,6 +744,37 @@ def test_compiled_query_sets_logical_plan_defer_reason_for_optional_shape() -> N
     assert compiled.logical_plan is None
     assert compiled.logical_plan_defer_reason is not None
     assert "OPTIONAL MATCH" in compiled.logical_plan_defer_reason
+
+
+def test_logical_plan_route_for_query_defers_unknown_alias_match_shape_by_default() -> None:
+    query = _parse_query("MATCH (n:Person) RETURN n")
+    bound_ir = BoundIR(
+        query_parts=[
+            BoundQueryPart(clause="MATCH", outputs=frozenset({"ghost"})),
+            BoundQueryPart(clause="RETURN", outputs=frozenset({"ghost"})),
+        ],
+        semantic_table=SemanticTable(variables={}),
+    )
+    logical_plan, defer_reason = _logical_plan_route_for_query(query, bound_ir=bound_ir)
+    assert logical_plan is None
+    assert defer_reason is not None
+    assert "present in semantic scope" in defer_reason
+
+
+def test_logical_plan_route_for_query_allows_unknown_alias_match_shape_when_opted_in() -> None:
+    query = _parse_query("MATCH (n:Person) RETURN n")
+    bound_ir = BoundIR(
+        query_parts=[
+            BoundQueryPart(clause="MATCH", outputs=frozenset({"ghost"})),
+            BoundQueryPart(clause="RETURN", outputs=frozenset({"ghost"})),
+        ],
+        semantic_table=SemanticTable(variables={}),
+    )
+    logical_plan, defer_reason = _logical_plan_route_for_query(
+        query, bound_ir=bound_ir, allow_unknown_match_aliases=True
+    )
+    assert logical_plan is not None
+    assert defer_reason is None
 
 
 def test_compiled_query_sets_logical_plan_route_for_call_shape() -> None:

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -738,6 +738,13 @@ def test_compiled_query_sets_logical_plan_route_for_covered_shape() -> None:
     assert compiled.logical_plan_defer_reason is None
 
 
+def test_compiled_query_sets_logical_plan_route_for_match_scalar_return_shape() -> None:
+    compiled = _compile_query("MATCH (n:Person) RETURN 1 AS x")
+    assert compiled.logical_plan_route == "planned"
+    assert compiled.logical_plan is not None
+    assert compiled.logical_plan_defer_reason is None
+
+
 def test_compiled_query_sets_logical_plan_defer_reason_for_optional_shape() -> None:
     compiled = _compile_query("OPTIONAL MATCH (n:Person) RETURN n")
     assert compiled.logical_plan_route == "deferred"

--- a/graphistry/tests/compute/gfql/test_logical_planner.py
+++ b/graphistry/tests/compute/gfql/test_logical_planner.py
@@ -318,6 +318,26 @@ def test_logical_planner_plans_single_alias_edge_match_shapes() -> None:
     assert set(pattern.output_schema.columns.keys()) == {"r"}
 
 
+def test_logical_planner_rejects_unknown_alias_match_shapes_by_default() -> None:
+    bound_ir = BoundIR(
+        query_parts=[BoundQueryPart(clause="MATCH", outputs=frozenset({"ghost"}))],
+        semantic_table=SemanticTable(variables={}),
+    )
+    with pytest.raises(GFQLValidationError, match="present in semantic scope"):
+        LogicalPlanner().plan(bound_ir, PlanContext())
+
+
+def test_logical_planner_allows_unknown_alias_match_shapes_when_opted_in() -> None:
+    bound_ir = BoundIR(
+        query_parts=[BoundQueryPart(clause="MATCH", outputs=frozenset({"ghost"}))],
+        semantic_table=SemanticTable(variables={}),
+    )
+    root = LogicalPlanner(allow_unknown_match_aliases=True).plan(bound_ir, PlanContext())
+    pattern = _find_first(root, PatternMatch)
+    assert pattern is not None
+    assert pattern.output_schema.columns == {}
+
+
 def test_logical_planner_rejects_unwind_without_exactly_one_new_alias() -> None:
     base_vars = {
         "n": BoundVariable(


### PR DESCRIPTION
## Summary
Resolves #1158 by tightening unknown-alias `MATCH` route behavior so permissive planning is explicit and scoped:

- Default planner path now rejects unknown-alias-only `MATCH` shapes with a stable validation message.
- Unknown-alias permissive planning is preserved only via explicit opt-in (`allow_unknown_match_aliases=True`).
- Lowering routes constructor synthetic flow through that explicit opt-in only.
- Planner validation now treats per-part `scope_stack` visible aliases as known context, avoiding false defers from semantic-table narrowing.

## Why
After #1155, unknown-alias fallback remained broadly permissive in planner validation. This could classify underconstrained shapes as `logical_plan_route == "planned"` unless explicitly bounded.

## Changes
- `graphistry/compute/gfql/logical_planner.py`
  - Add `LogicalPlanner(..., allow_unknown_match_aliases=False)`.
  - Default unknown-alias `MATCH` now raises `GFQLValidationError`.
  - Use `scope_stack[part_index].visible_vars` as additional known-context signal for legitimate bound MATCH stages.
- `graphistry/compute/gfql/cypher/lowering.py`
  - Add `allow_unknown_match_aliases` parameter to `_logical_plan_route_for_query()`.
  - Thread explicit opt-in only from `_compile_graph_constructor()` synthetic path.
- Tests
  - `graphistry/tests/compute/gfql/test_logical_planner.py`
    - default reject unknown alias
    - explicit opt-in allow unknown alias
  - `graphistry/tests/compute/gfql/cypher/test_lowering.py`
    - route helper defers unknown alias by default
    - route helper allows unknown alias when explicitly opted in

## Validation
- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest -q graphistry/tests/compute/gfql/test_logical_planner.py`
  - `22 passed`
- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "logical_plan_route or logical_plan_defer_reason or constructor or unknown_alias"`
  - `37 passed, 1 skipped, 726 deselected`
