### PR TITLE
test(cypher): lock #1038 IC4 return-side CASE behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL / Cypher**: Support direct local Cypher `shortestPath(...)` scalar execution for the benchmark-facing subset, including `length(path)`, `path IS NULL`, `CASE path IS NULL WHEN true THEN -1 ELSE length(path) END`, and the official comma-seeded `interactive-complex-13` shape. Generic path-carrier projections and `allShortestPaths(...)` remain explicit fail-fast boundaries (#1010).
 
 ### Fixed
+- **GFQL / Cypher (#1038, #1261 slices S1-S5)**: Hardened RETURN-side `CASE` handling in the local Cypher path for IC4-shaped query forms. Added a lowering fail-fast guard so aggregates nested inside row CASE expressions are rejected at compile-time with `E108` (instead of leaking to runtime row-expression failures), and stabilized regression-lock expectations across pandas compatibility lanes by asserting null-like semantics (`None`/`NaN`) where appropriate.
 - **GFQL / Cypher**: Non-final `WITH alias, agg()` aggregate stages on bindings-row tables (e.g., `WITH tag, sum(cd) AS total`) now correctly group per alias and preserve `alias.*` property columns for subsequent stages. Previously the group key used the wrong column name (`id` instead of `tag.id`), the entity-blob serializer made every row unique, and property columns like `tag.name` were dropped before the next `RETURN` stage could access them (#1054).
 - **GFQL / Cypher**: Extended scalar columns from a bindings-row `WITH` stage (e.g., `WITH tag, post.creationDate AS cd`) are now visible in subsequent non-aggregate stages (`WITH cd ... RETURN cd`). Previously, the next stage resolved the projected column name as an alias-qualified property path and prepended the active alias a second time, producing `None` instead of the actual scalar value (#1045).
 
@@ -171,6 +172,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Tests / RAPIDS compat**: Replace `cudf.DataFrame.from_pandas()` with `cudf.from_pandas()` across GFQL Cypher test suite for RAPIDS 25.02 + 26.02 compatibility.
 
 ### Tests
+- **GFQL / Cypher (#1038, #1261 slices S1-S5)**: Added/expanded regression coverage in `test_lowering.py`, `test_parser.py`, and `test_binder.py` for IC4-style RETURN-side CASE, parser rejection of malformed CASE, binder scope/name-resolution behavior for CASE after `WITH DISTINCT`, and explicit rejection of aggregate calls nested in row CASE expressions.
 - **GFQL / bindings rows**: Added benchmark-shaped regressions for native IS6-style multihop continuation plus direct Cypher IS1 / IS3 / IS6 projection shapes.
 - **GFQL / Cypher**: Added cartesian `MATCH` regressions covering scalar projection, non-simple row expressions, grouped/global aggregates, staged `WITH` filters, and direct `rows(binding_ops=[Node, Node])` cartesian row materialization.
 - **GFQL / Cypher**: Added exact IC6 runtime regression coverage plus multihop joined-row regressions for undirected no-backtracking, branching reentry fanout, and direct `rows(binding_ops=...)` bare-alias row expressions (#1000).

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -1959,6 +1959,14 @@ def _row_expr_arg(
         line=expr.span.line,
         column=expr.span.column,
     )
+    if _contains_aggregate_call(node):
+        raise _unsupported(
+            "Cypher aggregate functions must be top-level RETURN/WITH projections or valid post-aggregate expressions",
+            field=field,
+            value=expr.text,
+            line=expr.span.line,
+            column=expr.span.column,
+        )
     return _render_expr_node(node)
 
 

--- a/graphistry/tests/compute/gfql/cypher/test_binder.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binder.py
@@ -291,6 +291,30 @@ def test_binder_unresolved_name_failure_after_with_scope_reset() -> None:
         FrontendBinder().bind(parse_cypher(query), PlanContext(), strict_name_resolution=True)
 
 
+def test_binder_ic4_return_case_across_with_distinct_scope() -> None:
+    query = (
+        "MATCH (person:Person {id: $pid})-[:KNOWS]-(friend:Person), "
+        "(friend)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag) "
+        "WITH DISTINCT tag, post "
+        "RETURN CASE WHEN 1275350400000 <= post.creationDate AND post.creationDate < 1306886400000 "
+        "THEN post.id ELSE null END AS postId"
+    )
+    bound = FrontendBinder().bind(parse_cypher(query), PlanContext(), strict_name_resolution=True)
+
+    assert [part.clause for part in bound.query_parts] == ["MATCH", "WITH", "RETURN"]
+    assert "postId" in bound.semantic_table.variables
+    post_id_var = bound.semantic_table.variables["postId"]
+    assert isinstance(post_id_var.logical_type, ScalarType)
+    assert post_id_var.entity_kind == "scalar"
+
+
+def test_binder_unresolved_name_failure_inside_return_case_predicate() -> None:
+    query = "MATCH (n:Person) WITH n AS m RETURN CASE WHEN ghost IS NULL THEN 1 ELSE 0 END AS x"
+    with pytest.raises(GFQLValidationError, match="Unresolved identifier") as exc_info:
+        FrontendBinder().bind(parse_cypher(query), PlanContext(), strict_name_resolution=True)
+    assert exc_info.value.code == ErrorCode.E204
+
+
 @pytest.mark.parametrize(
     "query",
     [

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -11070,6 +11070,64 @@ def test_string_cypher_multi_alias_with_three_stage_case_aggregation() -> None:
     assert all(r["postCount"] > 0 for r in records)
 
 
+def test_issue_1038_ic4_return_side_case_expression_regression_lock() -> None:
+    """Regression lock for #1038: RETURN-side CASE over IC4-shaped post timestamp ranges."""
+    graph = _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["p1", "f1", "f2", "post1", "post2", "post3", "tag1", "tag2"],
+                "label__Person": [True, True, True, False, False, False, False, False],
+                "label__Post": [False, False, False, True, True, True, False, False],
+                "label__Tag": [False, False, False, False, False, False, True, True],
+                "name": ["", "", "", "", "", "", "TagA", "TagB"],
+                "creationDate": [
+                    0,
+                    0,
+                    0,
+                    1275350400000,
+                    1275264000000,
+                    1306799999999,
+                    0,
+                    0,
+                ],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["p1", "p1", "post1", "post2", "post3", "post1", "post2", "post3"],
+                "d": ["f1", "f2", "f1", "f1", "f2", "tag1", "tag1", "tag2"],
+                "type": [
+                    "KNOWS",
+                    "KNOWS",
+                    "HAS_CREATOR",
+                    "HAS_CREATOR",
+                    "HAS_CREATOR",
+                    "HAS_TAG",
+                    "HAS_TAG",
+                    "HAS_TAG",
+                ],
+            }
+        ),
+    )
+
+    result = graph.gfql(
+        "MATCH (person:Person {id: $pid})-[:KNOWS]-(friend:Person), "
+        "(friend)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag) "
+        "WITH DISTINCT tag, post "
+        "RETURN tag.name AS tagName, post.id AS rawPostId, "
+        "CASE WHEN 1275350400000 <= post.creationDate AND post.creationDate < 1306886400000 "
+        "THEN post.id ELSE null END AS postId "
+        "ORDER BY tagName ASC, rawPostId ASC",
+        params={"pid": "p1"},
+    )
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"tagName": "TagA", "rawPostId": "post1", "postId": "post1"},
+        {"tagName": "TagA", "rawPostId": "post2", "postId": None},
+        {"tagName": "TagB", "rawPostId": "post3", "postId": "post3"},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Issue #996: MATCH (connected) OPTIONAL MATCH ... RETURN mixed + CASE
 # ---------------------------------------------------------------------------

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -11121,11 +11121,13 @@ def test_issue_1038_ic4_return_side_case_expression_regression_lock() -> None:
         params={"pid": "p1"},
     )
 
-    assert result._nodes.to_dict(orient="records") == [
-        {"tagName": "TagA", "rawPostId": "post1", "postId": "post1"},
-        {"tagName": "TagA", "rawPostId": "post2", "postId": None},
-        {"tagName": "TagB", "rawPostId": "post3", "postId": "post3"},
-    ]
+    rows = result._nodes.to_dict(orient="records")
+    assert len(rows) == 3
+    assert rows[0] == {"tagName": "TagA", "rawPostId": "post1", "postId": "post1"}
+    assert rows[1]["tagName"] == "TagA"
+    assert rows[1]["rawPostId"] == "post2"
+    assert pd.isna(rows[1]["postId"])
+    assert rows[2] == {"tagName": "TagB", "rawPostId": "post3", "postId": "post3"}
 
 
 def test_issue_1038_rejects_aggregate_inside_row_case_expression() -> None:

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -11128,6 +11128,21 @@ def test_issue_1038_ic4_return_side_case_expression_regression_lock() -> None:
     ]
 
 
+def test_issue_1038_rejects_aggregate_inside_row_case_expression() -> None:
+    graph = _mk_ic4_shape_graph()
+
+    with pytest.raises(GFQLValidationError) as exc_info:
+        graph.gfql(
+            "MATCH (person:Person {id: $pid})-[:KNOWS]-(friend:Person), "
+            "(friend)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag) "
+            "WITH DISTINCT tag, post "
+            "RETURN CASE WHEN post.creationDate > 150 THEN count(*) ELSE 0 END AS out",
+            params={"pid": "p1"},
+        )
+
+    assert exc_info.value.code == ErrorCode.E108
+
+
 # ---------------------------------------------------------------------------
 # Issue #996: MATCH (connected) OPTIONAL MATCH ... RETURN mixed + CASE
 # ---------------------------------------------------------------------------

--- a/graphistry/tests/compute/gfql/cypher/test_parser.py
+++ b/graphistry/tests/compute/gfql/cypher/test_parser.py
@@ -537,6 +537,32 @@ def test_parse_return_simple_case_expression() -> None:
     assert parsed.return_.items[0].alias == "result"
 
 
+def test_parse_ic4_style_return_side_case_expression() -> None:
+    parsed = _parse_query(
+        "MATCH (person:Person {id: $pid})-[:KNOWS]-(friend:Person), "
+        "(friend)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag:Tag) "
+        "WITH DISTINCT tag, post "
+        "RETURN tag.name AS tagName, "
+        "CASE WHEN 1275350400000 <= post.creationDate AND post.creationDate < 1306886400000 "
+        "THEN post.id ELSE null END AS postId"
+    )
+
+    assert len(parsed.with_stages) == 1
+    assert parsed.with_stages[0].clause.distinct is True
+    assert parsed.with_stages[0].clause.items[0].expression.text == "tag"
+    assert parsed.with_stages[0].clause.items[1].expression.text == "post"
+    assert parsed.return_.items[1].expression.text == (
+        "CASE WHEN 1275350400000 <= post.creationDate AND post.creationDate < 1306886400000 "
+        "THEN post.id ELSE null END"
+    )
+    assert parsed.return_.items[1].alias == "postId"
+
+
+def test_parse_rejects_return_case_missing_end() -> None:
+    with pytest.raises(GFQLSyntaxError):
+        _parse_query("RETURN CASE WHEN score > 1 THEN true ELSE false AS result")
+
+
 @pytest.mark.parametrize(
     "query,expr_text",
     [


### PR DESCRIPTION
## Scope Guardrail
This PR is **strictly** the `#1261` child-slice implementation lane for `#1038`, limited to:
- `#1265` (S1 repro/lock)
- `#1266` (S2 parser/AST)
- `#1267` (S3 binder/type/scope)
- `#1268` (S4 lowering/runtime)
- `#1269` (S5 conformance/receipts)

Out of scope here:
- unrelated `#1259`/`#992` lanes (`#1256`, `#1257`, `#1219`, `#1046`, etc.)
- broader meta cleanup beyond this child-slice set

## Summary
- Add `#1038` IC4-style RETURN-side `CASE` regression lock.
- Add parser + binder coverage for CASE-return forms and scope handling.
- Add fail-fast lowering guard for aggregates nested in row CASE expressions.
- Normalize null assertion semantics (`None`/`NaN`) in the IC4 lock so pandas-compat lanes stay stable.

## Slice Checklist
### Done now in this PR
- [x] `#1265` S1 implemented and evidenced: lock test + receipt
- [x] `#1266` S2 implemented and evidenced: parser/AST locks + receipt
- [x] `#1267` S3 implemented and evidenced: binder/scope locks + receipt
- [x] `#1268` S4 implemented and evidenced: lowering/runtime fail-fast + receipt
- [x] `#1269` S5 evidenced: local + DGX GPU receipts (`25.02`, `26.02`)

### Merge-time follow-up (coordination)
- [ ] Sync `#1261` child checkboxes to reflect merged state
- [ ] Close **only** child issues satisfied by merged code + receipts (expected candidates: `#1265`–`#1269`)

## Evidence / Receipts
- `#1265`: https://github.com/graphistry/pygraphistry/issues/1265#issuecomment-4367530953
- `#1266`: https://github.com/graphistry/pygraphistry/issues/1266#issuecomment-4367562630
- `#1267`: https://github.com/graphistry/pygraphistry/issues/1267#issuecomment-4367562661
- `#1268`: https://github.com/graphistry/pygraphistry/issues/1268#issuecomment-4367570581
- `#1269` (GPU closeout): https://github.com/graphistry/pygraphistry/issues/1269#issuecomment-4367605769
- `#1038` sync: https://github.com/graphistry/pygraphistry/issues/1038#issuecomment-4367605803
- `#992` sync: https://github.com/graphistry/pygraphistry/issues/992#issuecomment-4367605843

## Validation
- `PYTHONPATH=. python -m pytest graphistry/tests/compute/gfql/cypher/test_lowering.py -k "issue_1038_" -q`
- `PYTHONPATH=. python -m pytest graphistry/tests/compute/gfql/cypher/test_parser.py -k "ic4_style_return_side_case_expression or return_case_missing_end" -q`
- `PYTHONPATH=. python -m pytest graphistry/tests/compute/gfql/cypher/test_binder.py -k "ic4_return_case_across_with_distinct_scope or unresolved_name_failure_inside_return_case_predicate" -q`
- `./bin/ruff.sh graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py graphistry/tests/compute/gfql/cypher/test_parser.py graphistry/tests/compute/gfql/cypher/test_binder.py`

### GPU Validation (dgx-spark)
- RAPIDS `25.02`: 4 targeted tests passed (`/tmp/issue1261_rapids2502.log`)
- RAPIDS `26.02`: 4 targeted tests passed (`/tmp/issue1261_rapids2602.log`)

## Related
- Source residual: #1038
- Meta decomposition: #1261
- Slice issues: #1265, #1266, #1267, #1268, #1269
- Queue meta: #992
