### PR TITLE
[CHORE] GFQL row tests: relocate #1362 ordering cases into row mirror (#1377)

### DIFF
--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -7937,54 +7937,11 @@ def test_string_cypher_supports_order_by_stringified_list_subscript_expression()
     ]
 
 
-def test_string_cypher_order_by_python_list_column_uses_list_orderability() -> None:
-    """Issue #1359 — Cypher ORDER BY <list-col> must use openCypher list-orderability.
-
-    Pairwise lex comparison; shorter list less-than its longer prefix-equal extension.
-    With Python-list-typed input, the row pipeline's ``build_list_sort_columns``
-    handles this correctly. This test pins the behavior so future refactors
-    don't regress to a string-cast fallback (the bug we lifted for str-typed cols).
-    """
-    g = _mk_graph(
-        pd.DataFrame(
-            {
-                "id": ["a", "b", "c", "d", "e"],
-                "list": [[2, -2], [1, 2], [300, 0], [1, -20], [2, -2, 100]],
-            }
-        ),
-        pd.DataFrame({"s": [], "d": []}),
-    )
-
-    asc = g.gfql(
-        "MATCH (a) "
-        "WITH a, a.list AS list "
-        "WITH a, list ORDER BY list ASC LIMIT 3 "
-        "RETURN a, list"
-    )
-    asc_lists = [tuple(v) for v in asc._nodes["list"].tolist()]
-    assert sorted(asc_lists) == sorted([(1, -20), (1, 2), (2, -2)])
-
-    desc = g.gfql(
-        "MATCH (a) "
-        "WITH a, a.list AS list "
-        "WITH a, list ORDER BY list DESC LIMIT 3 "
-        "RETURN a, list"
-    )
-    desc_lists = [tuple(v) for v in desc._nodes["list"].tolist()]
-    assert sorted(desc_lists) == sorted([(300, 0), (2, -2, 100), (2, -2)])
-
-
 def test_string_cypher_order_by_stringified_list_column_uses_list_orderability() -> None:
-    """Issue #1359 — Cypher ORDER BY <stringified-list-col>.
+    """Thin cypher integration smoke for stringified-list ORDER BY semantics.
 
-    When a list-valued property is stored as a string column (e.g. round-tripped
-    through CSV / Arrow string), pygraphistry must still apply Cypher list
-    orderability — not lex string sort, which mishandles negatives because
-    ``"-"`` < ``"2"`` in ASCII.
-
-    Pre-fix: lex string sort produced top-3 ASC = D, B, E (E in place of A).
-    Post-fix: top-3 ASC SET = {B, D, A} via ``order_detect_stringified_list_series``
-    + ``parse_stringified_list_series`` routing into ``build_list_sort_columns``.
+    Row-orderability specifics are covered in row-pipeline tests under
+    `graphistry/tests/compute/gfql/row/test_ordering.py`.
     """
     g = _mk_graph(
         pd.DataFrame(
@@ -8016,119 +7973,6 @@ def test_string_cypher_order_by_stringified_list_column_uses_list_orderability()
     )
     desc_values = sorted(str(v) for v in desc._nodes["list"].tolist())
     assert desc_values == sorted(["[300, 0]", "[2, -2, 100]", "[2, -2]"])
-
-
-def test_string_cypher_order_by_partial_stringified_list_raises_mixed_family() -> None:
-    """Issue #1359 W2-A1 — partial-list-shape columns must raise, not silently lex-sort.
-
-    Mixing list-shaped strings (`'[1, -20]'`) with plain strings (`'hello'`) was
-    classified as a single ``str`` family by ``validate_order_series_vector_safe``,
-    silently routing to lex sort and reproducing the wrong-row bug #1359 fixed.
-    Now the validator splits ``str`` into ``list_string`` vs plain ``str`` families
-    and raises mixed-family on the boundary.
-    """
-    g = _mk_graph(
-        pd.DataFrame(
-            {
-                "id": ["a", "b", "c"],
-                "list": pd.Series(["[1, -20]", "hello", "[2, 0]"], dtype="string"),
-            }
-        ),
-        pd.DataFrame({"s": [], "d": []}),
-    )
-
-    with pytest.raises((GFQLTypeError, ValueError)) as exc:
-        g.gfql(
-            "MATCH (a) WITH a, a.list AS list WITH a, list "
-            "ORDER BY list ASC RETURN a, list"
-        )
-    assert "list_string" in str(exc.value) and "str" in str(exc.value)
-
-
-def test_string_cypher_order_by_stringified_list_with_nulls_returns_top_k_without_error() -> None:
-    """Issue #1359 W1-I4 — stringified-list with nulls completes without error.
-
-    Documents the current behavior on null-bearing list columns:
-    ``pipeline.py:3955-3967`` explicitly skips the parsed-list path when any null
-    is present (``has_null=True`` carve-out, mirroring the Python-list path).
-    Falls through to ``validate_order_series_vector_safe``, which classifies
-    non-null cells as ``list_string`` family (singleton, no raise), then
-    ``sort_values`` runs default lex over the string representation. Pin: no
-    exception and top-K contains the smaller list-shaped values.
-    """
-    g = _mk_graph(
-        pd.DataFrame(
-            {
-                "id": ["a", "b", "c", "d"],
-                "list": pd.Series(["[1, 2]", None, "[3, 4]", "[1, 1]"], dtype="object"),
-            }
-        ),
-        pd.DataFrame({"s": [], "d": []}),
-    )
-
-    res = g.gfql(
-        "MATCH (a) WITH a, a.list AS list WITH a, list "
-        "ORDER BY list ASC LIMIT 3 RETURN a, list"
-    )
-    values = sorted(str(v) for v in res._nodes["list"].tolist())
-    # Top-3 SET excludes the larger [3, 4]; nulls sort high under pandas default.
-    assert "[1, 1]" in values and "[1, 2]" in values
-
-
-def test_string_cypher_order_by_malformed_stringified_list_falls_back_to_lex_sort() -> None:
-    """Issue #1359 W1-I6 — `'[1, 2'` (missing closing bracket) falls back gracefully.
-
-    The detector accepts the row (regex `^[.*]$` requires a closing bracket so this
-    actually FAILS the detector and routes to plain string lex sort). Pin the
-    fallback path so future detector tightening doesn't accidentally break it.
-    """
-    g = _mk_graph(
-        pd.DataFrame(
-            {
-                "id": ["a", "b"],
-                "list": pd.Series(["[1, 2", "abc"], dtype="string"),
-            }
-        ),
-        pd.DataFrame({"s": [], "d": []}),
-    )
-
-    res = g.gfql(
-        "MATCH (a) WITH a, a.list AS list WITH a, list "
-        "ORDER BY list ASC RETURN a, list"
-    )
-    # Malformed-string column treated as plain strings; lex sort: '[1, 2' < 'abc'.
-    values = [str(v) for v in res._nodes["list"].tolist()]
-    assert values == ["[1, 2", "abc"]
-
-
-def test_string_cypher_order_by_multi_key_stringified_list_with_scalar() -> None:
-    """Issue #1359 W1-I5 — multi-key ORDER BY mixing stringified-list with scalar.
-
-    Exercises ``aux_drop_cols`` accumulation across multiple ORDER BY iterations.
-    Sort by ``list ASC, num DESC`` over a stringified-list + numeric column.
-    Pins that the parsed aux column doesn't leak into the result.
-    """
-    g = _mk_graph(
-        pd.DataFrame(
-            {
-                "id": ["a", "b", "c", "d"],
-                "list": pd.Series(["[1, 2]", "[1, 2]", "[3, 4]", "[3, 4]"], dtype="string"),
-                "num": [10, 20, 5, 15],
-            }
-        ),
-        pd.DataFrame({"s": [], "d": []}),
-    )
-
-    res = g.gfql(
-        "MATCH (a) WITH a, a.list AS list, a.num AS num WITH a, list, num "
-        "ORDER BY list ASC, num DESC RETURN a, list, num"
-    )
-    # Within list=[1,2] group, num DESC: 20, 10. Within list=[3,4] group: 15, 5.
-    nums = res._nodes["num"].tolist()
-    assert nums == [20, 10, 15, 5]
-    # Aux col must not leak.
-    leaked = [c for c in res._nodes.columns if "__gfql_sort_listparsed" in str(c)]
-    assert leaked == [], f"aux columns leaked: {leaked}"
 
 
 def test_string_cypher_supports_return_star_after_with_distinct_row_projection() -> None:

--- a/graphistry/tests/compute/gfql/row/test_ordering.py
+++ b/graphistry/tests/compute/gfql/row/test_ordering.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from graphistry.compute.ast import limit, order_by, rows, select
+from graphistry.compute.exceptions import GFQLTypeError
+from graphistry.tests.test_compute import CGFull
+
+
+def _mk_graph(nodes_df: pd.DataFrame, edges_df: pd.DataFrame | None = None):
+    if edges_df is None:
+        edges_df = pd.DataFrame({"s": ["a"], "d": ["b"]})
+    return CGFull().nodes(nodes_df, "id").edges(edges_df, "s", "d")
+
+
+def _self_loop_edges(nodes_df: pd.DataFrame) -> pd.DataFrame:
+    if len(nodes_df) == 0:
+        return pd.DataFrame({"s": [], "d": []})
+    node_id = nodes_df["id"].iloc[0]
+    return pd.DataFrame({"s": [node_id], "d": [node_id]})
+
+
+def _run_node_steps(nodes_df: pd.DataFrame, steps: list[object], edges_df: pd.DataFrame | None = None):
+    return _mk_graph(nodes_df, edges_df).gfql(steps)._nodes
+
+
+def test_row_pipeline_order_by_supports_list_literal_and_subscript_expression_keys() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d", "e"],
+            "list": [[2, -2], [1, 2], [300, 0], [1, -20], [2, -2, 100]],
+            "list2": [[3, -2], [2, -2], [1, -2], [4, -2], [5, -2]],
+        }
+    )
+
+    result = _run_node_steps(
+        nodes_df,
+        [
+            rows(),
+            order_by([("[list2[1], list2[0], list[1]] + list + list2", "asc")]),
+            limit(3),
+            select([("id", "id")]),
+        ],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+
+    assert result.to_dict(orient="records") == [{"id": "c"}, {"id": "b"}, {"id": "a"}]
+
+
+def test_row_pipeline_order_by_list_column_matches_opencypher_prefix_tie_break() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d", "e"],
+            "list": [[2, -2], [1, 2], [300, 0], [1, -20], [2, -2, 100]],
+        }
+    )
+
+    asc = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "asc")]), limit(3), select([("id", "id")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    assert asc.to_dict(orient="records") == [{"id": "d"}, {"id": "b"}, {"id": "a"}]
+
+    desc = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "desc")]), limit(3), select([("id", "id")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    assert desc.to_dict(orient="records") == [{"id": "c"}, {"id": "e"}, {"id": "a"}]
+
+
+def test_row_pipeline_order_by_stringified_list_column_uses_list_orderability() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d", "e"],
+            "list": pd.Series(["[2, -2]", "[1, 2]", "[300, 0]", "[1, -20]", "[2, -2, 100]"], dtype="string"),
+        }
+    )
+
+    asc = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "asc")]), limit(3), select([("list", "list")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    asc_values = sorted(str(v) for v in asc["list"].tolist())
+    assert asc_values == sorted(["[1, -20]", "[1, 2]", "[2, -2]"])
+
+    desc = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "desc")]), limit(3), select([("list", "list")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    desc_values = sorted(str(v) for v in desc["list"].tolist())
+    assert desc_values == sorted(["[300, 0]", "[2, -2, 100]", "[2, -2]"])
+
+
+def test_row_pipeline_order_by_partial_stringified_list_raises_mixed_family() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c"],
+            "list": pd.Series(["[1, -20]", "hello", "[2, 0]"], dtype="string"),
+        }
+    )
+
+    with pytest.raises((GFQLTypeError, ValueError)) as exc:
+        _run_node_steps(
+            nodes_df,
+            [rows(), order_by([("list", "asc")]), select([("id", "id"), ("list", "list")])],
+            edges_df=_self_loop_edges(nodes_df),
+        )
+    assert "list_string" in str(exc.value) and "str" in str(exc.value)
+
+
+def test_row_pipeline_order_by_stringified_list_with_nulls_returns_top_k_without_error() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d"],
+            "list": pd.Series(["[1, 2]", None, "[3, 4]", "[1, 1]"], dtype="object"),
+        }
+    )
+
+    result = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "asc")]), limit(3), select([("list", "list")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    values = sorted(str(v) for v in result["list"].tolist())
+    assert "[1, 1]" in values and "[1, 2]" in values
+
+
+def test_row_pipeline_order_by_malformed_stringified_list_falls_back_to_lex_sort() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b"],
+            "list": pd.Series(["[1, 2", "abc"], dtype="string"),
+        }
+    )
+
+    result = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "asc")]), select([("list", "list")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    values = [str(v) for v in result["list"].tolist()]
+    assert values == ["[1, 2", "abc"]
+
+
+def test_row_pipeline_order_by_multi_key_stringified_list_with_scalar() -> None:
+    nodes_df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d"],
+            "list": pd.Series(["[1, 2]", "[1, 2]", "[3, 4]", "[3, 4]"], dtype="string"),
+            "num": [10, 20, 5, 15],
+        }
+    )
+
+    result = _run_node_steps(
+        nodes_df,
+        [rows(), order_by([("list", "asc"), ("num", "desc")]), select([("list", "list"), ("num", "num")])],
+        edges_df=_self_loop_edges(nodes_df),
+    )
+    assert result["num"].tolist() == [20, 10, 15, 5]
+    leaked = [c for c in result.columns if "__gfql_sort_listparsed" in str(c)]
+    assert leaked == [], f"aux columns leaked: {leaked}"

--- a/graphistry/tests/compute/gfql/test_row_pipeline_ops.py
+++ b/graphistry/tests/compute/gfql/test_row_pipeline_ops.py
@@ -309,57 +309,6 @@ def test_row_pipeline_select_rejects_invalid_range_arguments(expr: str, pattern:
         _run_node_steps(nodes_df, [rows(), select([("vals", expr)])], edges_df=_self_loop_edges(nodes_df))
 
 
-def test_row_pipeline_order_by_supports_list_literal_and_subscript_expression_keys() -> None:
-    nodes_df = pd.DataFrame(
-        {
-            "id": ["a", "b", "c", "d", "e"],
-            "list": [[2, -2], [1, 2], [300, 0], [1, -20], [2, -2, 100]],
-            "list2": [[3, -2], [2, -2], [1, -2], [4, -2], [5, -2]],
-        }
-    )
-
-    result = _run_node_steps(
-        nodes_df,
-        [
-            rows(),
-            order_by([("[list2[1], list2[0], list[1]] + list + list2", "asc")]),
-            limit(3),
-            select([("id", "id")]),
-        ],
-        edges_df=_self_loop_edges(nodes_df),
-    )
-
-    assert result.to_dict(orient="records") == [{"id": "c"}, {"id": "b"}, {"id": "a"}]
-
-
-def test_row_pipeline_order_by_list_column_matches_opencypher_prefix_tie_break() -> None:
-    # Mirrors openCypher TCK clauses/with-orderBy/WithOrderBy1.feature scenarios [31] / [32]
-    # with proper Python-list values. openCypher list comparator: element-wise; if all
-    # overlapping elements equal, the shorter list is less. So [2, -2] < [2, -2, 100] ASC.
-    # Pins build_list_sort_columns + order_detect_list_series behavior so future row-pipeline
-    # work doesn't regress this. See pygraphistry #1359 / tck-gfql#36.
-    nodes_df = pd.DataFrame(
-        {
-            "id": ["a", "b", "c", "d", "e"],
-            "list": [[2, -2], [1, 2], [300, 0], [1, -20], [2, -2, 100]],
-        }
-    )
-
-    asc = _run_node_steps(
-        nodes_df,
-        [rows(), order_by([("list", "asc")]), limit(3), select([("id", "id")])],
-        edges_df=_self_loop_edges(nodes_df),
-    )
-    assert asc.to_dict(orient="records") == [{"id": "d"}, {"id": "b"}, {"id": "a"}]
-
-    desc = _run_node_steps(
-        nodes_df,
-        [rows(), order_by([("list", "desc")]), limit(3), select([("id", "id")])],
-        edges_df=_self_loop_edges(nodes_df),
-    )
-    assert desc.to_dict(orient="records") == [{"id": "c"}, {"id": "e"}, {"id": "a"}]
-
-
 def test_row_pipeline_order_by_supports_temporal_duration_expression_keys() -> None:
     nodes_df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- create `graphistry/tests/compute/gfql/row/test_ordering.py` as the first row-mirror module
- relocate row-ordering/list-key tests from `graphistry/tests/compute/gfql/cypher/test_lowering.py` into row-pipeline tests
- keep one thin cypher integration smoke in `test_lowering.py`
- move list-ordering row tests out of monolithic `test_row_pipeline_ops.py`

## Why
- issue #1377 tracks row test placement debt: row semantics were over-coupled to cypher-lowering integration tests
- this keeps cypher integration coverage while shifting row semantics to row tests

## Validation
- `python -m pytest -q graphistry/tests/compute/gfql/row/test_ordering.py graphistry/tests/compute/gfql/test_row_pipeline_ops.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `uv run ruff check graphistry/tests/compute/gfql/row/test_ordering.py graphistry/tests/compute/gfql/test_row_pipeline_ops.py graphistry/tests/compute/gfql/cypher/test_lowering.py`

Closes #1377
