### PR TITLE
Fix relationship-row aggregate multiplicity for Cypher collect/count/sum (#1343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - **GFQL / Cypher lowering — bounded/exact variable-length `WHERE` pattern predicates (#973)**: Removed the pre-normalization compiler gate that rejected bounded/exact variable-length `WHERE` pattern predicates and now lower these shapes through the existing WHERE-pattern rewrite and row-filter paths. Converted the old fail-fast test into positive execution coverage and added boolean-wrapper amplification (`OR`/`XOR`/`NOT`) for bounded variable-length `WHERE` predicates in `graphistry/tests/compute/gfql/cypher/test_lowering.py`.
+- **GFQL / Cypher relationship-row aggregates over MATCH multiplicity (#1343)**: First-stage aggregate lowering now routes multiplicity-sensitive aggregate shapes (`collect`, non-distinct `count`, `sum`/`avg`) on relationship-pattern MATCH queries through bindings-row execution so relationship-row multiplicity is preserved before aggregation. This unblocks `collect(...)` and grouped/global `count`/`sum` relationship-row shapes previously rejected by the stale "repeated MATCH rows" guard on the collapsed-alias path.
 
 ### Tests
 - **GFQL / Cypher two-MATCH reentry varlen regression hardening (#1001)**: Strengthened reentry varlen acceptance assertions from shape-only checks to exact expected rows, and added forward/reverse split-vs-connected query equivalence regressions to guard against wrong-row drift in the `match5-25/26` query family.

--- a/bin/ci_cypher_surface_guard_baseline.json
+++ b/bin/ci_cypher_surface_guard_baseline.json
@@ -13,5 +13,5 @@
       "max_properties": 0
     }
   },
-  "lowering_py_max_lines": 8627
+  "lowering_py_max_lines": 8644
 }

--- a/bin/ci_cypher_surface_guard_baseline.json
+++ b/bin/ci_cypher_surface_guard_baseline.json
@@ -13,5 +13,5 @@
       "max_properties": 0
     }
   },
-  "lowering_py_max_lines": 8683
+  "lowering_py_max_lines": 8688
 }

--- a/bin/ci_cypher_surface_guard_baseline.json
+++ b/bin/ci_cypher_surface_guard_baseline.json
@@ -13,5 +13,5 @@
       "max_properties": 0
     }
   },
-  "lowering_py_max_lines": 8644
+  "lowering_py_max_lines": 8683
 }

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -4209,7 +4209,12 @@ def _build_initial_row_scope(
         aggregate_specs=stage_aggregate_specs,
         relationship_count=relationship_count,
     ):
-        binding_row_aliases = set(alias_targets.keys())
+        return_has_whole_row_alias = any(
+            item.expression.text in alias_targets
+            for item in query.return_.items
+        )
+        if len(query.with_stages) == 1 and not return_has_whole_row_alias:
+            binding_row_aliases = set(alias_targets.keys())
     binding_row_aliases.update(
         _binding_row_aliases_for_row_where(
             lowered.row_where,
@@ -6495,7 +6500,41 @@ def _lower_general_row_projection(
         aggregate_specs=aggregate_specs,
         relationship_count=relationship_count,
     ):
-        binding_row_aliases = set(alias_targets.keys())
+        base_active_alias: Optional[str] = None
+        can_force_bindings = True
+        try:
+            base_active_alias = _active_match_alias(
+                query,
+                alias_targets=alias_targets,
+                allowed_match_aliases=None,
+                params=params,
+            )
+        except GFQLValidationError:
+            can_force_bindings = False
+        if can_force_bindings and base_active_alias is not None:
+            if isinstance(alias_targets.get(base_active_alias), ASTEdge):
+                can_force_bindings = False
+        if can_force_bindings and base_active_alias is not None:
+            for agg_spec in aggregate_specs:
+                if agg_spec.expr_text is None:
+                    continue
+                try:
+                    refs = _expr_match_aliases(
+                        agg_spec.expr_text,
+                        alias_targets=alias_targets,
+                        params=params,
+                        field=query.return_.kind,
+                        line=agg_spec.span_line,
+                        column=agg_spec.span_column,
+                    )
+                except GFQLValidationError:
+                    can_force_bindings = False
+                    break
+                if len(refs) > 1 or (len(refs) == 1 and base_active_alias not in refs):
+                    can_force_bindings = False
+                    break
+        if can_force_bindings:
+            binding_row_aliases = set(alias_targets.keys())
     binding_row_aliases = _apply_bound_scope_membership(
         binding_row_aliases,
         alias_targets=alias_targets,

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -6502,6 +6502,11 @@ def _lower_general_row_projection(
     ):
         base_active_alias: Optional[str] = None
         can_force_bindings = True
+        if any(item.expression.text in alias_targets for item in non_aggregate_items):
+            # Keep whole-row grouping on the existing conservative path.
+            # This preserves the current fail-fast boundary for relationship-
+            # pattern grouped aggregates such as `RETURN a, count(*)`.
+            can_force_bindings = False
         try:
             base_active_alias = _active_match_alias(
                 query,

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -2390,6 +2390,36 @@ def _is_multiplicity_sensitive_aggregate(agg_spec: _AggregateSpec) -> bool:
     return False
 
 
+def _collect_aggregate_specs_for_clause(
+    clause: ReturnClause,
+    *,
+    params: Optional[Mapping[str, Any]],
+    alias_targets: Mapping[str, ASTObject],
+) -> List[_AggregateSpec]:
+    aggregate_specs: List[_AggregateSpec] = []
+    for item in clause.items:
+        agg_spec = _aggregate_spec(item, params=params, alias_targets=alias_targets)
+        if agg_spec is not None:
+            aggregate_specs.append(agg_spec)
+            continue
+        post_agg_plan = _post_aggregate_expr_plan(item, params=params, alias_targets=alias_targets)
+        if post_agg_plan is not None:
+            nested_aggregate_specs, _ = post_agg_plan
+            aggregate_specs.extend(nested_aggregate_specs)
+    return aggregate_specs
+
+
+def _requires_relationship_multiplicity_bindings(
+    *,
+    aggregate_specs: Sequence[_AggregateSpec],
+    relationship_count: int,
+) -> bool:
+    return relationship_count > 0 and any(
+        _is_multiplicity_sensitive_aggregate(spec)
+        for spec in aggregate_specs
+    )
+
+
 def _match_relationship_count(clause: MatchClause) -> int:
     return sum(1 for element in _match_pattern_elements(clause) if isinstance(element, RelationshipPattern))
 
@@ -4117,15 +4147,17 @@ def _build_initial_row_scope(
 ) -> Tuple[List[ASTObject], _StageScope]:
     alias_targets = _alias_target(lowered.query) if query.match is not None else {}
     merged_match = _merged_match_clause(query)
+    relationship_count = _match_relationship_count(merged_match) if merged_match is not None else 0
     binding_row_aliases = _binding_row_aliases_for_match(query.match, alias_targets=alias_targets)
+    stage_aggregate_specs = _collect_aggregate_specs_for_clause(
+        stage_clause,
+        params=params,
+        alias_targets=alias_targets,
+    )
     # Admit first-stage multi-alias non-aggregate WITH projections (shape A, #1273)
     # by routing through the bindings-row path when multiple MATCH node aliases are
     # referenced together in scalar expressions.
-    stage_has_aggregates = any(
-        _aggregate_spec(item, params=params, alias_targets=alias_targets) is not None
-        or _post_aggregate_expr_plan(item, params=params, alias_targets=alias_targets) is not None
-        for item in stage_clause.items
-    )
+    stage_has_aggregates = bool(stage_aggregate_specs)
     if (
         not stage_has_aggregates
         and len(alias_targets) > 1
@@ -4173,6 +4205,11 @@ def _build_initial_row_scope(
         }
         if len(whole_row_refs) > 1:
             binding_row_aliases = set(alias_targets.keys())
+    if _requires_relationship_multiplicity_bindings(
+        aggregate_specs=stage_aggregate_specs,
+        relationship_count=relationship_count,
+    ):
+        binding_row_aliases = set(alias_targets.keys())
     binding_row_aliases.update(
         _binding_row_aliases_for_row_where(
             lowered.row_where,
@@ -4276,7 +4313,7 @@ def _build_initial_row_scope(
             row_columns=set(unwind_aliases),
             projected_columns={},
             seed_rows=seed_rows,
-            relationship_count=_match_relationship_count(merged_match) if merged_match is not None else 0,
+            relationship_count=relationship_count,
         )
 
 
@@ -6377,11 +6414,10 @@ def _whole_row_group_entity_expr(
     column: int,
 ) -> str:
     target = alias_targets.get(alias_name)
-    alias_args = ", ".join(dict.fromkeys([alias_name] + [str(name) for name in alias_targets.keys()]))
     if isinstance(target, ASTNode):
-        return f"__node_entity__({alias_args})"
+        return f"__node_entity__({alias_name})"
     if isinstance(target, ASTEdge):
-        return f"__edge_entity__({alias_args})"
+        return f"__edge_entity__({alias_name})"
     raise _unsupported(
         "Cypher aggregate whole-row grouping requires a node or edge alias",
         field=field,
@@ -6435,7 +6471,31 @@ def _lower_general_row_projection(
     semantic_entity_kinds: Optional[Mapping[str, Literal["node", "edge", "scalar"]]] = None,
 ) -> CompiledCypherQuery:
     alias_targets = _alias_target(lowered.query) if query.match is not None else {}
+    merged_match = _merged_match_clause(query)
+    relationship_count = _match_relationship_count(merged_match) if merged_match is not None else 0
+    aggregate_specs: List[_AggregateSpec] = []
+    non_aggregate_items: List[ReturnItem] = []
+    post_aggregate_items: List[_PostAggregateExprPlan] = []
+    empty_result_row: Optional[Dict[str, Any]] = None
+    for item in query.return_.items:
+        agg_spec = _aggregate_spec(item, params=params, alias_targets=alias_targets)
+        if agg_spec is not None:
+            aggregate_specs.append(agg_spec)
+            continue
+        post_agg_plan = _post_aggregate_expr_plan(item, params=params, alias_targets=alias_targets)
+        if post_agg_plan is not None:
+            nested_aggregate_specs, post_agg_item = post_agg_plan
+            aggregate_specs.extend(nested_aggregate_specs)
+            post_aggregate_items.append(post_agg_item)
+            continue
+        non_aggregate_items.append(item)
+
     binding_row_aliases = _binding_row_aliases_for_match(query.match, alias_targets=alias_targets)
+    if _requires_relationship_multiplicity_bindings(
+        aggregate_specs=aggregate_specs,
+        relationship_count=relationship_count,
+    ):
+        binding_row_aliases = set(alias_targets.keys())
     binding_row_aliases = _apply_bound_scope_membership(
         binding_row_aliases,
         alias_targets=alias_targets,
@@ -6510,23 +6570,6 @@ def _lower_general_row_projection(
         )
         unwind_aliases.add(unwind_clause.alias)
 
-    aggregate_specs: List[_AggregateSpec] = []
-    non_aggregate_items: List[ReturnItem] = []
-    post_aggregate_items: List[_PostAggregateExprPlan] = []
-    empty_result_row: Optional[Dict[str, Any]] = None
-    for item in query.return_.items:
-        agg_spec = _aggregate_spec(item, params=params, alias_targets=alias_targets)
-        if agg_spec is not None:
-            aggregate_specs.append(agg_spec)
-            continue
-        post_agg_plan = _post_aggregate_expr_plan(item, params=params, alias_targets=alias_targets)
-        if post_agg_plan is not None:
-            nested_aggregate_specs, post_agg_item = post_agg_plan
-            aggregate_specs.extend(nested_aggregate_specs)
-            post_aggregate_items.append(post_agg_item)
-            continue
-        non_aggregate_items.append(item)
-
     expr_to_output: Dict[str, str] = {}
     available_columns: Set[str] = set()
 
@@ -6558,18 +6601,14 @@ def _lower_general_row_projection(
                         column=item.span.column,
                     )
                 hidden_key_name = _fresh_temp_name(temp_names, "__cypher_group_key__")
-                pre_items.append(
-                    (
-                        hidden_key_name,
-                        _whole_row_group_key_expr(
-                            alias_name,
-                            alias_targets=alias_targets,
-                            field=query.return_.kind,
-                            line=item.span.line,
-                            column=item.span.column,
-                        ),
-                    )
+                raw_key_expr = _whole_row_group_key_expr(
+                    alias_name,
+                    alias_targets=alias_targets,
+                    field=query.return_.kind,
+                    line=item.span.line,
+                    column=item.span.column,
                 )
+                pre_items.append((hidden_key_name, raw_key_expr))
                 pre_items.append(
                     (
                         output_name,
@@ -6678,12 +6717,13 @@ def _lower_general_row_projection(
                 alias_name=agg_spec.output_name,
             )
 
-        _reject_unsound_relationship_multiplicity_aggregates(
-            query,
-            aggregate_specs=aggregate_specs,
-            alias_targets=alias_targets,
-            active_match_alias=active_match_alias,
-        )
+        if not binding_row_aliases:
+            _reject_unsound_relationship_multiplicity_aggregates(
+                query,
+                aggregate_specs=aggregate_specs,
+                alias_targets=alias_targets,
+                active_match_alias=active_match_alias,
+            )
         if key_names:
             if len(pre_items) > 0:
                 row_steps.append(with_(pre_items))

--- a/graphistry/compute/gfql/df_executor.py
+++ b/graphistry/compute/gfql/df_executor.py
@@ -7,6 +7,7 @@ from typing import Dict, Literal, Sequence, List, Optional, Any, Tuple, Set
 from graphistry.Engine import Engine, safe_map_series, safe_merge
 from graphistry.Plottable import Plottable
 from graphistry.compute.ast import ASTCall, ASTEdge, ASTNode, ASTObject
+from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 from graphistry.gfql.ref.enumerator import OracleCaps, OracleResult, enumerate_chain
 from graphistry.compute.gfql.same_path_types import INEQ_WHERE_OPS, PathState, WhereComparison
 from graphistry.compute.gfql.same_path.chain_meta import ChainMeta
@@ -415,7 +416,13 @@ def _collect_alias_bindings(chain: Sequence[ASTObject]) -> Dict[str, AliasBindin
             continue
 
         if alias in bindings:
-            raise ValueError(f"Duplicate alias '{alias}' detected in chain")
+            raise GFQLValidationError(
+                ErrorCode.E108,
+                f"Duplicate alias '{alias}' detected in chain",
+                field="chain",
+                value=alias,
+                language="cypher",
+            )
         bindings[alias] = AliasBinding(alias, idx, kind, step)
     return bindings
 
@@ -434,7 +441,13 @@ def _validate_where_aliases(bindings: Dict[str, AliasBinding], where: Sequence[W
     referenced = {clause.left.alias for clause in where} | {clause.right.alias for clause in where}
     missing = sorted(alias for alias in referenced if alias not in bindings)
     if missing:
-        raise ValueError(f"WHERE references aliases with no node/edge bindings: {', '.join(missing)}")
+        raise GFQLValidationError(
+            ErrorCode.E108,
+            f"WHERE references aliases with no node/edge bindings: {', '.join(missing)}",
+            field="where",
+            value=missing,
+            language="cypher",
+        )
 
 
 def _validate_where_columns(
@@ -469,9 +482,13 @@ def _validate_where_columns(
                 available = ", ".join(sorted(cols)[:10])
                 if len(cols) > 10:
                     available += ", ..."
-                raise ValueError(
+                raise GFQLValidationError(
+                    ErrorCode.E108,
                     f"WHERE references missing column '{ref.column}' on alias '{ref.alias}' "
-                    f"({binding.kind}, step={binding.step_index}). Available columns: {available}"
+                    f"({binding.kind}, step={binding.step_index}). Available columns: {available}",
+                    field="where",
+                    value=f"{ref.alias}.{ref.column}",
+                    language="cypher",
                 )
 
 

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -1266,6 +1266,16 @@ def test_lower_match_query_rewrites_duplicate_node_aliases_to_internal_identity_
     assert lowered.where == [compare(col("n", "id"), "==", col(repeated._name, "id"))]
 
 
+def test_string_cypher_duplicate_node_alias_identity_shape_raises_gfql_validation_error() -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": ["a"]}),
+        pd.DataFrame({"s": ["a"], "d": ["a"], "type": ["LOOP"]}),
+    )
+
+    with pytest.raises(GFQLValidationError):
+        graph.gfql("MATCH (n)--(n) RETURN count(*)")
+
+
 def test_parse_where_pattern_predicate() -> None:
     parsed = _parse_query("MATCH (n) WHERE (n)-[:R]->() RETURN n")
 

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3077,16 +3077,18 @@ def test_string_cypher_supports_whole_row_grouping_with_count_star() -> None:
 
 
 @pytest.mark.parametrize(
-    "query",
+    "query,expected_rows",
     [
-        "MATCH (a:L)-[r]->(b) RETURN a, count(*) AS cnt",
-        "MATCH (a:L)-[r]->(b) RETURN a.id AS aid, count(*) AS cnt",
-        "MATCH (a)-[r]->(b) RETURN count(*) AS cnt",
-        "MATCH (a)-[r]->(b) RETURN count(a) AS cnt",
-        "MATCH (a)-[r]->(b) RETURN sum(1) AS total",
+        ("MATCH (a:L)-[r]->(b) RETURN a.id AS aid, count(*) AS cnt", [{"aid": "a", "cnt": 2}]),
+        ("MATCH (a)-[r]->(b) RETURN count(*) AS cnt", [{"cnt": 2}]),
+        ("MATCH (a)-[r]->(b) RETURN count(a) AS cnt", [{"cnt": 2}]),
+        ("MATCH (a)-[r]->(b) RETURN sum(1) AS total", [{"total": 2}]),
     ],
 )
-def test_string_cypher_rejects_unsound_node_carrier_multiplicity_sensitive_aggregates(query: str) -> None:
+def test_string_cypher_supports_relationship_row_multiplicity_sensitive_aggregates(
+    query: str,
+    expected_rows: List[Dict[str, Any]],
+) -> None:
     graph = _mk_graph(
         pd.DataFrame(
             {
@@ -3103,8 +3105,101 @@ def test_string_cypher_rejects_unsound_node_carrier_multiplicity_sensitive_aggre
         ),
     )
 
-    with pytest.raises(GFQLValidationError, match="repeated MATCH rows"):
-        graph.gfql(query)
+    result = graph.gfql(query)
+    assert result._nodes.to_dict(orient="records") == expected_rows
+
+
+def test_string_cypher_supports_optional_match_collect_alias_property() -> None:
+    graph = _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["p1", "u1", "u2"],
+                "label__Person": [True, False, False],
+                "label__University": [False, True, True],
+                "name": ["P", "Uni1", "Uni2"],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["p1", "p1"],
+                "d": ["u1", "u2"],
+                "id": ["e1", "e2"],
+                "type": ["STUDY_AT", "STUDY_AT"],
+                "classYear": [2001, 2002],
+            }
+        ),
+    )
+
+    result = graph.gfql(
+        "MATCH (p:Person {id: 'p1'}) "
+        "OPTIONAL MATCH (p)-[rel:STUDY_AT]->(uni:University) "
+        "WITH p, collect(uni.name) AS unis "
+        "RETURN p.id AS personId, unis"
+    )
+
+    assert result._nodes.to_dict(orient="records") == [{"personId": "p1", "unis": ["Uni1", "Uni2"]}]
+
+
+def test_string_cypher_supports_optional_match_collect_case_relationship_rows() -> None:
+    graph = _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["p1", "u1", "u2"],
+                "label__Person": [True, False, False],
+                "label__University": [False, True, True],
+                "name": ["P", "Uni1", "Uni2"],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["p1", "p1"],
+                "d": ["u1", "u2"],
+                "id": ["e1", "e2"],
+                "type": ["STUDY_AT", "STUDY_AT"],
+                "classYear": [2001, 2002],
+            }
+        ),
+    )
+
+    result = graph.gfql(
+        "MATCH (p:Person {id: 'p1'}) "
+        "OPTIONAL MATCH (p)-[rel:STUDY_AT]->(uni:University) "
+        "WITH p, collect(CASE uni.name WHEN null THEN null ELSE [uni.name, rel.classYear] END) AS unis "
+        "RETURN p.id AS personId, unis"
+    )
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"personId": "p1", "unis": [["Uni1", 2001], ["Uni2", 2002]]}
+    ]
+
+
+def test_string_cypher_supports_relationship_row_grouped_count_and_sum() -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": ["a", "b", "c"]}),
+        pd.DataFrame(
+            {
+                "s": ["a", "a"],
+                "d": ["b", "c"],
+                "id": ["r1", "r2"],
+                "type": ["R", "R"],
+                "weight": [2, 3],
+            }
+        ),
+    )
+
+    count_result = graph.gfql(
+        "MATCH (a)-[r:R]->(b) "
+        "WITH a, count(r) AS deg "
+        "RETURN a.id AS aid, deg"
+    )
+    sum_result = graph.gfql(
+        "MATCH (a)-[r:R]->(b) "
+        "WITH a, sum(r.weight) AS total "
+        "RETURN a.id AS aid, total"
+    )
+
+    assert count_result._nodes.to_dict(orient="records") == [{"aid": "a", "deg": 2}]
+    assert sum_result._nodes.to_dict(orient="records") == [{"aid": "a", "total": 5}]
 
 
 def test_string_cypher_keeps_single_edge_relationship_grouped_count_star() -> None:

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3109,6 +3109,27 @@ def test_string_cypher_supports_relationship_row_multiplicity_sensitive_aggregat
     assert result._nodes.to_dict(orient="records") == expected_rows
 
 
+def test_string_cypher_failfast_relationship_whole_row_grouped_count_star_boundary() -> None:
+    graph = _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["a", "b", "c"],
+                "label__L": [True, False, False],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["a", "a"],
+                "d": ["b", "c"],
+                "id": ["r1", "r2"],
+            }
+        ),
+    )
+
+    with pytest.raises(GFQLValidationError, match="repeated MATCH rows"):
+        graph.gfql("MATCH (a:L)-[rel]->(b) RETURN a, count(*)")
+
+
 def test_string_cypher_supports_optional_match_collect_alias_property() -> None:
     graph = _mk_graph(
         pd.DataFrame(

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3093,6 +3093,7 @@ def test_string_cypher_supports_whole_row_grouping_with_count_star() -> None:
         ("MATCH (a)-[r]->(b) RETURN count(*) AS cnt", [{"cnt": 2}]),
         ("MATCH (a)-[r]->(b) RETURN count(a) AS cnt", [{"cnt": 2}]),
         ("MATCH (a)-[r]->(b) RETURN sum(1) AS total", [{"total": 2}]),
+        ("MATCH (a)-[r]->(b) RETURN avg(r.weight) AS avg_w", [{"avg_w": 2.5}]),
     ],
 )
 def test_string_cypher_supports_relationship_row_multiplicity_sensitive_aggregates(
@@ -3111,6 +3112,7 @@ def test_string_cypher_supports_relationship_row_multiplicity_sensitive_aggregat
                 "s": ["a", "a"],
                 "d": ["b", "c"],
                 "id": ["r1", "r2"],
+                "weight": [2, 3],
             }
         ),
     )
@@ -3204,7 +3206,7 @@ def test_string_cypher_supports_optional_match_collect_case_relationship_rows() 
     ]
 
 
-def test_string_cypher_supports_relationship_row_grouped_count_and_sum() -> None:
+def test_string_cypher_supports_relationship_row_grouped_count_sum_and_avg() -> None:
     graph = _mk_graph(
         pd.DataFrame({"id": ["a", "b", "c"]}),
         pd.DataFrame(
@@ -3228,9 +3230,15 @@ def test_string_cypher_supports_relationship_row_grouped_count_and_sum() -> None
         "WITH a, sum(r.weight) AS total "
         "RETURN a.id AS aid, total"
     )
+    avg_result = graph.gfql(
+        "MATCH (a)-[r:R]->(b) "
+        "WITH a, avg(r.weight) AS avg_w "
+        "RETURN a.id AS aid, avg_w"
+    )
 
     assert count_result._nodes.to_dict(orient="records") == [{"aid": "a", "deg": 2}]
     assert sum_result._nodes.to_dict(orient="records") == [{"aid": "a", "total": 5}]
+    assert avg_result._nodes.to_dict(orient="records") == [{"aid": "a", "avg_w": 2.5}]
 
 
 def test_string_cypher_keeps_single_edge_relationship_grouped_count_star() -> None:

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3241,6 +3241,39 @@ def test_string_cypher_supports_relationship_row_grouped_count_sum_and_avg() -> 
     assert avg_result._nodes.to_dict(orient="records") == [{"aid": "a", "avg_w": 2.5}]
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "MATCH (a:L)-[r]->(b) RETURN a.id AS aid, count(r) AS cnt",
+        "MATCH (a:L)-[r]->(b) RETURN a.id AS aid, sum(r.weight) AS total",
+        "MATCH (a:L)-[r]->(b) RETURN a.id AS aid, avg(r.weight) AS avg_w",
+    ],
+)
+def test_string_cypher_direct_return_grouped_relationship_aggregate_one_source_boundary(
+    query: str,
+) -> None:
+    graph = _mk_graph(
+        pd.DataFrame(
+            {
+                "id": ["a", "b", "c"],
+                "label__L": [True, False, False],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "s": ["a", "a"],
+                "d": ["b", "c"],
+                "id": ["r1", "r2"],
+                "type": ["R", "R"],
+                "weight": [2, 3],
+            }
+        ),
+    )
+
+    with pytest.raises(GFQLValidationError, match="one MATCH source alias at a time"):
+        graph.gfql(query)
+
+
 def test_string_cypher_keeps_single_edge_relationship_grouped_count_star() -> None:
     graph = _mk_graph(
         pd.DataFrame({"id": ["a", "b", "c"]}),

--- a/tests/gfql/ref/test_df_executor_core.py
+++ b/tests/gfql/ref/test_df_executor_core.py
@@ -16,6 +16,7 @@ from graphistry.compute.gfql.df_executor import (
 )
 from graphistry.compute.gfql_unified import gfql
 from graphistry.compute.chain import Chain
+from graphistry.compute.exceptions import GFQLValidationError
 from graphistry.compute.gfql.same_path_types import col, compare
 from graphistry.gfql.ref.enumerator import OracleCaps, enumerate_chain
 from tests.gfql.ref.conftest import (
@@ -120,7 +121,7 @@ def test_missing_alias_raises():
     where = [compare(col("missing", "x"), "==", col("c", "owner_id"))]
     graph = _make_graph()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(GFQLValidationError):
         _inputs(chain, where, graph=graph)
 
 
@@ -129,7 +130,7 @@ def test_missing_where_column_raises_during_input_build():
     where = [compare(col("a", "missing_col"), "==", col("c", "owner_id"))]
     graph = _make_graph()
 
-    with pytest.raises(ValueError, match=r"WHERE references missing column 'missing_col'"):
+    with pytest.raises(GFQLValidationError, match=r"WHERE references missing column 'missing_col'"):
         _inputs(chain, where, graph=graph)
 
 
@@ -143,7 +144,7 @@ def test_where_column_added_by_prior_call_is_accepted():
 def test_where_missing_column_after_prior_call_still_rejected():
     chain = _prior_call_chain("get_indegrees", {"col": "deg"})
     where = [compare(col("a", "missing_after_call"), "==", col("c", "deg"))]
-    with pytest.raises(ValueError, match=r"WHERE references missing column 'missing_after_call'"):
+    with pytest.raises(GFQLValidationError, match=r"WHERE references missing column 'missing_after_call'"):
         _inputs(chain, where)
 
 
@@ -181,7 +182,7 @@ def test_where_missing_column_after_prior_call_still_rejected():
 def test_missing_where_column_env_overrides(monkeypatch, chain, where, env_var, env_value, should_raise):
     monkeypatch.setenv(env_var, env_value)
     if should_raise:
-        with pytest.raises(ValueError, match=r"WHERE references missing column 'missing_after_call'"):
+        with pytest.raises(GFQLValidationError, match=r"WHERE references missing column 'missing_after_call'"):
             _inputs(chain, where)
         return
     assert _inputs(chain, where) is not None


### PR DESCRIPTION
## Summary

Fixes #1343 by routing multiplicity-sensitive Cypher aggregates on relationship-pattern MATCH queries through bindings-row execution so row multiplicity is preserved before aggregation.

### What changed
- Added aggregate-shape detection in lowering for relationship-pattern MATCH + multiplicity-sensitive aggregate usage.
- For those shapes, force bindings-row path (`rows(binding_ops=...)`) so repeated relationship rows survive to `group_by`.
- Scoped the old `repeated MATCH rows` aggregate guard to non-bindings paths.
- Added admission constraints so forced bindings routing is limited to safe lanes (preserving existing fail-fast behavior for known unsupported multi-source/whole-row overlap lanes).
- Added regression coverage for:
  - grouped/global relationship-row `count(*)`, `count(alias)`, `sum(1)`, `avg(edge_prop)`
  - `OPTIONAL MATCH ... WITH p, collect(uni.name)`
  - `OPTIONAL MATCH ... WITH p, collect(CASE ...)`
  - grouped relationship-row `WITH a, count/sum/avg(...)`
- Added changelog entry in `Development`.

### CI guard update
- Updated `bin/ci_cypher_surface_guard_baseline.json` to match intentional `lowering.py` growth from this feature and follow-up safety constraints.
- Verified guard locally with `python bin/ci_cypher_surface_guard.py` (pass).

## Validation

- `./bin/ruff.sh graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `python -m pytest -q tests/gfql/ref/test_df_executor_core.py -k "missing_alias_raises or missing_where_column_raises_during_input_build or where_missing_column_after_prior_call_still_rejected"`
- `python bin/ci_cypher_surface_guard.py`

## Notes

- This PR focuses on relationship-row multiplicity for aggregate expressions over scalar/property projections.
- Whole-row carrier grouping shape (`RETURN a, count(*)`) remains on the legacy representation path and is not expanded in this change.
