### PR TITLE
Refactor GFQL connected join helpers into dfops layer

### DIFF
--- a/graphistry/compute/gfql/dfops/__init__.py
+++ b/graphistry/compute/gfql/dfops/__init__.py
@@ -1,0 +1,15 @@
+"""GFQL DataFrame operation helpers with engine-specific dispatch."""
+
+from .join import (
+    binding_join_columns,
+    connected_inner_join_rows,
+    joined_alias_columns,
+    joined_hidden_scalar_columns,
+)
+
+__all__ = [
+    "binding_join_columns",
+    "connected_inner_join_rows",
+    "joined_alias_columns",
+    "joined_hidden_scalar_columns",
+]

--- a/graphistry/compute/gfql/dfops/join.py
+++ b/graphistry/compute/gfql/dfops/join.py
@@ -1,0 +1,93 @@
+"""Join-related DataFrame operations for GFQL runtime execution paths."""
+
+from typing import Dict, List, Sequence, cast
+
+from graphistry.Engine import Engine
+from graphistry.compute.typing import DataFrameT
+
+
+def binding_join_columns(frame: DataFrameT) -> List[str]:
+    return [column for column in frame.columns if isinstance(column, str) and "." in column]
+
+
+def joined_hidden_scalar_columns(frame: DataFrameT) -> DataFrameT:
+    hidden_suffixes: Dict[str, List[str]] = {}
+    for column in frame.columns:
+        if not isinstance(column, str) or "." not in column:
+            continue
+        _, suffix = column.split(".", 1)
+        if suffix.startswith("__cypher_reentry_") or suffix.startswith("__gfql_hidden_"):
+            hidden_suffixes.setdefault(suffix, []).append(column)
+    out = frame
+    for suffix, columns in hidden_suffixes.items():
+        if suffix in out.columns:
+            continue
+        series = out[columns[0]]
+        for column in columns[1:]:
+            if hasattr(series, "combine_first"):
+                series = series.combine_first(out[column])
+        out = out.assign(**{suffix: series})
+    return out
+
+
+def joined_alias_columns(frame: DataFrameT) -> DataFrameT:
+    alias_candidates: Dict[str, str] = {}
+    for column in frame.columns:
+        if not isinstance(column, str) or "." not in column:
+            continue
+        alias, suffix = column.split(".", 1)
+        if alias in frame.columns:
+            continue
+        if suffix == alias:
+            alias_candidates.setdefault(alias, column)
+        elif suffix == "id" and alias not in alias_candidates:
+            alias_candidates[alias] = column
+    out = frame
+    for alias, source_column in alias_candidates.items():
+        out = out.assign(**{alias: out[source_column]})
+    return out
+
+
+def connected_inner_join_rows(
+    joined_rows: DataFrameT,
+    pattern_rows: DataFrameT,
+    *,
+    join_cols: Sequence[str],
+    keep_cols: Sequence[str],
+    engine: Engine,
+) -> DataFrameT:
+    """Inner-join connected MATCH row payloads.
+
+    cuDF path: avoid full-row merge on dotted payload columns by joining only
+    compact key/index frames, then gathering payload rows by position.
+    """
+    join_cols_list = list(join_cols)
+    keep_cols_list = list(keep_cols)
+    rhs = cast(DataFrameT, pattern_rows[keep_cols_list])
+    if engine != Engine.CUDF:
+        return cast(DataFrameT, joined_rows.merge(rhs, on=join_cols_list, how="inner"))
+
+    lhs_row_id = "__gfql_connected_lhs_row_id__"
+    rhs_row_id = "__gfql_connected_rhs_row_id__"
+    lhs = cast(DataFrameT, joined_rows.reset_index(drop=True))
+    rhs = cast(DataFrameT, rhs.reset_index(drop=True))
+    lhs_with_idx = cast(DataFrameT, lhs.reset_index().rename(columns={"index": lhs_row_id}))
+    rhs_with_idx = cast(DataFrameT, rhs.reset_index().rename(columns={"index": rhs_row_id}))
+    lhs_keys = cast(DataFrameT, lhs_with_idx[[lhs_row_id] + join_cols_list])
+    rhs_keys = cast(DataFrameT, rhs_with_idx[[rhs_row_id] + join_cols_list])
+    row_pairs = cast(DataFrameT, lhs_keys.merge(rhs_keys, on=join_cols_list, how="inner"))
+    rhs_payload_cols = [column for column in keep_cols_list if column not in join_cols_list]
+    if len(row_pairs) == 0:
+        out = cast(DataFrameT, lhs.head(0))
+        for column in rhs_payload_cols:
+            out = out.assign(**{column: rhs[column].head(0)})
+        return out
+
+    lhs_taken = cast(DataFrameT, lhs.take(row_pairs[lhs_row_id]))
+    if not rhs_payload_cols:
+        return cast(DataFrameT, lhs_taken.reset_index(drop=True))
+    rhs_payload = cast(DataFrameT, rhs[rhs_payload_cols].take(row_pairs[rhs_row_id]).reset_index(drop=True))
+    lhs_taken = cast(DataFrameT, lhs_taken.reset_index(drop=True))
+    for column in rhs_payload_cols:
+        lhs_taken = lhs_taken.assign(**{column: rhs_payload[column]})
+    return lhs_taken

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -52,6 +52,12 @@ from graphistry.compute.gfql.df_executor import (
     build_same_path_inputs,
     execute_same_path_chain,
 )
+from graphistry.compute.gfql.dfops import (
+    binding_join_columns as _binding_join_columns,
+    connected_inner_join_rows as _connected_inner_join_rows,
+    joined_alias_columns as _joined_alias_columns,
+    joined_hidden_scalar_columns as _joined_hidden_scalar_columns,
+)
 from graphistry.compute.gfql.ir.compilation import PhysicalPlan, PlanContext
 from graphistry.compute.gfql.ir.logical_plan import LogicalPlan
 from graphistry.compute.gfql.physical_planner import (
@@ -363,95 +369,6 @@ def _apply_connected_optional_match(
     joined_plottable._edges = df_ctor()
 
     return _chain_dispatch(joined_plottable, plan.post_join_chain, engine, policy, context)
-
-
-def _binding_join_columns(frame: DataFrameT) -> List[str]:
-    return [
-        column
-        for column in frame.columns
-        if isinstance(column, str) and "." in column
-    ]
-
-
-def _joined_hidden_scalar_columns(frame: DataFrameT) -> DataFrameT:
-    hidden_suffixes: Dict[str, List[str]] = {}
-    for column in frame.columns:
-        if not isinstance(column, str) or "." not in column:
-            continue
-        _, suffix = column.split(".", 1)
-        if suffix.startswith("__cypher_reentry_") or suffix.startswith("__gfql_hidden_"):
-            hidden_suffixes.setdefault(suffix, []).append(column)
-    out = frame
-    for suffix, columns in hidden_suffixes.items():
-        if suffix in out.columns:
-            continue
-        series = out[columns[0]]
-        for column in columns[1:]:
-            if hasattr(series, "combine_first"):
-                series = series.combine_first(out[column])
-        out = out.assign(**{suffix: series})
-    return out
-
-
-def _joined_alias_columns(frame: DataFrameT) -> DataFrameT:
-    alias_candidates: Dict[str, str] = {}
-    for column in frame.columns:
-        if not isinstance(column, str) or "." not in column:
-            continue
-        alias, suffix = column.split(".", 1)
-        if alias in frame.columns:
-            continue
-        if suffix == alias:
-            alias_candidates.setdefault(alias, column)
-        elif suffix == "id" and alias not in alias_candidates:
-            alias_candidates[alias] = column
-    out = frame
-    for alias, source_column in alias_candidates.items():
-        out = out.assign(**{alias: out[source_column]})
-    return out
-
-
-def _connected_inner_join_rows(
-    joined_rows: DataFrameT,
-    pattern_rows: DataFrameT,
-    *,
-    join_cols: List[str],
-    keep_cols: List[str],
-    engine: Engine,
-) -> DataFrameT:
-    """Inner-join connected MATCH row payloads.
-
-    cuDF path: avoid full-row merge on dotted payload columns by joining only
-    compact key/index frames, then gathering payload rows by position.
-    """
-    rhs = cast(DataFrameT, pattern_rows[keep_cols])
-    if engine != Engine.CUDF:
-        return cast(DataFrameT, joined_rows.merge(rhs, on=join_cols, how="inner"))
-
-    lhs_row_id = "__gfql_connected_lhs_row_id__"
-    rhs_row_id = "__gfql_connected_rhs_row_id__"
-    lhs = cast(DataFrameT, joined_rows.reset_index(drop=True))
-    rhs = cast(DataFrameT, rhs.reset_index(drop=True))
-    lhs_with_idx = cast(DataFrameT, lhs.reset_index().rename(columns={"index": lhs_row_id}))
-    rhs_with_idx = cast(DataFrameT, rhs.reset_index().rename(columns={"index": rhs_row_id}))
-    lhs_keys = cast(DataFrameT, lhs_with_idx[[lhs_row_id] + join_cols])
-    rhs_keys = cast(DataFrameT, rhs_with_idx[[rhs_row_id] + join_cols])
-    row_pairs = cast(DataFrameT, lhs_keys.merge(rhs_keys, on=join_cols, how="inner"))
-    rhs_payload_cols = [column for column in keep_cols if column not in join_cols]
-    if len(row_pairs) == 0:
-        out = cast(DataFrameT, lhs.head(0))
-        for column in rhs_payload_cols:
-            out = out.assign(**{column: rhs[column].head(0)})
-        return out
-
-    lhs_taken = cast(DataFrameT, lhs.take(row_pairs[lhs_row_id]))
-    if not rhs_payload_cols:
-        return cast(DataFrameT, lhs_taken.reset_index(drop=True))
-    rhs_payload = cast(DataFrameT, rhs[rhs_payload_cols].take(row_pairs[rhs_row_id]).reset_index(drop=True))
-    lhs_taken = cast(DataFrameT, lhs_taken.reset_index(drop=True))
-    for column in rhs_payload_cols:
-        lhs_taken = lhs_taken.assign(**{column: rhs_payload[column]})
-    return lhs_taken
 
 
 def _apply_connected_match_join(

--- a/graphistry/tests/compute/gfql/test_dfops_join.py
+++ b/graphistry/tests/compute/gfql/test_dfops_join.py
@@ -1,0 +1,109 @@
+import pandas as pd
+import pytest
+
+from graphistry.Engine import Engine
+from graphistry.compute.gfql.dfops.join import (
+    binding_join_columns,
+    connected_inner_join_rows,
+    joined_alias_columns,
+    joined_hidden_scalar_columns,
+)
+
+
+def _records(df):
+    if hasattr(df, "to_pandas"):
+        return df.to_pandas().to_dict(orient="records")
+    return df.to_dict(orient="records")
+
+
+def test_binding_join_columns_selects_dotted_columns_only() -> None:
+    frame = pd.DataFrame(
+        {
+            "a.id": ["n1"],
+            "a.label": ["A"],
+            "plain": [1],
+            5: [9],
+        }
+    )
+    assert binding_join_columns(frame) == ["a.id", "a.label"]
+
+
+def test_joined_hidden_scalar_columns_coalesces_suffix_variants() -> None:
+    frame = pd.DataFrame(
+        {
+            "a.__cypher_reentry_property__": [None, 2],
+            "b.__cypher_reentry_property__": [1, None],
+            "a.id": ["a1", "a2"],
+        }
+    )
+    out = joined_hidden_scalar_columns(frame)
+    assert _records(out[["__cypher_reentry_property__"]]) == [
+        {"__cypher_reentry_property__": 1.0},
+        {"__cypher_reentry_property__": 2.0},
+    ]
+
+
+def test_joined_alias_columns_recovers_alias_identity_columns() -> None:
+    frame = pd.DataFrame(
+        {
+            "a.id": ["a1"],
+            "b.b": ["b1"],
+            "b.id": ["b1-id-fallback"],
+        }
+    )
+    out = joined_alias_columns(frame)
+    assert _records(out[["a", "b"]]) == [{"a": "a1", "b": "b1"}]
+
+
+def test_connected_inner_join_rows_pandas_path() -> None:
+    joined_rows = pd.DataFrame(
+        {
+            "a.id": ["a1", "a2"],
+            "a.num": [1, 2],
+        }
+    )
+    pattern_rows = pd.DataFrame(
+        {
+            "a.id": ["a1", "a1", "a3"],
+            "b.id": ["b1", "b2", "b3"],
+        }
+    )
+    out = connected_inner_join_rows(
+        joined_rows,
+        pattern_rows,
+        join_cols=["a.id"],
+        keep_cols=["a.id", "b.id"],
+        engine=Engine.PANDAS,
+    )
+    assert _records(out[["a.id", "b.id"]]) == [
+        {"a.id": "a1", "b.id": "b1"},
+        {"a.id": "a1", "b.id": "b2"},
+    ]
+
+
+def test_connected_inner_join_rows_cudf_path() -> None:
+    cudf = pytest.importorskip("cudf")
+    joined_rows = cudf.DataFrame(
+        {
+            "a.id": ["a1", "a2"],
+            "a.num": [1, 2],
+        }
+    )
+    pattern_rows = cudf.DataFrame(
+        {
+            "a.id": ["a1", "a1", "a3"],
+            "b.id": ["b1", "b2", "b3"],
+        }
+    )
+    out = connected_inner_join_rows(
+        joined_rows,
+        pattern_rows,
+        join_cols=["a.id"],
+        keep_cols=["a.id", "b.id"],
+        engine=Engine.CUDF,
+    )
+    assert type(out).__module__.startswith("cudf")
+    assert _records(out[["a.id", "b.id"]]) == [
+        {"a.id": "a1", "b.id": "b1"},
+        {"a.id": "a1", "b.id": "b2"},
+    ]


### PR DESCRIPTION
## Summary
- add `graphistry/compute/gfql/dfops/` with join-focused DataFrame ops contracts
- migrate connected comma-pattern runtime helpers out of `gfql_unified.py` into `dfops/join.py`
- add targeted dfops join contract tests (pandas + cuDF-gated parity)

## Why
- first tranche for #1380: centralize engine-specific GFQL DataFrame join behavior
- preserve #1355 cuDF safety path while reducing duplication in unified runtime

## Scope notes
- this tranche focuses on connected-join + alias/hidden-column coalescing helpers
- follow-on dfops migrations (optional/same_path/reentry expansion) remain separate

## Validation
- `python -m pytest -q graphistry/tests/compute/gfql/test_dfops_join.py`
- `python -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k "flatten_admit_matches_hand_flattened_oracle_simple_rebind or relationship_variable_carried_on_cudf"`
- `python -m pytest -q graphistry/tests/compute/gfql/test_physical_planner.py`
- `./bin/ruff.sh graphistry/compute/gfql/dfops graphistry/compute/gfql_unified.py graphistry/tests/compute/gfql/test_dfops_join.py`

Refs #1380
