### PR TITLE
docs(gfql): add WCC/SCC labeling examples for cugraph/igraph/cypher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Documentation
+- **GFQL component-labeling examples + README clarity (#1324)**: Added concise WCC/SCC labeling examples for `compute_cugraph`, `compute_igraph('clusters')`, and local Cypher `CALL graphistry.cugraph.*` write/row modes in GFQL docs, clarified that component IDs are partition labels (not stable semantic IDs), and tightened the main README GFQL intro sentence for readability.
+
 ## [0.55.1 - 2026-05-05]
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ PyGraphistry is an open source Python library for data scientists and developers
 
 * [**Prototype locally and deploy remotely:**](https://www.graphistry.com/get-started) Prototype from notebooks like Jupyter and Databricks using local CPUs & GPUs, and then power production dashboards & pipelines with Graphistry Hub and your own self-hosted servers.
 
-* [**Query graphs with GFQL:**](https://pygraphistry.readthedocs.io/en/latest/gfql/index.html) Use GFQL, the first fully vectorized dataframe-native graph query language with an open-source GPU runtime, to ask relationship questions that are difficult for tabular tools and without requiring a database, including friendly Cypher syntax and declarative graph semantics through `g.gfql("MATCH ...")`, with the same GFQL execution model available on the current bound graph or remotely via `g.gfql_remote([...])`.
+* [**Query graphs with GFQL:**](https://pygraphistry.readthedocs.io/en/latest/gfql/index.html) Use GFQL, the first fully vectorized dataframe-native graph query language with an open-source GPU runtime, to ask relationship questions that are difficult for tabular tools without requiring a database. It supports friendly Cypher syntax and declarative graph semantics through `g.gfql("MATCH ...")`, with the same execution model available on the current bound graph or remotely via `g.gfql_remote([...])`.
 
 * [**graphistry[ai]:**](https://pygraphistry.readthedocs.io/en/latest/gfql/combo.html#) Call streamlined graph ML & AI methods to benefit from clustering, UMAP embeddings, graph neural networks, automatic feature engineering, and more.
 

--- a/docs/source/gfql/builtin_calls.rst
+++ b/docs/source/gfql/builtin_calls.rst
@@ -352,6 +352,24 @@ Current categories include:
             'out_col': 'community'
         })
     ])
+
+    # Weakly connected components (WCC) labels
+    g.gfql([
+        call('compute_cugraph', {
+            'alg': 'connected_components',
+            'out_col': 'wcc_id',
+            'directed': False
+        })
+    ])
+
+    # Strongly connected components (SCC) labels
+    g.gfql([
+        call('compute_cugraph', {
+            'alg': 'strongly_connected_components',
+            'out_col': 'scc_id',
+            'directed': True
+        })
+    ])
     
     # Betweenness centrality
     g.gfql([
@@ -446,6 +464,12 @@ Current supported names include:
         })
     ])
 
+    # Weakly connected components (WCC) labels
+    g.compute_igraph('clusters', out_col='wcc_id', params={'mode': 'weak'})
+
+    # Strongly connected components (SCC) labels
+    g.compute_igraph('clusters', out_col='scc_id', params={'mode': 'strong'})
+
 **Schema Effects:** Most algorithms add one node column. Topology-returning algorithms such as ``gomory_hu_tree`` and ``spanning_tree`` return a new graph topology instead.
 
 **Local Cypher Modes:**
@@ -463,6 +487,11 @@ Current supported names include:
   They follow the same row-vs-``.write()`` contract as the other backends: node calls use ``nodeId`` + value column rows, edge calls use ``source`` / ``destination`` + value column rows, and topology-returning calls require ``.write()``.
 
 **Parameter Discovery:** For detailed algorithm parameters, see the `Python igraph documentation <https://igraph.org/python/>`_. Parameters are passed via the ``params`` dictionary.
+
+.. note::
+   Component IDs (for example, ``wcc_id`` / ``scc_id``) are partition labels and
+   may differ numerically across backends or runs. Use them for grouping and
+   filtering by component membership, not as stable semantic IDs.
 
 .. note::
    For graphs with millions of edges, consider using ``compute_cugraph`` with a GPU for 10-50x speedup, or :ref:`gfql-remote` if no local GPU is available.

--- a/docs/source/gfql/cypher.rst
+++ b/docs/source/gfql/cypher.rst
@@ -371,6 +371,26 @@ Procedure And Multi-Branch Forms
   ``out_col``, ``directed``, ``kind``, ``use_vids``, and ``params``; any extra
   keys are forwarded into the nested algorithm ``params`` dictionary.
 
+Component-labeling examples:
+
+.. code-block:: python
+
+    # Graph-enrichment mode (keeps traversable _edges)
+    g.gfql(
+        "CALL graphistry.cugraph.connected_components.write({out_col: 'wcc_id', directed: false})",
+        language="cypher",
+    )
+    g.gfql(
+        "CALL graphistry.cugraph.strongly_connected_components.write({out_col: 'scc_id', directed: true})",
+        language="cypher",
+    )
+
+    # Row mode (no .write): returns nodeId + output column rows
+    g.gfql(
+        "CALL graphistry.cugraph.connected_components({out_col: 'wcc_row', directed: false})",
+        language="cypher",
+    )
+
 - Outside that smaller ``networkx`` subset, ``graphistry.nx.*`` is not part of
   the current local Cypher ``CALL`` surface.
 


### PR DESCRIPTION
## Summary
- add concise WCC/SCC labeling examples to GFQL builtin call docs
- add concise Cypher `CALL graphistry.cugraph.*` component-labeling examples (write mode + row mode)
- clarify that numeric component IDs are partition labels and not stable semantic IDs

## Executable-docs coverage
- targeted touched-pages harness:
  - `python -m pytest docs/test_doc_examples.py -q -k 'builtin_calls or cypher'`
  - `3 passed, 26 deselected`
- broader docs executable harness:
  - `python -m pytest docs/test_doc_examples.py -q`
  - `21 passed, 8 skipped`

## Review-skill convergence
- `plans/review-pr-1325/`
- 2-wave review with adversarial pass each wave
- final result: `BLOCKER=0`, `IMPORTANT=0`, `SUGGESTION=0`

## RTD pages to review
- Preview build root: https://pygraphistry--1325.org.readthedocs.build/en/1325/
- Preview page: https://pygraphistry--1325.org.readthedocs.build/en/1325/gfql/builtin_calls.html
- Preview page: https://pygraphistry--1325.org.readthedocs.build/en/1325/gfql/cypher.html

## CI
- PR checks green (including `test-docs`, `tck-gfql`, and RTD check)
