### PR TITLE
Fix cuDF connected comma-MATCH segfault for rel-property projection (#1355)

### DIFF
--- a/graphistry/compute/gfql/same_path/df_utils.py
+++ b/graphistry/compute/gfql/same_path/df_utils.py
@@ -27,6 +27,17 @@ _OPS = {
 }
 
 
+def _row_notna_all(frame: DataFrameT, cols: Sequence[str]) -> Any:
+    if len(cols) == 0:
+        return True
+    # cuDF 25.02 can segfault on DataFrame.notna().all(axis=1); reduce masks
+    # column-by-column instead of using row-wise DataFrame reductions.
+    mask = frame[cols[0]].notna()
+    for col in cols[1:]:
+        mask = mask & frame[col].notna()
+    return mask
+
+
 def project_node_attrs(frame: DataFrameT, node_col: str, cols: Sequence[str], *, id_label: str, prefix: str = "", labels: Optional[Sequence[str]] = None, node_domain: Optional[DomainT] = None, dedupe: bool = False, drop_nulls: bool = False) -> DataFrameT:
     df = frame[frame[node_col].isin(node_domain)] if node_domain is not None else frame
     data_cols = [node_col] + [col for col in cols if col != node_col]
@@ -39,7 +50,9 @@ def project_node_attrs(frame: DataFrameT, node_col: str, cols: Sequence[str], *,
     if labels is not None and node_col in cols:
         df[labels[cols.index(node_col)]] = df[id_label]
     if drop_nulls and labels is not None:
-        df = df[df[list(labels)].notna().all(axis=1)]
+        label_cols = [label for label in labels if label in df.columns]
+        if label_cols:
+            df = df[_row_notna_all(df, label_cols)]
     return df.drop_duplicates() if dedupe else df
 
 

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -4,7 +4,7 @@
 from dataclasses import replace
 from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple, Union, cast
 from graphistry.Plottable import Plottable
-from graphistry.Engine import Engine, EngineAbstract, df_concat, df_cons, resolve_engine
+from graphistry.Engine import Engine, EngineAbstract, df_concat, df_cons, df_to_engine, resolve_engine
 from graphistry.util import setup_logger
 from .ast import ASTObject, ASTLet, ASTNode, ASTEdge, ASTCall
 from .chain import Chain, chain as chain_impl
@@ -421,8 +421,12 @@ def _apply_connected_match_join(
 ) -> Plottable:
     from graphistry.compute.ast import ASTCall, serialize_binding_ops
 
-    concrete_engine = resolve_engine(cast(Any, engine), base_graph)
-    df_ctor = df_cons(concrete_engine)
+    requested_engine = resolve_engine(cast(Any, engine), base_graph)
+    # #1355: cuDF can segfault on connected comma-pattern row joins with some
+    # rel-property projection shapes. Execute this join route on pandas and
+    # convert the final rows back to cuDF so engine parity is preserved.
+    exec_engine = Engine.PANDAS if requested_engine == Engine.CUDF else requested_engine
+    df_ctor = df_cons(exec_engine)
     node_col = getattr(base_graph, "_node", "id")
 
     joined_rows: Optional[DataFrameT] = None
@@ -431,7 +435,7 @@ def _apply_connected_match_join(
             list(pattern_chain.chain) + [ASTCall("rows", {"binding_ops": serialize_binding_ops(pattern_chain.chain)})],
             where=pattern_chain.where,
         )
-        pattern_result = _chain_dispatch(base_graph, with_rows, engine, policy, context)
+        pattern_result = _chain_dispatch(base_graph, with_rows, exec_engine, policy, context)
         pattern_rows = cast(Optional[DataFrameT], getattr(pattern_result, "_nodes", None))
         if pattern_rows is None or len(pattern_rows) == 0:
             out = base_graph.bind()
@@ -471,7 +475,15 @@ def _apply_connected_match_join(
     joined_plottable = base_graph.bind()
     joined_plottable._nodes = joined_rows
     joined_plottable._edges = df_ctor()
-    return _chain_dispatch(joined_plottable, plan.post_join_chain, engine, policy, context)
+    result = _chain_dispatch(joined_plottable, plan.post_join_chain, exec_engine, policy, context)
+    if requested_engine != Engine.CUDF:
+        return result
+    out = result.bind()
+    if getattr(out, "_nodes", None) is not None:
+        out._nodes = cast(DataFrameT, df_to_engine(cast(Any, out._nodes), Engine.CUDF))
+    if getattr(out, "_edges", None) is not None:
+        out._edges = cast(DataFrameT, df_to_engine(cast(Any, out._edges), Engine.CUDF))
+    return out
 
 
 def _execute_graph_constructor_compiled(

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -411,6 +411,49 @@ def _joined_alias_columns(frame: DataFrameT) -> DataFrameT:
     return out
 
 
+def _connected_inner_join_rows(
+    joined_rows: DataFrameT,
+    pattern_rows: DataFrameT,
+    *,
+    join_cols: List[str],
+    keep_cols: List[str],
+    engine: Engine,
+) -> DataFrameT:
+    """Inner-join connected MATCH row payloads.
+
+    cuDF path: avoid full-row merge on dotted payload columns by joining only
+    compact key/index frames, then gathering payload rows by position.
+    """
+    rhs = cast(DataFrameT, pattern_rows[keep_cols])
+    if engine != Engine.CUDF:
+        return cast(DataFrameT, joined_rows.merge(rhs, on=join_cols, how="inner"))
+
+    lhs_row_id = "__gfql_connected_lhs_row_id__"
+    rhs_row_id = "__gfql_connected_rhs_row_id__"
+    lhs = cast(DataFrameT, joined_rows.reset_index(drop=True))
+    rhs = cast(DataFrameT, rhs.reset_index(drop=True))
+    lhs_with_idx = cast(DataFrameT, lhs.reset_index().rename(columns={"index": lhs_row_id}))
+    rhs_with_idx = cast(DataFrameT, rhs.reset_index().rename(columns={"index": rhs_row_id}))
+    lhs_keys = cast(DataFrameT, lhs_with_idx[[lhs_row_id] + join_cols])
+    rhs_keys = cast(DataFrameT, rhs_with_idx[[rhs_row_id] + join_cols])
+    row_pairs = cast(DataFrameT, lhs_keys.merge(rhs_keys, on=join_cols, how="inner"))
+    rhs_payload_cols = [column for column in keep_cols if column not in join_cols]
+    if len(row_pairs) == 0:
+        out = cast(DataFrameT, lhs.head(0))
+        for column in rhs_payload_cols:
+            out = out.assign(**{column: rhs[column].head(0)})
+        return out
+
+    lhs_taken = cast(DataFrameT, lhs.take(row_pairs[lhs_row_id]))
+    if not rhs_payload_cols:
+        return cast(DataFrameT, lhs_taken.reset_index(drop=True))
+    rhs_payload = cast(DataFrameT, rhs[rhs_payload_cols].take(row_pairs[rhs_row_id]).reset_index(drop=True))
+    lhs_taken = cast(DataFrameT, lhs_taken.reset_index(drop=True))
+    for column in rhs_payload_cols:
+        lhs_taken = lhs_taken.assign(**{column: rhs_payload[column]})
+    return lhs_taken
+
+
 def _apply_connected_match_join(
     base_graph: Plottable,
     plan: ConnectedMatchJoinPlan,
@@ -422,15 +465,8 @@ def _apply_connected_match_join(
     from graphistry.compute.ast import ASTCall, serialize_binding_ops
 
     requested_engine = resolve_engine(cast(Any, engine), base_graph)
-    use_cudf_join_fallback = requested_engine == Engine.CUDF
-    dispatch_engine: Union[EngineAbstract, str] = (
-        EngineAbstract.PANDAS if use_cudf_join_fallback else engine
-    )
-    # #1355: cuDF can segfault on connected comma-pattern row joins with some
-    # rel-property projection shapes. Execute this join route on pandas and
-    # convert the final rows back to cuDF so engine parity is preserved.
-    exec_engine = Engine.PANDAS if use_cudf_join_fallback else requested_engine
-    df_ctor = df_cons(exec_engine)
+    dispatch_engine: Union[EngineAbstract, str] = engine
+    df_ctor = df_cons(requested_engine)
     node_col = getattr(base_graph, "_node", "id")
 
     joined_rows: Optional[DataFrameT] = None
@@ -466,7 +502,13 @@ def _apply_connected_match_join(
                 language="cypher",
             )
         keep_cols = [column for column in pattern_rows.columns if column in join_cols or column not in joined_rows.columns]
-        joined_rows = cast(DataFrameT, joined_rows.merge(pattern_rows[keep_cols], on=join_cols, how="inner"))
+        joined_rows = _connected_inner_join_rows(
+            cast(DataFrameT, joined_rows),
+            cast(DataFrameT, pattern_rows),
+            join_cols=join_cols,
+            keep_cols=keep_cols,
+            engine=requested_engine,
+        )
 
     if joined_rows is None or len(joined_rows) == 0:
         out = base_graph.bind()
@@ -479,15 +521,7 @@ def _apply_connected_match_join(
     joined_plottable = base_graph.bind()
     joined_plottable._nodes = joined_rows
     joined_plottable._edges = df_ctor()
-    result = _chain_dispatch(joined_plottable, plan.post_join_chain, dispatch_engine, policy, context)
-    if requested_engine != Engine.CUDF:
-        return result
-    out = result.bind()
-    if getattr(out, "_nodes", None) is not None:
-        out._nodes = cast(DataFrameT, df_to_engine(cast(Any, out._nodes), Engine.CUDF))
-    if getattr(out, "_edges", None) is not None:
-        out._edges = cast(DataFrameT, df_to_engine(cast(Any, out._edges), Engine.CUDF))
-    return out
+    return _chain_dispatch(joined_plottable, plan.post_join_chain, dispatch_engine, policy, context)
 
 
 def _execute_graph_constructor_compiled(

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -422,11 +422,14 @@ def _apply_connected_match_join(
     from graphistry.compute.ast import ASTCall, serialize_binding_ops
 
     requested_engine = resolve_engine(cast(Any, engine), base_graph)
-    dispatch_engine: Union[EngineAbstract, str] = EngineAbstract.PANDAS if requested_engine == Engine.CUDF else engine
+    use_cudf_join_fallback = requested_engine == Engine.CUDF
+    dispatch_engine: Union[EngineAbstract, str] = (
+        EngineAbstract.PANDAS if use_cudf_join_fallback else engine
+    )
     # #1355: cuDF can segfault on connected comma-pattern row joins with some
     # rel-property projection shapes. Execute this join route on pandas and
     # convert the final rows back to cuDF so engine parity is preserved.
-    exec_engine = Engine.PANDAS if requested_engine == Engine.CUDF else requested_engine
+    exec_engine = Engine.PANDAS if use_cudf_join_fallback else requested_engine
     df_ctor = df_cons(exec_engine)
     node_col = getattr(base_graph, "_node", "id")
 

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -422,6 +422,7 @@ def _apply_connected_match_join(
     from graphistry.compute.ast import ASTCall, serialize_binding_ops
 
     requested_engine = resolve_engine(cast(Any, engine), base_graph)
+    dispatch_engine: Union[EngineAbstract, str] = EngineAbstract.PANDAS if requested_engine == Engine.CUDF else engine
     # #1355: cuDF can segfault on connected comma-pattern row joins with some
     # rel-property projection shapes. Execute this join route on pandas and
     # convert the final rows back to cuDF so engine parity is preserved.
@@ -435,7 +436,7 @@ def _apply_connected_match_join(
             list(pattern_chain.chain) + [ASTCall("rows", {"binding_ops": serialize_binding_ops(pattern_chain.chain)})],
             where=pattern_chain.where,
         )
-        pattern_result = _chain_dispatch(base_graph, with_rows, exec_engine, policy, context)
+        pattern_result = _chain_dispatch(base_graph, with_rows, dispatch_engine, policy, context)
         pattern_rows = cast(Optional[DataFrameT], getattr(pattern_result, "_nodes", None))
         if pattern_rows is None or len(pattern_rows) == 0:
             out = base_graph.bind()
@@ -475,7 +476,7 @@ def _apply_connected_match_join(
     joined_plottable = base_graph.bind()
     joined_plottable._nodes = joined_rows
     joined_plottable._edges = df_ctor()
-    result = _chain_dispatch(joined_plottable, plan.post_join_chain, exec_engine, policy, context)
+    result = _chain_dispatch(joined_plottable, plan.post_join_chain, dispatch_engine, policy, context)
     if requested_engine != Engine.CUDF:
         return result
     out = result.bind()

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3207,65 +3207,6 @@ def test_string_cypher_precedence_examples_use_integer_division(
     assert result._nodes.to_dict(orient="records") == expected_rows
 
 
-@pytest.mark.parametrize(
-    "query,expected_rows",
-    [
-        (
-            "RETURN 4 * 2 + 3 / 2 AS a, 4 * 2 + (3 / 2) AS b, 4 * (2 + 3) / 2 AS c",
-            [{"a": 9, "b": 9, "c": 10}],
-        ),
-        (
-            "RETURN 4 * 2 - 3 / 2 AS a, 4 * 2 - (3 / 2) AS b, 4 * (2 - 3) / 2 AS c",
-            [{"a": 7, "b": 7, "c": -2}],
-        ),
-        (
-            "RETURN 4 / 2 + 3 * 2 AS a, 4 / 2 + (3 * 2) AS b, 4 / (2 + 3) * 2 AS c",
-            [{"a": 8, "b": 8, "c": 0}],
-        ),
-        (
-            "RETURN 4 / 2 + 3 / 2 AS a, 4 / 2 + (3 / 2) AS b, 4 / (2 + 3) / 2 AS c",
-            [{"a": 3, "b": 3, "c": 0}],
-        ),
-        (
-            "RETURN 4 / 2 + 3 % 2 AS a, 4 / 2 + (3 % 2) AS b, 4 / (2 + 3) % 2 AS c",
-            [{"a": 3, "b": 3, "c": 0}],
-        ),
-        (
-            "RETURN 4 / 2 - 3 * 2 AS a, 4 / 2 - (3 * 2) AS b, 4 / (2 - 3) * 2 AS c",
-            [{"a": -4, "b": -4, "c": -8}],
-        ),
-        (
-            "RETURN 4 / 2 - 3 / 2 AS a, 4 / 2 - (3 / 2) AS b, 4 / (2 - 3) / 2 AS c",
-            [{"a": 1, "b": 1, "c": -2}],
-        ),
-        (
-            "RETURN 4 / 2 - 3 % 2 AS a, 4 / 2 - (3 % 2) AS b, 4 / (2 - 3) % 2 AS c",
-            [{"a": 1, "b": 1, "c": 0}],
-        ),
-        (
-            "RETURN 4 % 2 + 3 / 2 AS a, 4 % 2 + (3 / 2) AS b, 4 % (2 + 3) / 2 AS c",
-            [{"a": 1, "b": 1, "c": 2}],
-        ),
-        (
-            "RETURN 4 % 2 - 3 / 2 AS a, 4 % 2 - (3 / 2) AS b, 4 % (2 - 3) / 2 AS c",
-            [{"a": -1, "b": -1, "c": 0}],
-        ),
-    ],
-)
-def test_string_cypher_precedence_examples_use_integer_division(
-    query: str,
-    expected_rows: List[Dict[str, Any]],
-) -> None:
-    graph = _mk_graph(
-        pd.DataFrame({"id": ["n1"]}),
-        pd.DataFrame({"s": [], "d": []}),
-    )
-
-    result = graph.gfql(query)
-
-    assert result._nodes.to_dict(orient="records") == expected_rows
-
-
 def test_string_cypher_supports_whole_row_grouping_with_post_aggregate_expression() -> None:
     graph = _mk_graph(
         pd.DataFrame({"id": ["n1"]}),

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -10103,22 +10103,13 @@ def test_string_cypher_flatten_admit_matches_hand_flattened_oracle_simple_rebind
     assert via_flatten == via_oracle
 
 
-@pytest.mark.skip(
-    reason=(
-        "Pre-existing cuDF row-pipeline segfault (#1355) for shared-alias "
-        "multi-pattern with relationship-property projection — verified on "
-        "rapids 25.02 + 26.02 with both flatten-on and hand-flattened "
-        "single-MATCH form, exit code 139. ``skip`` not ``xfail`` because "
-        "SIGSEGV kills the pytest worker; xfail only catches in-process "
-        "exceptions. The pandas equivalent is locked in by "
-        "``test_flatten_admits_when_relationship_variable_is_carried`` "
-        "(#1341 round-001)."
-    )
-)
 def test_string_cypher_executes_with_match_reentry_relationship_variable_carried_on_cudf() -> None:
-    """Round-001 amplification (#1341): cuDF parity for the rel-var-carried admit
-    case. Mirrors ``test_flatten_admits_when_relationship_variable_is_carried``
-    on cuDF so the wave-4 fix's admit branch has backend parity coverage."""
+    """cuDF parity + no-crash regression for #1355.
+
+    Covers both:
+    - WITH-form that can flatten to connected comma-pattern
+    - Hand-flattened single-MATCH connected comma-pattern
+    """
     pytest.importorskip("cudf")
     nodes = pd.DataFrame(
         {
@@ -10131,15 +10122,21 @@ def test_string_cypher_executes_with_match_reentry_relationship_variable_carried
         {"s": ["a1", "b1"], "d": ["b1", "a1"], "type": ["R", "S"], "weight": [7, 9]}
     )
     g = _mk_cudf_graph(nodes, edges)
-    query = (
+    with_form = (
         "MATCH (a:A {id: 'a1'})-[r:R]->(b:B) "
         "WITH a, b, r "
         "MATCH (b)-[:S]->(a) "
         "RETURN r.weight AS w"
     )
-    result = g.gfql(query, engine="cudf")
-    assert type(result._nodes).__module__.startswith("cudf")
-    assert result._nodes.to_pandas().to_dict(orient="records") == [{"w": 7}]
+    hand_flattened = (
+        "MATCH (a:A {id: 'a1'})-[r:R]->(b:B), (b)-[:S]->(a) "
+        "RETURN r.weight AS w"
+    )
+
+    for query in (with_form, hand_flattened):
+        result = g.gfql(query, engine="cudf")
+        assert type(result._nodes).__module__.startswith("cudf")
+        assert _to_pandas_df(result._nodes).to_dict(orient="records") == [{"w": 7}]
 
 
 def test_string_cypher_executes_with_match_reentry_multi_whole_row_alias_property_carry_on_cudf() -> None:

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3148,6 +3148,63 @@ def test_string_cypher_uses_integer_division_for_literal_arithmetic_expression()
     result = graph.gfql("RETURN 12 / 4 * 3 - 2 * 4")
 
     assert result._nodes.to_dict(orient="records") == [{"12 / 4 * 3 - 2 * 4": 1}]
+@pytest.mark.parametrize(
+    "query,expected_rows",
+    [
+        (
+            "RETURN 4 * 2 + 3 / 2 AS a, 4 * 2 + (3 / 2) AS b, 4 * (2 + 3) / 2 AS c",
+            [{"a": 9, "b": 9, "c": 10}],
+        ),
+        (
+            "RETURN 4 * 2 - 3 / 2 AS a, 4 * 2 - (3 / 2) AS b, 4 * (2 - 3) / 2 AS c",
+            [{"a": 7, "b": 7, "c": -2}],
+        ),
+        (
+            "RETURN 4 / 2 + 3 * 2 AS a, 4 / 2 + (3 * 2) AS b, 4 / (2 + 3) * 2 AS c",
+            [{"a": 8, "b": 8, "c": 0}],
+        ),
+        (
+            "RETURN 4 / 2 + 3 / 2 AS a, 4 / 2 + (3 / 2) AS b, 4 / (2 + 3) / 2 AS c",
+            [{"a": 3, "b": 3, "c": 0}],
+        ),
+        (
+            "RETURN 4 / 2 + 3 % 2 AS a, 4 / 2 + (3 % 2) AS b, 4 / (2 + 3) % 2 AS c",
+            [{"a": 3, "b": 3, "c": 0}],
+        ),
+        (
+            "RETURN 4 / 2 - 3 * 2 AS a, 4 / 2 - (3 * 2) AS b, 4 / (2 - 3) * 2 AS c",
+            [{"a": -4, "b": -4, "c": -8}],
+        ),
+        (
+            "RETURN 4 / 2 - 3 / 2 AS a, 4 / 2 - (3 / 2) AS b, 4 / (2 - 3) / 2 AS c",
+            [{"a": 1, "b": 1, "c": -2}],
+        ),
+        (
+            "RETURN 4 / 2 - 3 % 2 AS a, 4 / 2 - (3 % 2) AS b, 4 / (2 - 3) % 2 AS c",
+            [{"a": 1, "b": 1, "c": 0}],
+        ),
+        (
+            "RETURN 4 % 2 + 3 / 2 AS a, 4 % 2 + (3 / 2) AS b, 4 % (2 + 3) / 2 AS c",
+            [{"a": 1, "b": 1, "c": 2}],
+        ),
+        (
+            "RETURN 4 % 2 - 3 / 2 AS a, 4 % 2 - (3 / 2) AS b, 4 % (2 - 3) / 2 AS c",
+            [{"a": -1, "b": -1, "c": 0}],
+        ),
+    ],
+)
+def test_string_cypher_precedence_examples_use_integer_division(
+    query: str,
+    expected_rows: List[Dict[str, Any]],
+) -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": ["n1"]}),
+        pd.DataFrame({"s": [], "d": []}),
+    )
+
+    result = graph.gfql(query)
+
+    assert result._nodes.to_dict(orient="records") == expected_rows
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Fixes #1355 by making connected comma-pattern `MATCH` execution cuDF-safe **without** a pandas roundtrip.
- Keeps connected join execution on cuDF (`fix(cypher): keep connected comma-pattern join fully on cudf`).
- Fixes a cuDF crash path in same-path null filtering by avoiding row-wise `DataFrame.all(axis=1)` in cuDF (`fix(gfql/cudf): avoid row-wise all(axis=1) segfault in same_path filters`).
- Includes runtime integer-division precedence alignment from #1366 to satisfy current `tck-gfql` xfail contract.

## Root Cause
- #1355 crash: certain relationship-property projection shapes in connected comma-pattern flows hit a cuDF segfault path.
- Additional crash path: row-wise null-filter reduction (`notna().all(axis=1)`) in same-path projection can trigger cuDF/numba segfault behavior.
- CI contract blocker on this branch baseline: integer-division precedence mismatch for `expr-mathematical8-*` until #1366 runtime semantics were applied.

## Changes
- cuDF-native connected join route:
  - `graphistry/compute/gfql_unified.py`
- cuDF-safe null-filter reduction for same-path projection:
  - `graphistry/compute/gfql/same_path/df_utils.py`
- Integer-division precedence runtime rewrite:
  - `graphistry/compute/gfql/cypher/lowering.py`
- Regression coverage updates:
  - `graphistry/tests/compute/gfql/cypher/test_lowering.py`
- CI surface baseline refresh:
  - `bin/ci_cypher_surface_guard_baseline.json`
- Changelog updates:
  - `CHANGELOG.md`

## Validation
- Local targeted regressions:
  - `python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "uses_integer_division_for_post_aggregate_expression or precedence_examples_use_integer_division or relationship_variable_carried_on_cudf"`
  - Result: pass
- DGX GPU repro verification:
  - RAPIDS `25.02`: #1355 repro query passes after fix
  - RAPIDS `26.02`: same repro query passes
- PR CI:
  - Latest full green run: `25595610854`
  - Includes `tck-gfql` passing

## Follow-on
- Backend DataFrame ops abstraction across GFQL runtime is tracked in #1380:
  - https://github.com/graphistry/pygraphistry/issues/1380

Closes #1355