### PR TITLE
[codex] Add #1416 recursive ancestor row-join regression

### DIFF
--- a/graphistry/tests/test_compute_chain.py
+++ b/graphistry/tests/test_compute_chain.py
@@ -889,7 +889,12 @@ class TestChainBindingsTable(NoAuthTestCase):
                 [
                     {"id": "c1", "labels": ["Comment"], "label__Comment": True},
                     {"id": "m1", "labels": ["Message"], "label__Message": True},
-                    {"id": "p1", "labels": ["Post"], "label__Post": True},
+                    {
+                        "id": "p1",
+                        "labels": ["Message", "Post"],
+                        "label__Message": True,
+                        "label__Post": True,
+                    },
                     {"id": "f1", "labels": ["Forum"], "label__Forum": True, "title": "Forum"},
                     {
                         "id": "u1",
@@ -922,9 +927,11 @@ class TestChainBindingsTable(NoAuthTestCase):
             pd.DataFrame({"s": [], "d": []}),
         )
 
-    def _forum_moderator_match_ops(self, reply_edge):
+    def _forum_moderator_match_ops(self, reply_edge, message_predicate=None):
+        if message_predicate is None:
+            message_predicate = {"id": "c1", "label__Comment": True}
         return [
-            n({"id": "c1", "label__Comment": True}, name="message"),
+            n(message_predicate, name="message"),
             reply_edge,
             n({"label__Post": True}, name="post"),
             e_reverse({"type": "CONTAINER_OF"}),
@@ -1475,6 +1482,31 @@ class TestChainBindingsTable(NoAuthTestCase):
             ),
             items=[("forumId", "forum.id"), ("moderatorId", "moderator.id")],
             expected=[{"forumId": "f1", "moderatorId": "u1"}],
+        )
+
+    def test_direct_rows_binding_ops_supports_zero_hop_post_ancestor_join(self):
+        """IS6 post inputs should bind the post ancestor via the zero-hop arm."""
+        g = self._mk_forum_moderator_graph()
+        self._assert_rows_binding_parity(
+            g,
+            self._forum_moderator_match_ops(
+                e_forward({"type": "REPLY_OF"}, min_hops=0, to_fixed_point=True),
+                message_predicate={"id": "p1", "label__Message": True},
+            ),
+            items=[
+                ("messageId", "message.id"),
+                ("postId", "post.id"),
+                ("forumId", "forum.id"),
+                ("moderatorId", "moderator.id"),
+            ],
+            expected=[
+                {
+                    "messageId": "p1",
+                    "postId": "p1",
+                    "forumId": "f1",
+                    "moderatorId": "u1",
+                }
+            ],
         )
 
     def test_direct_rows_binding_ops_supports_open_range_multihop_continuation_on_cudf(self):


### PR DESCRIPTION
## Summary

Adds focused regression coverage for #1416 / #880 around the GFQL recursive ancestor row-join lane.

The existing IS6-style test covered a `Comment` input where `REPLY_OF*0..` reaches the `Post` ancestor through nonzero hops. This adds the matching `Post` input case, where the post ancestor must bind through the zero-hop arm before joining to forum/moderator rows.

## Investigation

- The referenced rerun artifact `results/runs/local-snb-interactive-closeout-2026-05-09` is not present in this checkout.
- In-repo residual triage only reads `probe-results.json`; the suite runner/adapter fallback producer is not present here.
- Current direct GFQL execution passes the nonzero-hop and zero-hop row-binding cases locally.

## Validation

- `python3 -m pytest -q graphistry/tests/test_compute_chain.py::TestChainBindingsTable::test_direct_rows_binding_ops_supports_open_range_multihop_continuation graphistry/tests/test_compute_chain.py::TestChainBindingsTable::test_direct_rows_binding_ops_supports_zero_hop_post_ancestor_join graphistry/tests/test_compute_chain.py::TestChainBindingsTable::test_direct_rows_binding_ops_supports_bounded_open_range_multihop_continuation`
- `./bin/lint.sh graphistry/tests/test_compute_chain.py`

## Local blockers

- Full `TestChainBindingsTable` is not clean in this local environment: cuDF tests fail because no CUDA device is available, and row-expression tests fail because the parser backend dependency is missing.

Refs #1416. Fresh benchmark rerun confirmation is still required before closing the issue.
