### PR TITLE
test(gfql): pin list-column ORDER BY prefix-tie-break semantics (#1359)

### DIFF
--- a/graphistry/tests/compute/gfql/test_row_pipeline_ops.py
+++ b/graphistry/tests/compute/gfql/test_row_pipeline_ops.py
@@ -332,6 +332,34 @@ def test_row_pipeline_order_by_supports_list_literal_and_subscript_expression_ke
     assert result.to_dict(orient="records") == [{"id": "c"}, {"id": "b"}, {"id": "a"}]
 
 
+def test_row_pipeline_order_by_list_column_matches_opencypher_prefix_tie_break() -> None:
+    # Mirrors openCypher TCK clauses/with-orderBy/WithOrderBy1.feature scenarios [31] / [32]
+    # with proper Python-list values. openCypher list comparator: element-wise; if all
+    # overlapping elements equal, the shorter list is less. So [2, -2] < [2, -2, 100] ASC.
+    # Pins build_list_sort_columns + order_detect_list_series behavior so future row-pipeline
+    # work doesn't regress this. See pygraphistry #1359 / tck-gfql#36.
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d", "e"],
+            "list": [[2, -2], [1, 2], [300, 0], [1, -20], [2, -2, 100]],
+        }
+    )
+
+    asc = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "asc")]), limit(3), select([("id", "id")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    assert asc.to_dict(orient="records") == [{"id": "d"}, {"id": "b"}, {"id": "a"}]
+
+    desc = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "desc")]), limit(3), select([("id", "id")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    assert desc.to_dict(orient="records") == [{"id": "c"}, {"id": "e"}, {"id": "a"}]
+
+
 def test_row_pipeline_order_by_supports_temporal_duration_expression_keys() -> None:
     nodes_df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- Adds `test_row_pipeline_order_by_list_column_matches_opencypher_prefix_tie_break` to `graphistry/tests/compute/gfql/test_row_pipeline_ops.py`.
- Pins `build_list_sort_columns` openCypher-correct behavior for prefix-tied list keys: shorter list ranks before longer when prefix elements are equal (`[2, -2] < [2, -2, 100]`).
- Mirrors openCypher TCK `clauses/with-orderBy/WithOrderBy1.feature` scenarios [31]/[32] using proper Python-list values.

## Context

Triage for [#1353](https://github.com/graphistry/pygraphistry/issues/1353) item #1 / [#1359](https://github.com/graphistry/pygraphistry/issues/1359) wrong-row tranche showed pygraphistry's list-sort is correct when given Python lists; the 14 wrong-row classifications are tck-gfql repo issues, tracked in [tck-gfql#36](https://github.com/graphistry/tck-gfql/issues/36):

1. `parse_cypher.py::_parse_properties` stores list literals as strings, so the row pipeline never sees a list-typed column.
2. `_rows_ordered` forces ordered comparison even when the openCypher feature says "in any order".

This PR adds a defensive test so future row-pipeline work doesn't silently regress the (currently correct) list comparator + prefix-tie-break behavior. No production code change.

#1359 stays open until tck-gfql#36 lands and the contract count drops.

## Test plan

- [x] `pytest graphistry/tests/compute/gfql/test_row_pipeline_ops.py` (178 passed, 5 skipped locally)
- [x] `./bin/ruff.sh graphistry/tests/compute/gfql/test_row_pipeline_ops.py`
- [ ] CI green