### PR TITLE
fix(cypher): grammar-resolve where_predicates vs expr ambiguity (#1194)

### DIFF
--- a/graphistry/compute/gfql/cypher/parser.py
+++ b/graphistry/compute/gfql/cypher/parser.py
@@ -1046,8 +1046,27 @@ def _build_transformer(source: str, *, allow_where_reparse: bool = True) -> _Tra
                 try:
                     reparsed_tree = _where_clause_parser().parse(clause_text)
                     reparsed_node = _build_transformer(clause_text, allow_where_reparse=False).transform(reparsed_tree)
-                    if isinstance(reparsed_node, WhereClause) and reparsed_node.expr is None and len(reparsed_node.predicates) > 0:
-                        return reparsed_node
+                    if (
+                        isinstance(reparsed_node, WhereClause)
+                        and reparsed_node.expr is None
+                        and len(reparsed_node.predicates) > 0
+                        and all(
+                            isinstance(term, WherePredicate)
+                            and term.op == "has_labels"
+                            and isinstance(term.left, LabelRef)
+                            for term in reparsed_node.predicates
+                        )
+                    ):
+                        predicates = tuple(
+                            WherePredicate(
+                                left=LabelRef(alias=term.left.alias, labels=term.left.labels, span=span),
+                                op="has_labels",
+                                right=None,
+                                span=span,
+                            )
+                            for term in cast(Tuple[WherePredicate, ...], reparsed_node.predicates)
+                        )
+                        return WhereClause(predicates=predicates, expr=None, span=span)
                 except Exception:
                     # Keep generic expr fallback if sub-parse fails or still
                     # resolves to a generic clause.

--- a/graphistry/compute/gfql/cypher/parser.py
+++ b/graphistry/compute/gfql/cypher/parser.py
@@ -1057,15 +1057,18 @@ def _build_transformer(source: str, *, allow_where_reparse: bool = True) -> _Tra
                             for term in reparsed_node.predicates
                         )
                     ):
-                        predicates = tuple(
-                            WherePredicate(
-                                left=LabelRef(alias=term.left.alias, labels=term.left.labels, span=span),
-                                op="has_labels",
-                                right=None,
-                                span=span,
+                        predicates_list: List[WherePredicate] = []
+                        for term in cast(Tuple[WherePredicate, ...], reparsed_node.predicates):
+                            label_ref = cast(LabelRef, term.left)
+                            predicates_list.append(
+                                WherePredicate(
+                                    left=LabelRef(alias=label_ref.alias, labels=label_ref.labels, span=span),
+                                    op="has_labels",
+                                    right=None,
+                                    span=span,
+                                )
                             )
-                            for term in cast(Tuple[WherePredicate, ...], reparsed_node.predicates)
-                        )
+                        predicates = tuple(predicates_list)
                         return WhereClause(predicates=predicates, expr=None, span=span)
                 except Exception:
                     # Keep generic expr fallback if sub-parse fails or still

--- a/graphistry/compute/gfql/cypher/parser.py
+++ b/graphistry/compute/gfql/cypher/parser.py
@@ -301,7 +301,6 @@ BLOCK_COMMENT: /\/\*[\s\S]*?\*\//
 %ignore BLOCK_COMMENT
 """
 
-_BARE_LABEL_PREDICATE_RE = re.compile(r"^(?P<alias>[A-Za-z_][A-Za-z0-9_]*)((?::[A-Za-z_][A-Za-z0-9_]*)+)$")
 _RESERVED_IDENTIFIER_GRAPH = "graph"
 _WHERE_PATTERN_ITEM_RE = re.compile(
     r"\([^)\n]*\)\s*(?:<--|-->|--|<-\[[^\]\n]*\]-|-\[[^\]\n]*\]->|-\[[^\]\n]*\]-)\s*\([^)\n]*\)"
@@ -421,6 +420,20 @@ def _pattern_parser() -> _ParserLike:
     return cast(_ParserLike, parser)
 
 
+@lru_cache(maxsize=1)
+def _where_clause_parser() -> _ParserLike:
+    Lark, _, _, _ = _lark_imports()
+    parser = Lark(
+        _GRAMMAR,
+        start="where_clause",
+        parser="earley",
+        ambiguity="resolve",
+        maybe_placeholders=False,
+        propagate_positions=True,
+    )
+    return cast(_ParserLike, parser)
+
+
 def _to_syntax_error(message: str, *, line: Optional[int] = None, column: Optional[int] = None, **extra: Any) -> GFQLSyntaxError:
     return GFQLSyntaxError(
         ErrorCode.E107,
@@ -495,7 +508,7 @@ def _canonicalize_where_single_pattern_and_expr(source: str) -> Optional[str]:
     return None
 
 
-def _build_transformer(source: str) -> _TransformerLike:
+def _build_transformer(source: str, *, allow_where_reparse: bool = True) -> _TransformerLike:
     _, Transformer, _, v_args = _lark_imports()
     op_map = {
         "=": "==",
@@ -1028,40 +1041,17 @@ def _build_transformer(source: str) -> _TransformerLike:
         def generic_where_clause(self, meta: Any, _items: Sequence[Any]) -> WhereClause:
             span = _span_from_meta(meta)
             expr = self._slice(span)[len("WHERE"):].strip()
-            # Lark's ambiguity resolution prefers the generic `expr` path over
-            # the structured `where_predicates` rule, so AND-joined bare label
-            # predicates ("n:Admin AND n:Active") land here rather than in
-            # `where_clause`.  Detect and lift them to structured predicates so
-            # the binder can perform label narrowing without regex.  Any part
-            # that is not a bare label predicate causes a conservative fallback
-            # to raw expr (no narrowing).
-            #
-            # Split on top-level AND using the shared helper (quote/bracket/
-            # paren/backtick-aware, case-insensitive).  An empty result means
-            # malformed input — fall back to the whole expression as a single
-            # term so the label-match check runs uniformly.
-            parts = split_top_level_and(expr) or (expr,)
-            predicates: List[WherePredicate] = []
-            for part in parts:
-                # `fullmatch` anchoring is load-bearing for security: it prevents
-                # fragments of string literals (which contain quotes/spaces) from
-                # matching as bare label predicates.  Relaxing to `match` would
-                # re-introduce the false-positive that motivated issue #1125.
-                m = _BARE_LABEL_PREDICATE_RE.fullmatch(part.strip())
-                if m is None:
-                    predicates = []
-                    break
-                labels = tuple(label for label in m.group(2).split(":") if label)
-                predicates.append(
-                    WherePredicate(
-                        left=LabelRef(alias=m.group("alias"), labels=labels, span=span),
-                        op="has_labels",
-                        right=None,
-                        span=span,
-                    )
-                )
-            if predicates:
-                return WhereClause(predicates=tuple(predicates), expr=None, span=span)
+            if allow_where_reparse and ":" in expr:
+                clause_text = self._slice(span)
+                try:
+                    reparsed_tree = _where_clause_parser().parse(clause_text)
+                    reparsed_node = _build_transformer(clause_text, allow_where_reparse=False).transform(reparsed_tree)
+                    if isinstance(reparsed_node, WhereClause) and reparsed_node.expr is None and len(reparsed_node.predicates) > 0:
+                        return reparsed_node
+                except Exception:
+                    # Keep generic expr fallback if sub-parse fails or still
+                    # resolves to a generic clause.
+                    pass
             return WhereClause(predicates=(), expr=ExpressionText(text=expr, span=span), span=span)
 
         def unwind_clause(self, meta: Any, items: Sequence[Any]) -> UnwindClause:

--- a/graphistry/compute/gfql/frontends/cypher/binder.py
+++ b/graphistry/compute/gfql/frontends/cypher/binder.py
@@ -939,12 +939,26 @@ def _where_predicates(where: WhereClause) -> List[BoundPredicate]:
 
 
 def _apply_where_label_narrowing(state: _BindState, where: WhereClause) -> Set[str]:
+    if where.expr is not None:
+        return set()
+    if not where.predicates:
+        return set()
+    # Conservative policy: only narrow when the whole WHERE clause is a
+    # conjunction of label predicates. Mixed label/property predicates must
+    # keep original labels untouched.
+    if any(
+        not (isinstance(term, WherePredicate) and term.op == "has_labels" and isinstance(term.left, LabelRef))
+        for term in where.predicates
+    ):
+        return set()
+
     narrowed: Dict[str, Set[str]] = {}
 
-    for term in where.predicates:
-        if isinstance(term, WherePredicate) and term.op == "has_labels" and isinstance(term.left, LabelRef):
-            labels = narrowed.setdefault(term.left.alias, set())
-            labels.update(term.left.labels)
+    for raw_term in where.predicates:
+        term = cast(WherePredicate, raw_term)
+        label_ref = cast(LabelRef, term.left)
+        labels = narrowed.setdefault(label_ref.alias, set())
+        labels.update(label_ref.labels)
 
     changed: Set[str] = set()
     for alias, labels in narrowed.items():

--- a/graphistry/tests/compute/gfql/cypher/test_binder.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binder.py
@@ -429,6 +429,17 @@ def test_binder_label_narrowing_mixed_label_and_property_predicate() -> None:
     assert n_var.logical_type.labels == frozenset()
 
 
+def test_binder_label_narrowing_mixed_property_and_label_predicate_order_is_conservative() -> None:
+    # "n.prop = 1 AND n:Admin" is the same logical shape as the inverse order
+    # and must remain all-or-nothing (no partial label narrowing).
+    query = "MATCH (n) WHERE n.prop = 1 AND n:Admin RETURN n"
+    bound = FrontendBinder().bind(parse_cypher(query), PlanContext())
+
+    n_var = bound.semantic_table.variables["n"]
+    assert isinstance(n_var.logical_type, NodeRef)
+    assert n_var.logical_type.labels == frozenset()
+
+
 def test_binder_label_narrowing_multi_label_per_alias_in_and_conjunction() -> None:
     # "n:A:B AND n:C" — multi-label per predicate combined with AND.
     query = "MATCH (n) WHERE n:A:B AND n:C RETURN n"

--- a/graphistry/tests/compute/gfql/cypher/test_parser.py
+++ b/graphistry/tests/compute/gfql/cypher/test_parser.py
@@ -20,6 +20,7 @@ from graphistry.compute.gfql.cypher import (
     WherePatternPredicate,
     parse_cypher,
 )
+from graphistry.compute.gfql.cypher import parser as cypher_parser
 from graphistry.compute.gfql.cypher.ast import GraphBinding, GraphConstructor, UseClause
 
 
@@ -360,8 +361,7 @@ def test_parse_where_clause() -> None:
 
 
 def test_parse_where_and_label_predicates_produces_structured_ast() -> None:
-    # AND-joined bare label predicates must land in WhereClause.predicates (not .expr)
-    # because Lark routes them to generic_where_clause via ambiguity resolution.
+    # AND-joined bare label predicates must land in WhereClause.predicates (not .expr).
     parsed = _parse_query("MATCH (n) WHERE n:Admin AND n:Active RETURN n")
 
     assert parsed.where is not None
@@ -391,10 +391,7 @@ def test_parse_where_single_label_predicate_produces_structured_ast() -> None:
 
 
 def test_parse_where_non_label_expression_produces_raw_expr() -> None:
-    # Non-label WHERE expressions land through a different grammar path
-    # (`where_predicates` or raw expr); the contract under review is that
-    # `generic_where_clause` never synthesizes fake has_labels predicates
-    # from non-label text.  Assert no has_labels predicate is present.
+    # Non-label WHERE expressions must never synthesize fake has_labels terms.
     parsed = _parse_query("MATCH (n) WHERE n.name = 'alice' RETURN n")
 
     assert parsed.where is not None
@@ -414,12 +411,7 @@ def test_parse_where_xor_label_expression_stays_as_raw_expr() -> None:
     assert parsed.where.predicates == ()
 
 
-def test_parse_where_triple_and_label_conjunction_through_generic_where_clause() -> None:
-    # End-to-end coverage that a triple-AND bare-label WHERE still routes
-    # through ``generic_where_clause`` and is lifted into structured
-    # ``WhereClause.predicates`` by the shared ``split_top_level_and``
-    # helper (see graphistry/compute/gfql/expr_split.py).  Quote-awareness
-    # of the helper is covered directly by ``test_expr_split.py``.
+def test_parse_where_triple_and_label_conjunction_produces_structured_ast() -> None:
     parsed = _parse_query("MATCH (n) WHERE n:Admin AND n:Active AND n:Super RETURN n")
 
     assert parsed.where is not None
@@ -431,6 +423,13 @@ def test_parse_where_triple_and_label_conjunction_through_generic_where_clause()
         if isinstance(p, WherePredicate) and isinstance(p.left, LabelRef)
     ]
     assert aliases == ["n", "n", "n"]
+
+
+def test_parse_where_label_conjunction_uses_structured_where_predicates_rule() -> None:
+    tree = cypher_parser._where_clause_parser().parse("WHERE n:Admin AND n:Active")
+
+    assert any(True for _ in tree.find_data("where_predicates"))
+    assert not any(True for _ in tree.find_data("generic_where_clause"))
 
 
 def test_parse_where_null_predicates() -> None:


### PR DESCRIPTION
## Summary
- resolves #1194 by replacing regex/text-split lifting in `generic_where_clause` with grammar-driven reparsing of ambiguous `WHERE` clauses
- keeps primary Cypher parser on `lalr` (to avoid query-shape regressions), and adds a targeted `earley` `where_clause` subparser for ambiguous label-predicate cases
- hardens binder label narrowing to an explicit all-or-nothing policy: only narrow when the full WHERE predicate set is label-only
- updates parser/binder tests for routing and conservative mixed-predicate behavior

## Why this shape
- a full parser switch to `earley` fixed ambiguity but regressed clause attachment (for example `WITH ... WHERE ...`)
- targeted `where_clause` reparsing preserves existing global parse behavior while removing the regex fallback and still using grammar-level disambiguation

## Validation
- `PYTHONPATH=. uv run --no-project --with lark --with pytest python -m pytest graphistry/tests/compute/gfql/cypher/test_parser.py -q`
- `PYTHONPATH=. uv run --no-project --with lark --with pytest python -m pytest graphistry/tests/compute/gfql/cypher/test_binder.py -q`
- `PYTHONPATH=. uv run --no-project --with lark --with pytest python -m pytest graphistry/tests/compute/gfql/cypher/test_lowering.py -q`
- `PYTHONPATH=. uv run --no-project --with ruff ruff check graphistry/compute/gfql/cypher/parser.py graphistry/compute/gfql/frontends/cypher/binder.py graphistry/tests/compute/gfql/cypher/test_parser.py graphistry/tests/compute/gfql/cypher/test_binder.py`
