### PR TITLE
fix(cypher): restore free-form reentry plan contract post-#1260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Tests
+- **GFQL / Cypher reentry contract coverage (#989 follow-through)**: Added compile-shape regression `test_compile_cypher_records_freeform_reentry_plan_contract` to lock free-form intermediate MATCH as `ReentryPlan(free_form=True, scalar_only=False)` and prevent regressions to scalar-only fallback tagging.
+
 ### Internal
+- **GFQL / Cypher reentry follow-through cleanup (#989, post-#1260 extraction)**: In `graphistry/compute/gfql/cypher/reentry/runtime.py`, free-form intermediate MATCH plan construction now routes through the whole-row/free-form `ReentryPlan` contract instead of scalar-only fallback tagging. This makes the dedicated runtime `plan.free_form` lane reachable again and removes incidental scalar-only-path dependence for free-form reentry dispatch.
 - **GFQL native types T4 — Arrow/type bridge contracts and coercion semantics (#1312, #1262, #1046)**: Added `graphistry/compute/gfql/ir/arrow_bridge.py` with stable schema-level interchange helpers `to_arrow()` and `from_arrow()` for `RowSchema` + schema-confidence metadata. The bridge records per-field logical-type metadata (`gfql.logical_type`) and confidence (`gfql.schema_confidence`) for deterministic round-trips, supports strict vs widening coercion (`coercion='strict'|'widen'`) at export/import boundaries, preserves scalar nullability exactly, and defines structural-type fallback behavior (`NodeRef`/`EdgeRef`/`PathType` as widened string bridge fields in widen mode). Added focused regression coverage in `graphistry/tests/compute/gfql/test_ir_arrow_bridge.py` for round-trip fidelity, nullability behavior, confidence handling, and strict/widen coercion boundaries.
 
 ## [0.55.0 - 2026-05-05]

--- a/graphistry/compute/gfql/cypher/reentry/runtime.py
+++ b/graphistry/compute/gfql/cypher/reentry/runtime.py
@@ -361,7 +361,6 @@ def _compile_bounded_reentry_query(
             value="*",
             span=query.return_.span,
         )
-    admit_freeform_intermediate_match = free_form
     if first_alias is None:
         raise _unsupported_at_span(
             "Cypher MATCH after WITH currently requires the trailing MATCH to start from a named node alias",
@@ -372,10 +371,10 @@ def _compile_bounded_reentry_query(
 
     hidden_columns = tuple(_reentry_hidden_column_name(output_name) for output_name in carry_columns)
 
-    # Build the explicit ReentryPlan contract. The plan records every whole-row
-    # alias the prefix carries; the row-carrier rewrite (#989) uses CarriedAlias
-    # entries to surface non-source alias properties downstream.
-    if scalar_only_prefix or admit_freeform_intermediate_match:
+    # Build the explicit ReentryPlan contract. Scalar-only prefixes carry
+    # scalar columns only, while whole-row prefixes (including free-form)
+    # record carried aliases explicitly.
+    if scalar_only_prefix:
         current_reentry_plan: ReentryPlan = ReentryPlan(
             reentry_alias_name=reentry_alias,
             aliases=(),
@@ -552,7 +551,7 @@ def _compile_bounded_reentry_query(
                 query_graph=target_extras.query_graph,
                 start_nodes_query=prefix_compiled,
                 optional_reentry=is_optional,
-                reentry_plan=current_reentry_plan if (scalar_only_prefix or admit_freeform_intermediate_match) else (target.reentry_plan or current_reentry_plan),
+                reentry_plan=current_reentry_plan,
                 logical_plan=target.logical_plan,
                 logical_plan_defer_reason=target.logical_plan_defer_reason,
             ),

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -1256,9 +1256,8 @@ def _compiled_query_scalar_reentry_state(
             suggestion="Retry with a node-backed graph before MATCH re-entry.",
         )
     if not carried_columns:
-        # Free-form intermediate MATCH admission (#1263 safe subset) can route
-        # through scalar reentry with zero carried scalars. Keep full node table;
-        # row fan-out/union for multi-row prefixes happens in the caller.
+        # Scalar-only prefix with zero carried scalars: keep the full node table.
+        # Row fan-out/union for multi-row prefixes happens in the caller.
         dispatch_graph = base_graph.bind()
         dispatch_graph._nodes = base_nodes
         edges_df = getattr(base_graph, "_edges", None)

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -8117,6 +8117,26 @@ def test_compile_cypher_records_reentry_plan_for_multi_whole_row_prefix() -> Non
     assert len(non_source) == 1 and non_source[0].output_name == "x"
 
 
+def test_compile_cypher_records_freeform_reentry_plan_contract() -> None:
+    """#989 follow-through: free-form intermediate MATCH must not degrade to
+    scalar-only reentry plan routing.
+    """
+    query = (
+        "MATCH (a:A {id: 'a'}) "
+        "WITH a "
+        "MATCH (n:B) "
+        "RETURN n.id AS nid"
+    )
+    compiled = cast(CompiledCypherQuery, compile_cypher(query))
+    plan = compiled.reentry_plan
+    assert plan is not None
+    assert plan.reentry_alias_name == "n"
+    assert plan.scalar_only is False
+    assert plan.free_form is True
+    assert tuple(alias.output_name for alias in plan.aliases) == ("a",)
+    assert plan.reentry_alias is None
+
+
 def test_string_cypher_admits_multi_whole_row_prefix_when_non_source_aliases_are_unused() -> None:
     """#989 slice 4.3: admit `WITH a, x` prefix when only `a` is referenced downstream."""
     query = (


### PR DESCRIPTION
## Summary
- Worker D #989 follow-through cleanup slice (dead-path retirement tied to post-#1260 reentry extraction)
- Fix bounded reentry plan construction so free-form intermediate MATCH compiles as ReentryPlan(free_form=True, scalar_only=False) instead of degrading to scalar-only tagging
- Keep reentry attachment explicit on the terminal reentry consumer and remove incidental free-form/scalar-only branch coupling
- Add compile-shape regression lock for free-form plan contract
- Update changelog and scalar-only runtime helper comment to match the new contract

## Validation
- python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "compile_cypher_records_freeform_reentry_plan_contract or freeform_intermediate_reentry or scalar_only_prefix_with_match_reentry"
- python -m pytest -q graphistry/tests/compute/test_gfql.py -k "reentry"
- python -m pytest -q graphistry/tests/compute/gfql/cypher/test_cycle_policy.py
- python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "reentry"
- uv run ruff check graphistry/compute/gfql/cypher/reentry/runtime.py graphistry/compute/gfql_unified.py graphistry/tests/compute/gfql/cypher/test_lowering.py

## Issue
- #989
