### PR TITLE
Reject invalid Direct-Cypher toString list items

### DIFF
--- a/bin/ci_cypher_surface_guard_baseline.json
+++ b/bin/ci_cypher_surface_guard_baseline.json
@@ -13,5 +13,5 @@
       "max_properties": 0
     }
   },
-  "lowering_py_max_lines": 8973
+  "lowering_py_max_lines": 8977
 }

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -987,6 +987,10 @@ def _list_item_invalid_for_tostring(
     *,
     alias_targets: Optional[Mapping[str, ASTObject]],
 ) -> bool:
+    if isinstance(item, ExprLiteral):
+        return isinstance(item.value, (list, dict))
+    if isinstance(item, (ListLiteral, MapLiteral)):
+        return True
     if isinstance(item, Identifier):
         return alias_targets is not None and item.name in alias_targets
     if isinstance(item, FunctionCall):

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -5159,6 +5159,16 @@ def test_string_cypher_executes_extreme_year_duration_functions() -> None:
             pd.DataFrame({"id": ["n1", "n2"]}),
             pd.DataFrame({"s": ["n1"], "d": ["n2"], "type": ["T"]}),
         ),
+        (
+            "MATCH p = (n)-[r:T]->() RETURN [x IN [1, '', []] | toString(x) ] AS list",
+            pd.DataFrame({"id": ["n1", "n2"]}),
+            pd.DataFrame({"s": ["n1"], "d": ["n2"], "type": ["T"]}),
+        ),
+        (
+            "MATCH p = (n)-[r:T]->() RETURN [x IN [1, '', {}] | toString(x) ] AS list",
+            pd.DataFrame({"id": ["n1", "n2"]}),
+            pd.DataFrame({"s": ["n1"], "d": ["n2"], "type": ["T"]}),
+        ),
     ],
 )
 def test_string_cypher_failfast_rejects_invalid_supported_overlap_queries(


### PR DESCRIPTION
Closes #1429.

Sidecar tck-gfql PR: https://github.com/graphistry/tck-gfql/pull/104

## Summary

- Reject invalid Direct-Cypher `toString()` list-comprehension item types for list/map literals.
- Add focused lowering regressions for `toString([])` and `toString({})`.
- Coordinate with the same-name tck-gfql branch to update the direct-Cypher contract and promote fixed string/literal rows.
- Update the Cypher surface guard baseline for the intentional +4 `lowering.py` lines used by the validation helper.

## Validation

- `PYTHONPATH=/tmp/pyg1411-deps python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_failfast_rejects_invalid_supported_overlap_queries graphistry/tests/compute/gfql/cypher/test_parser.py graphistry/tests/compute/gfql/test_expr_parser.py`
  - `203 passed, 4 warnings`
- `./bin/ruff.sh graphistry/compute/gfql/cypher/lowering.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `git diff --check`
- `./bin/typecheck.sh graphistry/compute/gfql/cypher/lowering.py`
- `python3 bin/ci_cypher_surface_guard.py`
- `PYTHONPATH=/tmp/pyg1411-deps:/home/lmeyerov/Work/pygraphistry:/home/lmeyerov/Work/tck-gfql python3 -m pytest -q /home/lmeyerov/Work/tck-gfql/tests/cypher_tck/test_tck_runner.py::test_direct_cypher_xfail_contract /home/lmeyerov/Work/tck-gfql/tests/cypher_tck/test_report.py /home/lmeyerov/Work/tck-gfql/tests/cypher_tck/test_parse_cypher.py /home/lmeyerov/Work/tck-gfql/tests/cypher_tck/test_lane_contracts.py`
  - `895 passed`
- `PYTHONPATH=/tmp/pyg1411-deps PATH=/tmp/pyg1429-bin:$PATH ./bin/test-minimal-lite.sh --ignore=plans --ignore=test_env --ignore=graphistry/tests/test_text_utils.py --ignore=graphistry/tests/test_compute_cluster.py --ignore=graphistry/tests/compute/test_indegrees_after_umap.py --ignore=graphistry/tests/compute/test_let_engine_coercion.py --ignore=graphistry/tests/compute/test_safe_map_series.py --ignore=graphistry/tests/compute/test_call_engine_coercion.py -k 'not cudf and not umap and not dask'`
  - `2947 passed, 155 skipped, 244 deselected, 15 xfailed`
- DGX `ssh dgx-spark`, isolated tracked-file snapshot at `~/repos/pygraphistry-1429`, `docker/test-rapids-official-local.sh`, `PROFILE=gfql`, `WITH_GPU=1`, `WITH_IMAGE_BUILD=0`, focused GFQL parser/row-pipeline/cuDF/cugraph/#1429 failfast set:
  - `RAPIDS_VERSION=25.02`: `graphistry/test-rapids-official:25.02-gfql`, `nvcr.io/nvidia/rapidsai/base:25.02-cuda12.8-py3.12`, `358 passed, 6 warnings`, log `/tmp/pyg1429-rapids-25.02-gfql.log`
  - `RAPIDS_VERSION=26.02`: `graphistry/test-rapids-official:26.02-gfql`, `nvcr.io/nvidia/rapidsai/base:26.02-cuda12-py3.13`, `358 passed, 5 warnings`, log `/tmp/pyg1429-rapids-26.02-gfql.log`
