### PR TITLE
fix(cypher): make conjoined varlen WHERE predicates order-invariant (#1332)

### DIFF
--- a/graphistry/compute/gfql/cypher/ast_normalizer.py
+++ b/graphistry/compute/gfql/cypher/ast_normalizer.py
@@ -483,9 +483,18 @@ def _rewrite_where_pattern_predicates_to_matches(query: CypherQuery) -> CypherQu
     positive_preds = [p for p in pattern_preds if not p.negated]
     if not positive_preds:
         return query
-    # Slice 3 of #1031: support N positive pattern predicates by emitting one
-    # appended ``MatchClause`` per predicate.  Each predicate is independently
-    # validated (must include a relationship; cannot introduce new aliases).
+    # Keep multi-positive pattern predicate conjunctions in WHERE so lowering
+    # can evaluate each predicate independently via semi-apply markers.
+    #
+    # Rewriting multiple positive predicates into one appended MatchClause
+    # can incorrectly couple otherwise independent existence checks and make
+    # `AND` operand order observable (#1332).
+    if len(positive_preds) > 1:
+        return query
+
+    # Single positive pattern predicate still rewrites to an appended MATCH.
+    # Each predicate is independently validated (must include a relationship;
+    # cannot introduce new aliases).
     bound_aliases = {
         cast(str, element.variable)
         for clause in query.matches
@@ -493,12 +502,7 @@ def _rewrite_where_pattern_predicates_to_matches(query: CypherQuery) -> CypherQu
         for element in pattern
         if getattr(element, "variable", None) is not None
     }
-    # Validate every positive pattern; collect into a single appended
-    # MatchClause whose ``patterns`` tuple holds N patterns (multi-positive
-    # WHERE pattern via cartesian-style multi-pattern MATCH; #1031 slice 3).
-    # Packing into one MatchClause (rather than N appended MatchClauses)
-    # preserves the lowering invariant that only the FINAL match is
-    # connected — seeds remain node-only.
+    # Validate the positive pattern; emit as a single appended MatchClause.
     for pred in positive_preds:
         if len(pred.pattern) < 3:
             raise _unsupported(

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -6080,6 +6080,18 @@ def _rewrite_where_expr_patterns_to_markers(
     return ExpressionText(text=boolean_expr_to_text(rewritten), span=where.span), marker_ops
 
 
+def _where_pattern_predicate_marker_col(
+    span: SourceSpan,
+    *,
+    existing: Set[str],
+) -> str:
+    base = (
+        "__gfql_where_pattern_"
+        f"{span.line}_{span.column}_{span.end_line}_{span.end_column}__"
+    )
+    return _fresh_temp_name(existing, base)
+
+
 def _lower_negated_pattern_predicate_to_row_filter(
     predicate: WherePatternPredicate,
     *,
@@ -6179,6 +6191,11 @@ def lower_match_query(
             params=params,
         )
         row_pre_filters.extend(where_pattern_row_filters)
+        marker_cols_in_use: Set[str] = {
+            cast(str, op.params.get("out_col"))
+            for op in row_pre_filters
+            if isinstance(op.params.get("out_col"), str)
+        }
         if where_expr is not None:
             type_where = _extract_relationship_type_where(
                 where_expr,
@@ -6207,13 +6224,20 @@ def lower_match_query(
                         )
                     )
                     continue
-                raise _unsupported(
-                    "Cypher WHERE pattern predicates must be rewritten before lowering",
-                    field="where",
-                    value=None,
-                    line=predicate.span.line,
-                    column=predicate.span.column,
+                marker_col = _where_pattern_predicate_marker_col(
+                    predicate.span,
+                    existing=marker_cols_in_use,
                 )
+                row_pre_filters.append(
+                    _lower_pattern_predicate_to_row_marker(
+                        predicate,
+                        alias_targets=alias_targets,
+                        params=params,
+                        out_col=marker_col,
+                    )
+                )
+                row_where_predicates.append(marker_col)
+                continue
             if isinstance(predicate.left, LabelRef):
                 _apply_label_where(alias_targets, left=predicate.left)
                 continue
@@ -7868,6 +7892,11 @@ def _apply_where_to_ops(
         params=params,
     )
     row_pre_filters.extend(where_pattern_row_filters)
+    marker_cols_in_use: Set[str] = {
+        cast(str, op.params.get("out_col"))
+        for op in row_pre_filters
+        if isinstance(op.params.get("out_col"), str)
+    }
     if where_expr is not None:
         type_where = _extract_relationship_type_where(
             where_expr,
@@ -7899,13 +7928,20 @@ def _apply_where_to_ops(
                     )
                 )
                 continue
-            raise _unsupported(
-                "Cypher WHERE pattern predicates must be rewritten before lowering",
-                field="where",
-                value=None,
-                line=predicate.span.line,
-                column=predicate.span.column,
+            marker_col = _where_pattern_predicate_marker_col(
+                predicate.span,
+                existing=marker_cols_in_use,
             )
+            row_pre_filters.append(
+                _lower_pattern_predicate_to_row_marker(
+                    predicate,
+                    alias_targets=alias_targets,
+                    params=params,
+                    out_col=marker_col,
+                )
+            )
+            row_expr_filters.append(ExpressionText(text=marker_col, span=predicate.span))
+            continue
         if isinstance(predicate.left, LabelRef):
             _apply_label_where(alias_targets, left=predicate.left)
             continue

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -5444,7 +5444,13 @@ def test_string_cypher_executes_conjoined_bounded_varlen_where_predicates_across
     rows_forward = graph.gfql(
         "MATCH (n) WHERE (n)-[:REL1*2]->() AND (n)-[:REL2*1]->() RETURN n.id AS id ORDER BY id"
     )._nodes.to_dict(orient="records")
-    assert rows_forward == [{"id": "b"}]
+    rows_reverse = graph.gfql(
+        "MATCH (n) WHERE (n)-[:REL2*1]->() AND (n)-[:REL1*2]->() RETURN n.id AS id ORDER BY id"
+    )._nodes.to_dict(orient="records")
+
+    assert rows_forward == [{"id": "a"}, {"id": "b"}]
+    assert rows_reverse == [{"id": "a"}, {"id": "b"}]
+    assert rows_forward == rows_reverse
 
 
 def test_string_cypher_executes_xor_between_bounded_reverse_and_forward_where_patterns() -> None:


### PR DESCRIPTION
## Summary

Fixes #1332: `WHERE` conjunctions containing variable-length pattern predicates were order-sensitive.

### Root cause

`ASTNormalizer._rewrite_where_pattern_predicates_to_matches()` rewrote multiple positive pattern predicates into an appended `MATCH` clause, which could couple independent existence checks into a connected pattern shape and make `AND` operand order observable.

### Fix

- Keep **multi-positive** WHERE pattern predicates in WHERE (skip the appended-MATCH rewrite for that case)
- Lower positive `WherePatternPredicate` entries directly into independent `semi_apply_mark` row pre-filters
- Conjoin generated marker columns as row-level filters

### Tests

Updated regression coverage in `test_lowering.py`:
- Existing conjoined bounded-varlen test now checks both operand orders
- Asserts equality across swapped-order queries
- Corrected expected rows to the logical conjunction result for fixture: `[{"id":"a"}, {"id":"b"}]`

## Validation

- `PYTHONPATH=. UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest --with pandas python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "bounded_variable_length_where_pattern_predicates or conjoined_bounded_varlen_where_predicates_across_edge_types or bounded_variable_length_where_pattern_boolean_wrappers"`
- `PYTHONPATH=. UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest --with pandas python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "where_pattern_predicate"`
- `./bin/ruff.sh graphistry/compute/gfql/cypher/ast_normalizer.py graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py`

Refs #1332
