### PR TITLE
Fix Direct-Cypher string literal backslash preservation

### DIFF
--- a/graphistry/compute/gfql/cypher/ast_normalizer.py
+++ b/graphistry/compute/gfql/cypher/ast_normalizer.py
@@ -25,6 +25,7 @@ from graphistry.compute.gfql.expr_parser import (
     Wildcard,
     parse_expr,
 )
+from graphistry.compute.gfql.string_literals import render_cypher_string_literal
 
 from .ast import (
     BooleanExpr,
@@ -129,7 +130,7 @@ def _cypher_literal_expr_text(value: Any) -> str:
             return "null"
         return repr(value)
     if isinstance(value, str):
-        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+        return render_cypher_string_literal(value)
     if isinstance(value, (list, tuple)):
         return "[" + ", ".join(_cypher_literal_expr_text(item) for item in value) + "]"
     if isinstance(value, dict):
@@ -139,7 +140,7 @@ def _cypher_literal_expr_text(value: Any) -> str:
             if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key_txt):
                 rendered_key = key_txt
             else:
-                rendered_key = "'" + key_txt.replace("\\", "\\\\").replace("'", "\\'") + "'"
+                rendered_key = render_cypher_string_literal(key_txt)
             parts.append(f"{rendered_key}: {_cypher_literal_expr_text(item)}")
         return "{" + ", ".join(parts) + "}"
     raise GFQLValidationError(

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -116,6 +116,7 @@ from graphistry.compute.gfql.cypher.call_procedures import (
     compile_cypher_call,
 )
 from graphistry.compute.gfql.cypher.ast_normalizer import ASTNormalizer
+from graphistry.compute.gfql.string_literals import render_cypher_string_literal
 from graphistry.compute.gfql.temporal_text import (
     fold_temporal_constructor_ast,
     resolve_duration_text_property,
@@ -1102,7 +1103,7 @@ def _cypher_literal_expr_text(value: Any) -> str:
             return "null"
         return repr(value)
     if isinstance(value, str):
-        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+        return render_cypher_string_literal(value)
     if isinstance(value, (list, tuple)):
         return "[" + ", ".join(_cypher_literal_expr_text(item) for item in value) + "]"
     if isinstance(value, dict):
@@ -1112,7 +1113,7 @@ def _cypher_literal_expr_text(value: Any) -> str:
             if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key_txt):
                 rendered_key = key_txt
             else:
-                rendered_key = "'" + key_txt.replace("\\", "\\\\").replace("'", "\\'") + "'"
+                rendered_key = render_cypher_string_literal(key_txt)
             parts.append(f"{rendered_key}: {_cypher_literal_expr_text(item)}")
         return "{" + ", ".join(parts) + "}"
     raise GFQLValidationError(
@@ -6474,8 +6475,7 @@ def _render_row_where_operand_text(value: Union[PropertyRef, CypherLiteral]) -> 
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        escaped = value.replace("\\", "\\\\").replace("'", "\\'")
-        return f"'{escaped}'"
+        return render_cypher_string_literal(value)
     return str(value)
 
 

--- a/graphistry/compute/gfql/expr_parser.py
+++ b/graphistry/compute/gfql/expr_parser.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import ast as pyast
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Protocol, Sequence, Set, Tuple, Type, Union, cast
 
+from graphistry.compute.gfql.string_literals import parse_cypher_string_token
 from graphistry.compute.gfql.language_defs import (
     GFQL_ALLOWED_BINARY_OPS,
     GFQL_ALLOWED_FUNCTIONS,
@@ -308,14 +308,10 @@ def _parser() -> _ParserLike:
 
 
 def _parse_string_token(token: str) -> str:
-    if len(token) < 2 or token[0] != token[-1] or token[0] not in {"'", '"'}:
-        raise GFQLExprParseError("Invalid string literal")
     try:
-        value = pyast.literal_eval(token)
+        value = parse_cypher_string_token(token)
     except Exception as exc:
         raise GFQLExprParseError("Invalid string literal") from exc
-    if not isinstance(value, str):
-        raise GFQLExprParseError("Invalid string literal")
     return value
 
 

--- a/graphistry/compute/gfql/string_literals.py
+++ b/graphistry/compute/gfql/string_literals.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+
+
+_ESCAPE_RE = re.compile(r"\\(u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|.)")
+_PARSE_ESCAPES = {
+    "\\": "\\\\",
+    "'": "'",
+    '"': '"',
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "b": "\b",
+    "f": "\f",
+}
+_RENDER_ESCAPES = str.maketrans(
+    {
+        "\\": r"\u005C",
+        "'": r"\u0027",
+        "\n": r"\u000A",
+        "\r": r"\u000D",
+        "\t": r"\u0009",
+        "\b": r"\u0008",
+        "\f": r"\u000C",
+    }
+)
+
+
+def parse_cypher_string_token(token: str) -> str:
+    if len(token) < 2 or token[0] != token[-1] or token[0] not in {"'", '"'}:
+        raise ValueError("Invalid string literal")
+
+    body = token[1:-1]
+    trailing_slashes = len(body) - len(body.rstrip("\\"))
+    if trailing_slashes % 2 == 1:
+        raise ValueError("Invalid string literal")
+
+    def replace_escape(match: re.Match[str]) -> str:
+        escape = match.group(1)
+        if escape[0] in {"u", "U"}:
+            return chr(int(escape[1:], 16))
+        if escape in _PARSE_ESCAPES:
+            return _PARSE_ESCAPES[escape]
+        raise ValueError("Invalid string literal")
+
+    return _ESCAPE_RE.sub(replace_escape, body)
+
+
+def render_cypher_string_literal(value: str) -> str:
+    return "'" + value.translate(_RENDER_ESCAPES) + "'"

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -3378,6 +3378,56 @@ def test_string_cypher_uses_integer_division_for_literal_arithmetic_expression()
     result = graph.gfql("RETURN 12 / 4 * 3 - 2 * 4")
 
     assert result._nodes.to_dict(orient="records") == [{"12 / 4 * 3 - 2 * 4": 1}]
+
+
+def test_string_cypher_preserves_escaped_literal_backslash_pairs() -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": []}),
+        pd.DataFrame({"s": [], "d": []}),
+    )
+
+    result = graph.gfql(r"""RETURN 'a\\bcn5t\'"\\//\\"\'' AS literal""")
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"literal": "a\\\\bcn5t'\"\\\\//\\\\\"'"}
+    ]
+
+
+def test_string_cypher_preserves_unicode_string_literal() -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": []}),
+        pd.DataFrame({"s": [], "d": []}),
+    )
+
+    result = graph.gfql(r"RETURN '\u01FF' AS literal")
+
+    assert result._nodes.to_dict(orient="records") == [{"literal": "\u01ff"}]
+
+
+def test_string_cypher_handles_standard_string_literal_escapes() -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": []}),
+        pd.DataFrame({"s": [], "d": []}),
+    )
+
+    result = graph.gfql(r"""RETURN '\n\t\r\b\f\\\'\"' AS literal""")
+
+    assert result._nodes.to_dict(orient="records") == [
+        {"literal": "\n\t\r\b\f\\\\'\""}
+    ]
+
+
+@pytest.mark.parametrize("query", [r"RETURN '\uH' AS literal", "RETURN 'unterminated AS literal"])
+def test_string_cypher_rejects_invalid_string_literals(query: str) -> None:
+    graph = _mk_graph(
+        pd.DataFrame({"id": []}),
+        pd.DataFrame({"s": [], "d": []}),
+    )
+
+    with pytest.raises(GFQLSyntaxError):
+        graph.gfql(query)
+
+
 @pytest.mark.parametrize(
     "query,expected_rows",
     [

--- a/graphistry/tests/compute/gfql/test_expr_parser.py
+++ b/graphistry/tests/compute/gfql/test_expr_parser.py
@@ -17,6 +17,7 @@ from graphistry.compute.gfql.expr_parser import (
     validate_expr_capabilities,
 )
 from graphistry.compute.gfql.language_defs import GFQL_COMPARISON_BINARY_OP_NAMES
+from graphistry.compute.gfql.string_literals import parse_cypher_string_token, render_cypher_string_literal
 
 
 def _has_lark() -> bool:
@@ -79,6 +80,113 @@ def test_validate_expr_capabilities_rejects_properties_on_scalar_literals() -> N
     for bad in (Literal(1), Literal("Cypher"), parse_expr("[true, false]") if _has_lark() else Literal(True)):
         errors = validate_expr_capabilities(FunctionCall(name="properties", args=(bad,)))
         assert "properties() requires a node, relationship, map, or null argument" in errors
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [
+        ("'plain'", "plain"),
+        ('"double"', "double"),
+        (r"'\''", "'"),
+        (r'"\""', '"'),
+        (r"'\u01FF'", "\u01ff"),
+        (r"'\U000001FF'", "\u01ff"),
+        (r"'a\\bcn5t'", "a\\\\bcn5t"),
+        (r"'\n\t\r\b\f'", "\n\t\r\b\f"),
+        (r"'\\'", "\\\\"),
+        (r"'\"'", '"'),
+        (r'"\'"', "'"),
+    ],
+)
+def test_parse_cypher_string_token_accepts_unicode_quote_and_preserved_escapes(
+    token: str,
+    expected: str,
+) -> None:
+    assert parse_cypher_string_token(token) == expected
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "plain",
+        "'unterminated",
+        r"'trailing\'",
+        r"'\q'",
+        r"'\/'",
+        r"'\uH'",
+        r"'\U0001FF'",
+        "123",
+        "None",
+    ],
+)
+def test_parse_cypher_string_token_rejects_invalid_literals(token: str) -> None:
+    with pytest.raises(ValueError):
+        parse_cypher_string_token(token)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "'",
+        '"',
+        "\\",
+        "\\'",
+        "\\\\'",
+        "a\\b",
+        "line\nbreak",
+        "tab\tseparated",
+        "carriage\rreturn",
+        "backspace\bseparated",
+        "formfeed\fseparated",
+        "\u01ff",
+    ],
+)
+def test_cypher_string_literal_renderer_round_trips(value: str) -> None:
+    assert parse_cypher_string_token(render_cypher_string_literal(value)) == value
+
+
+def test_cypher_string_literal_renderer_uses_unambiguous_backslash_and_quote_escapes() -> None:
+    assert render_cypher_string_literal("\\'\n") == r"'\u005C\u0027\u000A'"
+
+
+@requires_lark
+@pytest.mark.parametrize(
+    "value",
+    [
+        "\\",
+        "\\'",
+        "'",
+        '"',
+        "a\\b",
+        "line\nbreak",
+        "tab\tseparated",
+        "\u01ff",
+    ],
+)
+def test_parse_expr_round_trips_rendered_cypher_string_literals(value: str) -> None:
+    assert parse_expr(render_cypher_string_literal(value)) == Literal(value)
+
+
+@requires_lark
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        (r"'\n\t\r\b\f'", "\n\t\r\b\f"),
+        (r"'\\'", "\\\\"),
+        (r"'\"'", '"'),
+        (r'"\'"', "'"),
+    ],
+)
+def test_parse_expr_handles_user_written_cypher_string_escapes(expr: str, expected: str) -> None:
+    assert parse_expr(expr) == Literal(expected)
+
+
+@requires_lark
+@pytest.mark.parametrize("expr", ["'unterminated", r"'\uH'"])
+def test_parse_expr_rejects_invalid_string_literals(expr: str) -> None:
+    with pytest.raises(Exception):
+        parse_expr(expr)
 
 
 @requires_lark


### PR DESCRIPTION
Refs #1368

## Summary
- Preserve Cypher backslash pairs in GFQL row-expression string literals instead of using Python `ast.literal_eval`.
- Centralize Cypher string literal rendering for Direct-Cypher lowering/normalization.
- Add amplified positive/negative regressions for string parsing, rendering, `expr-literals6-5`, unicode strings, controls/quotes, unsupported escapes, and invalid string literals.

## Validation
- `python3 -m pytest -q graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_cypher_string_token_accepts_unicode_quote_and_preserved_escapes graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_cypher_string_token_rejects_invalid_literals graphistry/tests/compute/gfql/test_expr_parser.py::test_cypher_string_literal_renderer_round_trips graphistry/tests/compute/gfql/test_expr_parser.py::test_cypher_string_literal_renderer_uses_unambiguous_backslash_and_quote_escapes graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_expr_round_trips_rendered_cypher_string_literals graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_expr_rejects_invalid_string_literals graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_preserves_escaped_literal_backslash_pairs graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_preserves_unicode_string_literal graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_rejects_invalid_string_literals`
- `python3 -m pytest -q graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_expr_handles_user_written_cypher_string_escapes graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_handles_standard_string_literal_escapes`
- `python3 -m pytest -q graphistry/tests/compute/gfql/test_expr_parser.py graphistry/tests/compute/gfql/cypher/test_ast_normalizer.py graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_preserves_escaped_literal_backslash_pairs graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_preserves_string_literals_during_rewrite_passes`
- `PYTHONPATH=/tmp/pygraphistry-1436-rebase:/tmp/tck-gfql-1368-pygraphistry-cleanup UV_EXCLUDE_NEWER=2026-05-08 uv run --python 3.13 --no-project --with pytest --with pandas --with numpy --with palettable --with 'lark>=1.1,<2' --with pyarrow --with requests --with typing-extensions --with 'packaging>=20.1' --with setuptools python -m pytest -q tests/cypher_tck/test_tck_runner.py -k "expr-literals6-5 or expr-string8-5 or test_direct_cypher_xfail_contract"` -> `768 passed, 3703 deselected`.
- `PYTHONPATH=/home/lmeyerov/Work/pygraphistry:/home/lmeyerov/Work/tck-gfql UV_EXCLUDE_NEWER=2026-05-08 uv run --python 3.13 --no-project --with pytest --with pandas --with numpy --with palettable --with 'lark>=1.1,<2' --with pyarrow --with requests --with typing-extensions --with 'packaging>=20.1' --with setuptools python -m pytest -q tests/cypher_tck/test_tck_runner.py -k "test_direct_cypher_xfail_contract"`
- `./bin/ruff.sh graphistry/compute/gfql/string_literals.py graphistry/compute/gfql/expr_parser.py graphistry/compute/gfql/cypher/lowering.py graphistry/compute/gfql/cypher/ast_normalizer.py graphistry/tests/compute/gfql/test_expr_parser.py graphistry/tests/compute/gfql/cypher/test_lowering.py`
- `./bin/typecheck.sh graphistry/compute/gfql/string_literals.py graphistry/compute/gfql/expr_parser.py graphistry/compute/gfql/cypher/lowering.py graphistry/compute/gfql/cypher/ast_normalizer.py`
- Review skill convergence: `plans/direct-cypher-string-literal-type-conversion-1368/waves/wave-1/wave-report.md`, `wave-2/wave-report.md`, `wave-3/wave-report.md`; wave 1 finding fixed, waves 2/3 clean.
- DGX RAPIDS GPU matrix after amplification/rebase: `ssh dgx-spark 'bash -lc "cd ~/repos/pygraphistry-1436-ff088334/docker && RAPIDS_VERSIONS=\"25.02 26.02\" PROFILES=gfql WITH_GPU=1 WITH_IMAGE_BUILD=0 WITH_LINT=0 WITH_TYPECHECK=0 WITH_TEST=1 WITH_BUILD=0 TEST_FILES=\"graphistry/tests/compute/gfql/cypher/test_parser.py graphistry/tests/compute/gfql/test_row_pipeline_ops.py graphistry/tests/compute/gfql/cypher/test_lowering.py::test_graph_constructor_cudf_support graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_formats_filtered_edge_entity_projection_on_cudf graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_executes_real_cugraph_node_row_call_on_cudf graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_cypher_string_token_accepts_unicode_quote_and_preserved_escapes graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_cypher_string_token_rejects_invalid_literals graphistry/tests/compute/gfql/test_expr_parser.py::test_cypher_string_literal_renderer_round_trips graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_expr_round_trips_rendered_cypher_string_literals graphistry/tests/compute/gfql/test_expr_parser.py::test_parse_expr_handles_user_written_cypher_string_escapes graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_preserves_escaped_literal_backslash_pairs graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_preserves_unicode_string_literal graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_handles_standard_string_literal_escapes graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_rejects_invalid_string_literals\" ./test-rapids-official-matrix.sh"'` -> `25.02/gfql PASS`, `26.02/gfql PASS`, `Matrix passed` (`393 passed` per RAPIDS cell).
- GitHub CI: `gh pr checks 1436 --watch` green at `ff0883344fef173387c7695ba110ed292ec110ce`.

## Local sentinel note
`./bin/test-minimal-lite.sh` starts with a `python3` shim, but this local shell has cuDF installed and no CUDA device, so the broad sentinel fails on `cudaErrorNoDevice` in unrelated GPU tests. Focused CPU/GFQL validation is green; DGX RAPIDS 25.02/26.02 validation covers the GPU proof.
