### PR TITLE
docs(skills): audit vectorization + cuDF compatibility in review skill

### DIFF
--- a/agents/skills/review/SKILL.md
+++ b/agents/skills/review/SKILL.md
@@ -175,6 +175,59 @@ python -m pytest -q [targeted_test]
 - If startup/runtime claims are made, verify entrypoints/scripts in `bin/` and workflow behavior.
 - For docs-only PRs, prioritize spec/documentation accuracy and navigability (toctree links, anchors, cross-refs).
 
+#### Vectorization & engine compatibility (GFQL / row pipeline / compute)
+
+GFQL is vectorization-first and pure-functional. The row pipeline runs on pandas + cuDF; per-row Python loops are a pandas perf cliff and a cuDF break, and in-place mutation creates aliasing surprises. Audit edits in `graphistry/compute/**` (esp. `gfql/**`, `plotter/**`) for the patterns below.
+
+**Engine-polymorphic helpers** (use these instead of pandas-only APIs in compute paths):
+- `graphistry.Engine.df_cons(engine)`, `df_concat(engine)`, `df_to_engine(df, engine)`, `safe_merge`, `resolve_engine(arg, df)`
+- `graphistry.compute.dataframe_utils.template_df_cons(template_df, data)`
+- Type DataFrame params as `DataFrameT` (`graphistry.compute.typing`), not `pd.DataFrame`.
+
+**Vectorization** — flag (BLOCKER on hot rows / IMPORTANT elsewhere unless noted):
+
+| Pattern | Fix |
+|---|---|
+| `df.apply(fn, axis=1)`, `iterrows()`, `itertuples()` | Vectorized ops on Series |
+| `for x in df[col]` building a Series | `Series.map` / numpy / mask |
+| `sum(s)` / `max(s)` / etc. on a Series (SUGGESTION) | `s.sum()` / `s.max()` |
+| `df[col][i]` scalar access in a loop | Same vectorization fix; cuDF rejects this |
+
+**Mutation** — pygraphistry is pure-functional; flag IMPORTANT (BLOCKER if cell-wise in a loop):
+
+| Pattern | Pure alternative |
+|---|---|
+| `df[col] = v` / `df.col = v` | `df.assign(col=v)` |
+| `df.loc[mask, col] = v` | `df.assign(col=df[col].where(~mask, v))` |
+| `df.loc[i,c]=` / `df.iloc[]=` / `df.at[]=` in a loop | Build column vectorized + `df.assign(...)` |
+| `inplace=True` (drop/rename/sort/fillna/...) | Drop kwarg; assign return |
+| `del df[col]` | `df.drop(columns=[col])` |
+| `df.append(...)` (deprecated; not in cuDF) | `df_concat(engine)([df, other])` |
+| Mutating then returning the input df | Return a new df; no observable side effects |
+
+Vectorized mutation (`df.loc[mask, col] = v`) is still mutation — prefer `df.assign(...)`.
+
+**cuDF compatibility** — flag IMPORTANT unless noted:
+
+| Pattern | Fix |
+|---|---|
+| `df.apply(fn, axis=1)` (BLOCKER on cuDF lanes) | Vectorize |
+| `.to_pandas()` → pandas op → back | Round-trip = missing vectorization |
+| `is pd.NA` / `== pd.NA` | `s.isna()` |
+| `dtype == "<pandas-name>"` (SUGGESTION) | `pd.api.types.is_*_dtype` or engine-aware helper |
+| Param typed `pd.DataFrame` instead of `DataFrameT` | Use `DataFrameT` |
+
+**Hot row path** = row pipeline executor, edge/node materialization, anything called per-query in `_execute_*` / `_compile_*` / `_lower_*` / row-pipeline ops. **Control plane** = one-shot config builders, error formatters, parser glue (lower bar).
+
+**Paired cuDF coverage required** for changes in `compute/gfql/row/`, `compute/gfql/cypher/`, `compute/gfql_unified.py`, `compute/chain.py`, `compute/hop.py`, `compute/materialize_nodes.py`. Sibling pattern: `pytest.importorskip("cudf")` + engine-parametrized fixture. New DataFrame-touching helpers also need cuDF smoke if on a hot path.
+
+**Flag wording**:
+> [BLOCKER] `<file>:<line>` — `<pattern>` on hot row path. Use `<engine-polymorphic alt>`. See `agents/skills/review/SKILL.md#vectorization--engine-compatibility-gfql--row-pipeline--compute`.
+
+**Don't flag**: `apply(axis=0)` (column-wise = vectorized); `iterrows()` in CLI/test fixtures; mutation of a df the function itself just constructed (no aliasing — SUGGESTION at most); `inplace=True` in throwaway setup code.
+
+**Pre-existing patterns**: verify novelty via `git show origin/<base>:<file>` before raising. Don't re-flag repo debt.
+
 ### Per-file findings format
 
 ```markdown


### PR DESCRIPTION
## Summary

Adds three audit checks to `agents/skills/review/SKILL.md`'s "Pygraphistry-specific review checks" section so reviewers consistently catch GFQL/compute regressions:

1. **Vectorization** — flag `apply(axis=1)`, `iterrows()`, `itertuples()`, per-row Python loops, scalar-in-loop access on hot row paths.
2. **Mutation (pygraphistry is pure-functional)** — flag `df[col]=v`, `df.loc[mask,c]=v`, cell-wise mutation in loops, `inplace=True`, `del df[col]`, `df.append(...)`, mutating-then-returning-input. Inline pure alternatives (`df.assign`, `df.where`, `df.drop`, engine-polymorphic `df_concat(engine)`, etc.).
3. **cuDF compatibility** — flag pandas-only APIs, `.to_pandas()` round-trips, `is pd.NA` comparisons, dtype string matches, signatures locked to `pd.DataFrame` instead of `DataFrameT`.

Plus: a list of engine-polymorphic helpers reviewers should recommend (`df_cons`, `df_concat`, `df_to_engine`, `safe_merge`, `resolve_engine`, `template_df_cons`, `DataFrameT`); paired-cuDF-coverage rule; flag-wording template; false-positive guard distinguishing hot-row paths from control-plane code.

## Why now

The skill currently has one GPU-related line ("if the PR touches GPU code, run GPU CI on dgx-spark") that fires AFTER a code change ships. There's nothing pre-CI guiding a reviewer to flag, e.g., a new `df.apply(fn, axis=1)` on the row pipeline (cuDF-incompatible), a new `df[col] = v` mutation pattern, an `inplace=True`, or a helper signature locking the DataFrame param to `pd.DataFrame`.

Pygraphistry #1279 (free-form intermediate MATCH admit, in review) made these assumptions concrete enough to codify. This PR is independent of #1279.

## What's in / out

**In**: a `#### Vectorization & engine compatibility (GFQL / row pipeline / compute)` subsection (~53 LOC under "Pygraphistry-specific review checks"). Three terse severity tables, engine-polymorphic-helpers list, paired-cuDF rule, flag wording, FP guard.

**Out**: GPU-validation-evidence rule (line 172-174) unchanged. No changes to other skill phases.

## Test plan

- [x] Single-file 53-line addition; reads cleanly with surrounding skill structure.
- [ ] CI green (push pending).

## Refs

- Catalyst: pygraphistry #1279
- No paired TCK PR needed.
