### PR TITLE
Add Cypher compiler policy lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Added
+- **GFQL policy / Cypher compiler error hook (#1454)**: Added an experimental exact-key `compile_error` policy hook for local Cypher string queries that fail before execution. The hook receives a stable `CompileErrorSummary` with scalar rejection metadata including compiler phase, error code, and structured context; successful queries and no-hook paths keep the existing runtime policy behavior.
+
 ### Changed
 - **GFQL / Cypher pattern predicate existence semantics (#1449)**: Direct-Cypher `WHERE (pattern)` predicates now lower through correlated semi-apply markers instead of rewriting single positive predicates into appended `MATCH` clauses, preventing existence checks from multiplying result rows. Added pandas/cuDF coverage for the residual `expr-pattern1-10`, `expr-pattern1-13`, and `expr-pattern1-18` undirected pattern-predicate wrong-row cases.
 - **GFQL / Cypher reentry failfast scaffolding cleanup (#1421)**: Removed the obsolete `graphistry.compute.gfql.cypher.reentry.runtime` compatibility re-export shim after compile-time reentry ownership moved to `reentry.compiletime`, moved tests off the old private `gfql_unified._compiled_query_reentry_state` access path, and lifted the stale closed-#1256 aggregate failfast so chained reentry secondary-property carries now flow through downstream aggregating `WITH` stages with positive row assertions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Added
-- **GFQL policy / Cypher compiler error hook (#1454)**: Added an experimental exact-key `compile_error` policy hook for local Cypher string queries that fail before execution. The hook receives a stable `CompileErrorSummary` with scalar rejection metadata including compiler phase, error code, and structured context; successful queries and no-hook paths keep the existing runtime policy behavior.
+- **GFQL policy / Cypher compiler hooks (#1454)**: Added experimental exact-key `precompile` and `postcompile` policy hooks for local Cypher string-query compilation. `postcompile` reports success or failure using the existing policy `success`, `error`, and `error_type` fields plus a stable `CompileSummary` with scalar compiler metadata.
 
 ### Changed
 - **GFQL / Cypher pattern predicate existence semantics (#1449)**: Direct-Cypher `WHERE (pattern)` predicates now lower through correlated semi-apply markers instead of rewriting single positive predicates into appended `MATCH` clauses, preventing existence checks from multiplying result rows. Added pandas/cuDF coverage for the residual `expr-pattern1-10`, `expr-pattern1-13`, and `expr-pattern1-18` undirected pattern-predicate wrong-row cases.

--- a/docs/source/gfql/policy.rst
+++ b/docs/source/gfql/policy.rst
@@ -57,10 +57,13 @@ Policies are invoked at these phases:
 **postcall**
     After method execution. Can validate result size, track execution time, and log performance.
 
-**compile_error**
-    Experimental exact-key hook for local Cypher string queries that fail before
-    execution. It receives a stable ``CompileErrorSummary`` object and is not
-    included in ``pre`` or ``post`` shortcut expansion.
+**precompile**
+    Experimental exact-key hook before local Cypher string queries are compiled.
+    It is not included in ``pre`` shortcut expansion.
+
+**postcompile**
+    Experimental exact-key hook after local Cypher string-query compilation
+    succeeds or fails. It is not included in ``post`` shortcut expansion.
 
 
 Context Fields
@@ -70,7 +73,7 @@ The context dictionary passed to policy functions contains:
 
 **Always present:**
 
-- ``phase``: Current phase ('preload', 'postload', 'prelet', 'postlet', 'prechain', 'postchain', 'precall', 'postcall', 'preletbinding', 'postletbinding', 'compile_error')
+- ``phase``: Current phase ('preload', 'postload', 'prelet', 'postlet', 'prechain', 'postchain', 'precall', 'postcall', 'preletbinding', 'postletbinding', 'precompile', 'postcompile')
 - ``hook``: Hook name (same as phase, useful for shared handlers)
 - ``_policy_depth``: Internal recursion counter
 
@@ -87,18 +90,17 @@ The context dictionary passed to policy functions contains:
 - ``call_op``: Operation name (precall/postcall phases only)
 - ``call_params``: Operation parameters (precall/postcall phases only)
 - ``execution_time``: Method execution duration in seconds (postcall phase only)
-- ``success``: Execution success flag (postcall/postlet/postchain/postletbinding phases)
+- ``success``: Execution success flag (postcall/postlet/postchain/postletbinding/postcompile phases)
 - ``error``: Error message string (post* phases when success=False)
 - ``error_type``: Error type name (post* phases when success=False)
 
-**Compiler-specific** (``compile_error`` phase only):
+**Compiler-specific** (``precompile``/``postcompile`` phases only):
 
 - ``compile_language``: Source language for string-query compilation.
-- ``compile_error``: ``CompileErrorSummary`` with stable scalar fields:
-  ``language``, ``error_type``, ``message``, ``compiler_phase``, ``code``,
-  ``context``, ``field``, ``suggestion``, ``line``, ``column``,
-  ``value_repr``, and ``param_keys``. Private parser/binder/lowering objects
-  and DataFrames are not exposed.
+- ``compile``: ``CompileSummary`` for ``postcompile`` with stable scalar
+  fields such as ``language``, ``success``, ``compiler_phase``, ``code``,
+  ``context``, and optional error details. Private parser, binder, lowering,
+  and DataFrame objects are not exposed.
 
 **Binding-specific** (preletbinding/postletbinding phases only):
 

--- a/docs/source/gfql/policy.rst
+++ b/docs/source/gfql/policy.rst
@@ -25,7 +25,7 @@ Quick Start
 Policy Phases
 -------------
 
-Policies are invoked at ten distinct phases:
+Policies are invoked at these phases:
 
 **preload**
     Before data is loaded (local or remote). Can prevent data access.
@@ -57,6 +57,11 @@ Policies are invoked at ten distinct phases:
 **postcall**
     After method execution. Can validate result size, track execution time, and log performance.
 
+**compile_error**
+    Experimental exact-key hook for local Cypher string queries that fail before
+    execution. It receives a stable ``CompileErrorSummary`` object and is not
+    included in ``pre`` or ``post`` shortcut expansion.
+
 
 Context Fields
 --------------
@@ -65,7 +70,7 @@ The context dictionary passed to policy functions contains:
 
 **Always present:**
 
-- ``phase``: Current phase ('preload', 'postload', 'prelet', 'postlet', 'prechain', 'postchain', 'precall', 'postcall', 'preletbinding', 'postletbinding')
+- ``phase``: Current phase ('preload', 'postload', 'prelet', 'postlet', 'prechain', 'postchain', 'precall', 'postcall', 'preletbinding', 'postletbinding', 'compile_error')
 - ``hook``: Hook name (same as phase, useful for shared handlers)
 - ``_policy_depth``: Internal recursion counter
 
@@ -85,6 +90,15 @@ The context dictionary passed to policy functions contains:
 - ``success``: Execution success flag (postcall/postlet/postchain/postletbinding phases)
 - ``error``: Error message string (post* phases when success=False)
 - ``error_type``: Error type name (post* phases when success=False)
+
+**Compiler-specific** (``compile_error`` phase only):
+
+- ``compile_language``: Source language for string-query compilation.
+- ``compile_error``: ``CompileErrorSummary`` with stable scalar fields:
+  ``language``, ``error_type``, ``message``, ``compiler_phase``, ``code``,
+  ``context``, ``field``, ``suggestion``, ``line``, ``column``,
+  ``value_repr``, and ``param_keys``. Private parser/binder/lowering objects
+  and DataFrames are not exposed.
 
 **Binding-specific** (preletbinding/postletbinding phases only):
 

--- a/graphistry/compute/gfql/policy/__init__.py
+++ b/graphistry/compute/gfql/policy/__init__.py
@@ -2,7 +2,7 @@
 
 from .exceptions import PolicyException
 from .types import (
-    CompileErrorSummary,
+    CompileSummary,
     PolicyContext,
     PolicyFunction,
     PolicyDict,
@@ -17,7 +17,7 @@ from .shortcuts import expand_policy, debug_policy, format_policy_expansion, Han
 
 __all__ = [
     'PolicyException',
-    'CompileErrorSummary',
+    'CompileSummary',
     'PolicyContext',
     'PolicyFunction',
     'PolicyDict',

--- a/graphistry/compute/gfql/policy/__init__.py
+++ b/graphistry/compute/gfql/policy/__init__.py
@@ -2,6 +2,7 @@
 
 from .exceptions import PolicyException
 from .types import (
+    CompileErrorSummary,
     PolicyContext,
     PolicyFunction,
     PolicyDict,
@@ -16,6 +17,7 @@ from .shortcuts import expand_policy, debug_policy, format_policy_expansion, Han
 
 __all__ = [
     'PolicyException',
+    'CompileErrorSummary',
     'PolicyContext',
     'PolicyFunction',
     'PolicyDict',

--- a/graphistry/compute/gfql/policy/shortcuts.py
+++ b/graphistry/compute/gfql/policy/shortcuts.py
@@ -55,6 +55,8 @@ _EXPANSION_MAP: Dict[Phase, Tuple[GeneralShortcut, ScopeShortcut, Phase]] = {
     'postcall': ('post', 'call', 'postcall')
 }
 
+_DIRECT_HOOKS: Tuple[Phase, ...] = ('compile_error',)
+
 
 def expand_policy(policy: Dict[str, PolicyFunction]) -> PolicyDict:
     """Expand shorthand policy keys to full hook names with composition.
@@ -116,6 +118,10 @@ def expand_policy(policy: Dict[str, PolicyFunction]) -> PolicyDict:
 
         # Single handler or compose multiple
         expanded[hook_name] = handlers[0] if len(handlers) == 1 else _compose(*handlers)
+
+    for hook_name in _DIRECT_HOOKS:
+        if hook_name in policy:
+            expanded[hook_name] = policy[hook_name]
 
     return expanded
 
@@ -191,6 +197,10 @@ def debug_policy(policy: Dict[str, PolicyFunction]) -> HookExpansionMap:
 
         # Store handler name and source key - both are properly typed now
         debug_info[hook_name] = [(fn.__name__, key) for key, fn in sources]
+
+    for hook_name in _DIRECT_HOOKS:
+        if hook_name in policy:
+            debug_info[hook_name] = [(policy[hook_name].__name__, hook_name)]
 
     return debug_info
 

--- a/graphistry/compute/gfql/policy/shortcuts.py
+++ b/graphistry/compute/gfql/policy/shortcuts.py
@@ -55,7 +55,7 @@ _EXPANSION_MAP: Dict[Phase, Tuple[GeneralShortcut, ScopeShortcut, Phase]] = {
     'postcall': ('post', 'call', 'postcall')
 }
 
-_DIRECT_HOOKS: Tuple[Phase, ...] = ('compile_error',)
+_DIRECT_HOOKS: Tuple[Phase, ...] = ('precompile', 'postcompile')
 
 
 def expand_policy(policy: Dict[str, PolicyFunction]) -> PolicyDict:

--- a/graphistry/compute/gfql/policy/types.py
+++ b/graphistry/compute/gfql/policy/types.py
@@ -19,30 +19,32 @@ Phase = Literal[
     "postcall",
     "preletbinding",
     "postletbinding",
-    "compile_error",
+    "precompile",
+    "postcompile",
 ]
 
 # Shortcut key literal type (includes general, scope, and specific keys)
 GeneralShortcut = Literal["pre", "post"]
 ScopeShortcut = Literal["load", "let", "chain", "binding", "call"]
-ShortcutKey = Literal["pre", "post", "load", "let", "chain", "binding", "call", "preload", "postload", "prelet", "postlet", "prechain", "postchain", "precall", "postcall", "preletbinding", "postletbinding", "compile_error"]
+ShortcutKey = Literal["pre", "post", "load", "let", "chain", "binding", "call", "preload", "postload", "prelet", "postlet", "prechain", "postchain", "precall", "postcall", "preletbinding", "postletbinding", "precompile", "postcompile"]
 
 # Query type literal
 QueryType = Literal["chain", "dag", "single"]
 
 
 @dataclass(frozen=True)
-class CompileErrorSummary:
-    """Stable, public compiler rejection summary for policy hooks.
+class CompileSummary:
+    """Stable, public compiler summary for policy hooks.
 
     This object intentionally carries scalar metadata only. It does not expose
     parser, binder, AST, lowering, or DataFrame objects.
     """
 
     language: str
-    error_type: str
-    message: str
+    success: bool
     compiler_phase: str = "compile"
+    error_type: Optional[str] = None
+    message: Optional[str] = None
     code: Optional[str] = None
     context: Mapping[str, Any] = field(default_factory=dict)
     field: Optional[str] = None
@@ -57,7 +59,7 @@ class PolicyContext(TypedDict, total=False):
     """Strongly typed context passed to policy functions.
 
     Attributes:
-        phase: Current execution phase (preload, postload, prelet, postlet, prechain, postchain, precall, postcall, preletbinding, postletbinding, compile_error)
+        phase: Current execution phase (preload, postload, prelet, postlet, prechain, postchain, precall, postcall, preletbinding, postletbinding, precompile, postcompile)
         hook: Hook name (same as phase, useful for shared handlers)
         query: Original/global query object
         current_ast: Current AST object being executed (if applicable)
@@ -77,9 +79,9 @@ class PolicyContext(TypedDict, total=False):
         error: Error message string (post* phases, when success=False)
         error_type: Error type name (post* phases, when success=False)
 
-        # Compiler-specific fields (compile_error phase only; experimental)
+        # Compiler-specific fields (precompile/postcompile phases only; experimental)
         compile_language: Source language for string-query compilation
-        compile_error: Stable compiler rejection summary
+        compile: Stable compiler summary (postcompile only)
 
         # Hierarchy/tracing fields (for OpenTelemetry and telemetry systems)
         execution_depth: Nesting depth (0=query, 1=let/chain, 2=binding/op, ...)
@@ -112,9 +114,9 @@ class PolicyContext(TypedDict, total=False):
     error: Optional[str]             # Error message (post* phases, when success=False)
     error_type: Optional[str]        # Error type name (post* phases, when success=False)
 
-    # Compiler-specific fields (compile_error phase only; experimental)
+    # Compiler-specific fields (precompile/postcompile phases only; experimental)
     compile_language: Optional[str]
-    compile_error: Optional[CompileErrorSummary]
+    compile: Optional[CompileSummary]
 
     # Hierarchy/tracing fields (for OpenTelemetry and telemetry systems)
     execution_depth: Optional[int]       # Nesting depth (0=query, 1=let/chain, 2=binding, ...)

--- a/graphistry/compute/gfql/policy/types.py
+++ b/graphistry/compute/gfql/policy/types.py
@@ -1,28 +1,63 @@
 """Type definitions for GFQL policy system."""
 
-from typing import TypedDict, Optional, Dict, Any, Literal, Callable, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TypedDict, Optional, Dict, Any, Literal, Callable, Mapping, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from graphistry.Plottable import Plottable
     from graphistry.compute.gfql.policy.stats import GraphStats
 
-# Phase literal type (the 10 specific hook names)
-Phase = Literal["preload", "postload", "prelet", "postlet", "prechain", "postchain", "precall", "postcall", "preletbinding", "postletbinding"]
+# Phase literal type (the concrete hook names)
+Phase = Literal[
+    "preload",
+    "postload",
+    "prelet",
+    "postlet",
+    "prechain",
+    "postchain",
+    "precall",
+    "postcall",
+    "preletbinding",
+    "postletbinding",
+    "compile_error",
+]
 
 # Shortcut key literal type (includes general, scope, and specific keys)
 GeneralShortcut = Literal["pre", "post"]
 ScopeShortcut = Literal["load", "let", "chain", "binding", "call"]
-ShortcutKey = Literal["pre", "post", "load", "let", "chain", "binding", "call", "preload", "postload", "prelet", "postlet", "prechain", "postchain", "precall", "postcall", "preletbinding", "postletbinding"]
+ShortcutKey = Literal["pre", "post", "load", "let", "chain", "binding", "call", "preload", "postload", "prelet", "postlet", "prechain", "postchain", "precall", "postcall", "preletbinding", "postletbinding", "compile_error"]
 
 # Query type literal
 QueryType = Literal["chain", "dag", "single"]
+
+
+@dataclass(frozen=True)
+class CompileErrorSummary:
+    """Stable, public compiler rejection summary for policy hooks.
+
+    This object intentionally carries scalar metadata only. It does not expose
+    parser, binder, AST, lowering, or DataFrame objects.
+    """
+
+    language: str
+    error_type: str
+    message: str
+    compiler_phase: str = "compile"
+    code: Optional[str] = None
+    context: Mapping[str, Any] = field(default_factory=dict)
+    field: Optional[str] = None
+    suggestion: Optional[str] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    value_repr: Optional[str] = None
+    param_keys: Tuple[str, ...] = ()
 
 
 class PolicyContext(TypedDict, total=False):
     """Strongly typed context passed to policy functions.
 
     Attributes:
-        phase: Current execution phase (preload, postload, prelet, postlet, prechain, postchain, precall, postcall, preletbinding, postletbinding)
+        phase: Current execution phase (preload, postload, prelet, postlet, prechain, postchain, precall, postcall, preletbinding, postletbinding, compile_error)
         hook: Hook name (same as phase, useful for shared handlers)
         query: Original/global query object
         current_ast: Current AST object being executed (if applicable)
@@ -41,6 +76,10 @@ class PolicyContext(TypedDict, total=False):
         success: Execution success flag (postcall/postload/postletbinding phases)
         error: Error message string (post* phases, when success=False)
         error_type: Error type name (post* phases, when success=False)
+
+        # Compiler-specific fields (compile_error phase only; experimental)
+        compile_language: Source language for string-query compilation
+        compile_error: Stable compiler rejection summary
 
         # Hierarchy/tracing fields (for OpenTelemetry and telemetry systems)
         execution_depth: Nesting depth (0=query, 1=let/chain, 2=binding/op, ...)
@@ -72,6 +111,10 @@ class PolicyContext(TypedDict, total=False):
     success: Optional[bool]          # Execution success flag (post* phases)
     error: Optional[str]             # Error message (post* phases, when success=False)
     error_type: Optional[str]        # Error type name (post* phases, when success=False)
+
+    # Compiler-specific fields (compile_error phase only; experimental)
+    compile_language: Optional[str]
+    compile_error: Optional[CompileErrorSummary]
 
     # Hierarchy/tracing fields (for OpenTelemetry and telemetry systems)
     execution_depth: Optional[int]       # Nesting depth (0=query, 1=let/chain, 2=binding, ...)

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -2,6 +2,7 @@
 # ruff: noqa: E501
 
 from dataclasses import replace
+from types import MappingProxyType
 from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple, Union, cast
 from graphistry.Plottable import Plottable
 from graphistry.Engine import Engine, EngineAbstract, df_concat, df_cons, df_to_engine, resolve_engine
@@ -11,6 +12,7 @@ from .chain import Chain, chain as chain_impl
 from .chain_let import chain_let as chain_let_impl
 from .execution_context import ExecutionContext
 from .gfql.policy import (
+    CompileErrorSummary,
     PolicyContext,
     PolicyException,
     PolicyFunction,
@@ -1196,6 +1198,112 @@ def _compile_string_query(
     return compile_cypher(query, params=params, _warn_deprecated=False)
 
 
+def _compile_error_value_repr(value: Any) -> str:
+    try:
+        rendered = repr(value)
+    except Exception:
+        rendered = f"<unrepresentable {type(value).__name__}>"
+    if len(rendered) > 200:
+        return f"{rendered[:197]}..."
+    return rendered
+
+
+def _compile_error_context_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(k): _compile_error_context_value(v) for k, v in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_compile_error_context_value(v) for v in value)
+    return _compile_error_value_repr(value)
+
+
+def _compiler_phase_for_error(exc: GFQLValidationError) -> str:
+    if exc.code == ErrorCode.E107:
+        return "parse"
+    context = getattr(exc, "context", {})
+    if isinstance(context, dict) and (
+        "visible_scope" in context
+        or "existing_kind" in context
+        or "new_kind" in context
+    ):
+        return "bind"
+    if exc.code == ErrorCode.E108:
+        return "lower"
+    return "compile"
+
+
+def _compile_error_summary(
+    *,
+    query_language: str,
+    params: Optional[Mapping[str, Any]],
+    exc: GFQLValidationError,
+) -> CompileErrorSummary:
+    context = getattr(exc, "context", {})
+    error_context = context if isinstance(context, dict) else {}
+    public_context = MappingProxyType({str(k): _compile_error_context_value(v) for k, v in error_context.items()})
+    return CompileErrorSummary(
+        language=query_language,
+        error_type=type(exc).__name__,
+        message=exc.message,
+        compiler_phase=_compiler_phase_for_error(exc),
+        code=exc.code,
+        context=public_context,
+        field=error_context.get("field"),
+        suggestion=error_context.get("suggestion"),
+        line=error_context.get("line"),
+        column=error_context.get("column"),
+        value_repr=(
+            _compile_error_value_repr(error_context["value"])
+            if "value" in error_context
+            else None
+        ),
+        param_keys=tuple(sorted(str(key) for key in params.keys())) if params else (),
+    )
+
+
+def _fire_compile_error_policy(
+    policy: Optional[PolicyDict],
+    *,
+    query: str,
+    query_language: str,
+    exc: GFQLValidationError,
+    policy_depth: int,
+    execution_depth: int,
+    operation_path: str,
+    params: Optional[Mapping[str, Any]],
+) -> None:
+    if not policy or "compile_error" not in policy:
+        return
+    summary = _compile_error_summary(
+        query_language=query_language,
+        params=params,
+        exc=exc,
+    )
+    policy_context: PolicyContext = {
+        "phase": "compile_error",
+        "hook": "compile_error",
+        "query": query,
+        "current_ast": None,
+        "query_type": "chain",
+        "compile_language": query_language,
+        "compile_error": summary,
+        "error": str(exc),
+        "error_type": type(exc).__name__,
+        "success": False,
+        "execution_depth": execution_depth,
+        "operation_path": operation_path,
+        "parent_operation": "query" if execution_depth == 0 else operation_path.rsplit(".", 1)[0],
+        "_policy_depth": policy_depth,
+    }
+    try:
+        policy["compile_error"](policy_context)
+    except PolicyException as policy_exc:
+        if policy_exc.query_type is None:
+            policy_exc.query_type = policy_context.get("query_type")
+        raise policy_exc from exc
+
+
 @otel_traced("gfql.run", attrs_fn=_gfql_otel_attrs)
 def gfql(self: Plottable,
          query: Union[ASTObject, List[ASTObject], ASTLet, Chain, dict, str],
@@ -1428,19 +1536,47 @@ def gfql(self: Plottable,
                 raise ValueError("where cannot be combined with string queries; embed Cypher predicates in the query itself")
 
         if validate:
-            gfql_preflight_validate(
-                dispatch_self,
-                query,
-                where=where_param,
-                language=language,
-                params=params,
-                strict=True,
-                schema=True,
-                collect_all=False,
-            )
+            try:
+                gfql_preflight_validate(
+                    dispatch_self,
+                    query,
+                    where=where_param,
+                    language=language,
+                    params=params,
+                    strict=True,
+                    schema=True,
+                    collect_all=False,
+                )
+            except GFQLValidationError as exc:
+                if isinstance(query, str):
+                    _fire_compile_error_policy(
+                        expanded_policy,
+                        query=query,
+                        query_language=language or "cypher",
+                        exc=exc,
+                        policy_depth=policy_depth,
+                        execution_depth=current_depth,
+                        operation_path=current_path,
+                        params=params,
+                    )
+                raise
 
         if isinstance(query, str):
-            compiled_query = _compile_string_query(query, language=language, params=params)
+            query_language = language or "cypher"
+            try:
+                compiled_query = _compile_string_query(query, language=language, params=params)
+            except GFQLValidationError as exc:
+                _fire_compile_error_policy(
+                    expanded_policy,
+                    query=query,
+                    query_language=query_language,
+                    exc=exc,
+                    policy_depth=policy_depth,
+                    execution_depth=current_depth,
+                    operation_path=current_path,
+                    params=params,
+                )
+                raise
             if isinstance(compiled_query, CompiledCypherGraphQuery):
                 return _execute_graph_query(self, compiled_query, engine=engine, policy=expanded_policy, context=context)
             if isinstance(compiled_query, CompiledCypherQuery):

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -12,7 +12,7 @@ from .chain import Chain, chain as chain_impl
 from .chain_let import chain_let as chain_let_impl
 from .execution_context import ExecutionContext
 from .gfql.policy import (
-    CompileErrorSummary,
+    CompileSummary,
     PolicyContext,
     PolicyException,
     PolicyFunction,
@@ -1198,7 +1198,7 @@ def _compile_string_query(
     return compile_cypher(query, params=params, _warn_deprecated=False)
 
 
-def _compile_error_value_repr(value: Any) -> str:
+def _compile_value_repr(value: Any) -> str:
     try:
         rendered = repr(value)
     except Exception:
@@ -1208,14 +1208,14 @@ def _compile_error_value_repr(value: Any) -> str:
     return rendered
 
 
-def _compile_error_context_value(value: Any) -> Any:
+def _compile_context_value(value: Any) -> Any:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, Mapping):
-        return MappingProxyType({str(k): _compile_error_context_value(v) for k, v in value.items()})
+        return MappingProxyType({str(k): _compile_context_value(v) for k, v in value.items()})
     if isinstance(value, (list, tuple)):
-        return tuple(_compile_error_context_value(v) for v in value)
-    return _compile_error_value_repr(value)
+        return tuple(_compile_context_value(v) for v in value)
+    return _compile_value_repr(value)
 
 
 def _compiler_phase_for_error(exc: GFQLValidationError) -> str:
@@ -1233,17 +1233,25 @@ def _compiler_phase_for_error(exc: GFQLValidationError) -> str:
     return "compile"
 
 
-def _compile_error_summary(
+def _compile_summary(
     *,
     query_language: str,
     params: Optional[Mapping[str, Any]],
-    exc: GFQLValidationError,
-) -> CompileErrorSummary:
+    exc: Optional[GFQLValidationError] = None,
+) -> CompileSummary:
+    if exc is None:
+        return CompileSummary(
+            language=query_language,
+            success=True,
+            param_keys=tuple(sorted(str(key) for key in params.keys())) if params else (),
+        )
+
     context = getattr(exc, "context", {})
     error_context = context if isinstance(context, dict) else {}
-    public_context = MappingProxyType({str(k): _compile_error_context_value(v) for k, v in error_context.items()})
-    return CompileErrorSummary(
+    public_context = MappingProxyType({str(k): _compile_context_value(v) for k, v in error_context.items()})
+    return CompileSummary(
         language=query_language,
+        success=False,
         error_type=type(exc).__name__,
         message=exc.message,
         compiler_phase=_compiler_phase_for_error(exc),
@@ -1254,7 +1262,7 @@ def _compile_error_summary(
         line=error_context.get("line"),
         column=error_context.get("column"),
         value_repr=(
-            _compile_error_value_repr(error_context["value"])
+            _compile_value_repr(error_context["value"])
             if "value" in error_context
             else None
         ),
@@ -1262,46 +1270,95 @@ def _compile_error_summary(
     )
 
 
-def _fire_compile_error_policy(
-    policy: Optional[PolicyDict],
+def _base_compile_policy_context(
     *,
+    hook: Literal["precompile", "postcompile"],
     query: str,
     query_language: str,
-    exc: GFQLValidationError,
     policy_depth: int,
     execution_depth: int,
     operation_path: str,
-    params: Optional[Mapping[str, Any]],
-) -> None:
-    if not policy or "compile_error" not in policy:
-        return
-    summary = _compile_error_summary(
-        query_language=query_language,
-        params=params,
-        exc=exc,
-    )
-    policy_context: PolicyContext = {
-        "phase": "compile_error",
-        "hook": "compile_error",
+) -> PolicyContext:
+    return {
+        "phase": hook,
+        "hook": hook,
         "query": query,
         "current_ast": None,
         "query_type": "chain",
         "compile_language": query_language,
-        "compile_error": summary,
-        "error": str(exc),
-        "error_type": type(exc).__name__,
-        "success": False,
         "execution_depth": execution_depth,
         "operation_path": operation_path,
         "parent_operation": "query" if execution_depth == 0 else operation_path.rsplit(".", 1)[0],
         "_policy_depth": policy_depth,
     }
+
+
+def _fire_precompile_policy(
+    policy: Optional[PolicyDict],
+    *,
+    query: str,
+    query_language: str,
+    policy_depth: int,
+    execution_depth: int,
+    operation_path: str,
+) -> None:
+    if not policy or "precompile" not in policy:
+        return
+    policy_context = _base_compile_policy_context(
+        hook="precompile",
+        query=query,
+        query_language=query_language,
+        policy_depth=policy_depth,
+        execution_depth=execution_depth,
+        operation_path=operation_path,
+    )
     try:
-        policy["compile_error"](policy_context)
+        policy["precompile"](policy_context)
     except PolicyException as policy_exc:
         if policy_exc.query_type is None:
             policy_exc.query_type = policy_context.get("query_type")
-        raise policy_exc from exc
+        raise
+
+
+def _fire_postcompile_policy(
+    policy: Optional[PolicyDict],
+    *,
+    query: str,
+    query_language: str,
+    exc: Optional[GFQLValidationError],
+    policy_depth: int,
+    execution_depth: int,
+    operation_path: str,
+    params: Optional[Mapping[str, Any]],
+) -> None:
+    if not policy or "postcompile" not in policy:
+        return
+    summary = _compile_summary(
+        query_language=query_language,
+        params=params,
+        exc=exc,
+    )
+    policy_context = _base_compile_policy_context(
+        hook="postcompile",
+        query=query,
+        query_language=query_language,
+        policy_depth=policy_depth,
+        execution_depth=execution_depth,
+        operation_path=operation_path,
+    )
+    policy_context["compile"] = summary
+    policy_context["success"] = exc is None
+    if exc is not None:
+        policy_context["error"] = str(exc)
+        policy_context["error_type"] = type(exc).__name__
+    try:
+        policy["postcompile"](policy_context)
+    except PolicyException as policy_exc:
+        if policy_exc.query_type is None:
+            policy_exc.query_type = policy_context.get("query_type")
+        if exc is not None:
+            raise policy_exc from exc
+        raise
 
 
 @otel_traced("gfql.run", attrs_fn=_gfql_otel_attrs)
@@ -1534,6 +1591,15 @@ def gfql(self: Plottable,
         if isinstance(query, str):
             if where_param:
                 raise ValueError("where cannot be combined with string queries; embed Cypher predicates in the query itself")
+            query_language = language or "cypher"
+            _fire_precompile_policy(
+                expanded_policy,
+                query=query,
+                query_language=query_language,
+                policy_depth=policy_depth,
+                execution_depth=current_depth,
+                operation_path=current_path,
+            )
 
         if validate:
             try:
@@ -1549,7 +1615,7 @@ def gfql(self: Plottable,
                 )
             except GFQLValidationError as exc:
                 if isinstance(query, str):
-                    _fire_compile_error_policy(
+                    _fire_postcompile_policy(
                         expanded_policy,
                         query=query,
                         query_language=language or "cypher",
@@ -1566,7 +1632,7 @@ def gfql(self: Plottable,
             try:
                 compiled_query = _compile_string_query(query, language=language, params=params)
             except GFQLValidationError as exc:
-                _fire_compile_error_policy(
+                _fire_postcompile_policy(
                     expanded_policy,
                     query=query,
                     query_language=query_language,
@@ -1577,6 +1643,16 @@ def gfql(self: Plottable,
                     params=params,
                 )
                 raise
+            _fire_postcompile_policy(
+                expanded_policy,
+                query=query,
+                query_language=query_language,
+                exc=None,
+                policy_depth=policy_depth,
+                execution_depth=current_depth,
+                operation_path=current_path,
+                params=params,
+            )
             if isinstance(compiled_query, CompiledCypherGraphQuery):
                 return _execute_graph_query(self, compiled_query, engine=engine, policy=expanded_policy, context=context)
             if isinstance(compiled_query, CompiledCypherQuery):

--- a/graphistry/tests/compute/gfql/cypher/test_compiler_policy.py
+++ b/graphistry/tests/compute/gfql/cypher/test_compiler_policy.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import List, cast
+
+import pandas as pd
+import pytest
+
+from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
+from graphistry.compute.gfql.policy import CompileErrorSummary, PolicyContext
+from graphistry.tests.test_compute import CGFull
+
+
+class _CypherPolicyGraph(CGFull):
+    _dgl_graph = None
+
+    def search_graph(self, query: str, scale: float = 0.5, top_n: int = 100, thresh: float = 5000, broader: bool = False, inplace: bool = False):
+        raise NotImplementedError
+
+    def search(self, query: str, cols=None, thresh: float = 5000, fuzzy: bool = True, top_n: int = 10):
+        raise NotImplementedError
+
+    def embed(self, relation: str, *args, **kwargs):
+        raise NotImplementedError
+
+
+def _mk_graph() -> _CypherPolicyGraph:
+    return cast(
+        _CypherPolicyGraph,
+        _CypherPolicyGraph()
+        .nodes(pd.DataFrame({"id": ["a", "b"]}), "id")
+        .edges(pd.DataFrame({"s": ["a"], "d": ["b"]}), "s", "d"),
+    )
+
+
+def test_compile_error_policy_fires_once_with_structured_binder_payload() -> None:
+    calls: List[PolicyContext] = []
+
+    def observe(ctx: PolicyContext) -> None:
+        calls.append(ctx)
+
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _mk_graph().gfql(
+            "MATCH (a) MATCH ()-[a]->() RETURN a",
+            policy={"compile_error": observe},
+        )
+
+    assert exc_info.value.code == ErrorCode.E204
+    assert len(calls) == 1
+    ctx = calls[0]
+    assert ctx["phase"] == "compile_error"
+    assert ctx["hook"] == "compile_error"
+    assert ctx["compile_language"] == "cypher"
+    summary = ctx["compile_error"]
+    assert isinstance(summary, CompileErrorSummary)
+    assert summary.language == "cypher"
+    assert summary.error_type == "GFQLValidationError"
+    assert summary.compiler_phase == "bind"
+    assert summary.code == ErrorCode.E204
+    assert summary.message == "Cypher alias rebound as a different entity kind"
+    assert summary.context["existing_kind"] == "node"
+    assert summary.context["new_kind"] == "edge"
+    assert summary.context["new_role"] == "relationship pattern"
+    assert summary.context["value"] == "a"
+    with pytest.raises(TypeError):
+        summary.context["existing_kind"] = "scalar"  # type: ignore[index]
+    assert summary.field == "identifier"
+    assert summary.value_repr == "'a'"
+    assert summary.suggestion is not None
+    assert summary.line is None
+    assert summary.column is None
+    assert summary.param_keys == ()
+
+
+def test_compile_error_policy_absent_preserves_existing_error_surface() -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _mk_graph().gfql("MATCH (a) MATCH ()-[a]->() RETURN a")
+
+    assert exc_info.value.code == ErrorCode.E204
+    assert exc_info.value.context["existing_kind"] == "node"
+    assert exc_info.value.context["new_kind"] == "edge"
+    assert exc_info.value.context["new_role"] == "relationship pattern"
+
+
+def test_compile_error_policy_fires_for_validate_true_preflight() -> None:
+    calls: List[PolicyContext] = []
+
+    def observe(ctx: PolicyContext) -> None:
+        calls.append(ctx)
+
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _mk_graph().gfql(
+            "MATCH (a) MATCH ()-[a]->() RETURN a",
+            validate=True,
+            policy={"compile_error": observe},
+        )
+
+    assert exc_info.value.code == ErrorCode.E204
+    assert len(calls) == 1
+    summary = calls[0]["compile_error"]
+    assert isinstance(summary, CompileErrorSummary)
+    assert summary.compiler_phase == "bind"
+    assert summary.context["existing_kind"] == "node"
+    assert summary.context["new_kind"] == "edge"
+
+
+def test_compile_error_policy_does_not_fire_for_successful_row_hot_loop_query() -> None:
+    calls: List[PolicyContext] = []
+
+    def observe(ctx: PolicyContext) -> None:
+        calls.append(ctx)
+
+    result = _mk_graph().gfql(
+        "UNWIND [1, 2, 3] AS x RETURN x ORDER BY x",
+        policy={"compile_error": observe},
+    )
+
+    assert calls == []
+    assert result._nodes is not None
+    assert result._nodes[["x"]].to_dict(orient="records") == [{"x": 1}, {"x": 2}, {"x": 3}]
+
+
+def test_compile_error_policy_fires_before_runtime_hooks() -> None:
+    calls: List[str] = []
+
+    def observe_compile_error(ctx: PolicyContext) -> None:
+        calls.append(cast(str, ctx["phase"]))
+
+    def observe_runtime(ctx: PolicyContext) -> None:
+        calls.append(cast(str, ctx["phase"]))
+
+    with pytest.raises(GFQLValidationError):
+        _mk_graph().gfql(
+            "MATCH (a) MATCH ()-[a]->() RETURN a",
+            policy={
+                "compile_error": observe_compile_error,
+                "prechain": observe_runtime,
+                "precall": observe_runtime,
+                "postcall": observe_runtime,
+            },
+        )
+
+    assert calls == ["compile_error"]

--- a/graphistry/tests/compute/gfql/cypher/test_compiler_policy.py
+++ b/graphistry/tests/compute/gfql/cypher/test_compiler_policy.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
-from graphistry.compute.gfql.policy import CompileErrorSummary, PolicyContext
+from graphistry.compute.gfql.policy import CompileSummary, PolicyContext, PolicyException
 from graphistry.tests.test_compute import CGFull
 
 
@@ -32,7 +32,7 @@ def _mk_graph() -> _CypherPolicyGraph:
     )
 
 
-def test_compile_error_policy_fires_once_with_structured_binder_payload() -> None:
+def test_postcompile_policy_fires_once_with_structured_binder_payload() -> None:
     calls: List[PolicyContext] = []
 
     def observe(ctx: PolicyContext) -> None:
@@ -41,18 +41,22 @@ def test_compile_error_policy_fires_once_with_structured_binder_payload() -> Non
     with pytest.raises(GFQLValidationError) as exc_info:
         _mk_graph().gfql(
             "MATCH (a) MATCH ()-[a]->() RETURN a",
-            policy={"compile_error": observe},
+            policy={"postcompile": observe},
         )
 
     assert exc_info.value.code == ErrorCode.E204
     assert len(calls) == 1
     ctx = calls[0]
-    assert ctx["phase"] == "compile_error"
-    assert ctx["hook"] == "compile_error"
+    assert ctx["phase"] == "postcompile"
+    assert ctx["hook"] == "postcompile"
     assert ctx["compile_language"] == "cypher"
-    summary = ctx["compile_error"]
-    assert isinstance(summary, CompileErrorSummary)
+    assert ctx["success"] is False
+    assert ctx["error_type"] == "GFQLValidationError"
+    assert "Cypher alias rebound" in ctx["error"]
+    summary = ctx["compile"]
+    assert isinstance(summary, CompileSummary)
     assert summary.language == "cypher"
+    assert summary.success is False
     assert summary.error_type == "GFQLValidationError"
     assert summary.compiler_phase == "bind"
     assert summary.code == ErrorCode.E204
@@ -71,7 +75,7 @@ def test_compile_error_policy_fires_once_with_structured_binder_payload() -> Non
     assert summary.param_keys == ()
 
 
-def test_compile_error_policy_absent_preserves_existing_error_surface() -> None:
+def test_postcompile_policy_absent_preserves_existing_error_surface() -> None:
     with pytest.raises(GFQLValidationError) as exc_info:
         _mk_graph().gfql("MATCH (a) MATCH ()-[a]->() RETURN a")
 
@@ -81,7 +85,7 @@ def test_compile_error_policy_absent_preserves_existing_error_surface() -> None:
     assert exc_info.value.context["new_role"] == "relationship pattern"
 
 
-def test_compile_error_policy_fires_for_validate_true_preflight() -> None:
+def test_postcompile_policy_fires_for_validate_true_preflight() -> None:
     calls: List[PolicyContext] = []
 
     def observe(ctx: PolicyContext) -> None:
@@ -91,19 +95,21 @@ def test_compile_error_policy_fires_for_validate_true_preflight() -> None:
         _mk_graph().gfql(
             "MATCH (a) MATCH ()-[a]->() RETURN a",
             validate=True,
-            policy={"compile_error": observe},
+            policy={"postcompile": observe},
         )
 
     assert exc_info.value.code == ErrorCode.E204
     assert len(calls) == 1
-    summary = calls[0]["compile_error"]
-    assert isinstance(summary, CompileErrorSummary)
+    assert calls[0]["phase"] == "postcompile"
+    assert calls[0]["success"] is False
+    summary = calls[0]["compile"]
+    assert isinstance(summary, CompileSummary)
     assert summary.compiler_phase == "bind"
     assert summary.context["existing_kind"] == "node"
     assert summary.context["new_kind"] == "edge"
 
 
-def test_compile_error_policy_does_not_fire_for_successful_row_hot_loop_query() -> None:
+def test_postcompile_policy_fires_once_for_successful_row_query() -> None:
     calls: List[PolicyContext] = []
 
     def observe(ctx: PolicyContext) -> None:
@@ -111,18 +117,30 @@ def test_compile_error_policy_does_not_fire_for_successful_row_hot_loop_query() 
 
     result = _mk_graph().gfql(
         "UNWIND [1, 2, 3] AS x RETURN x ORDER BY x",
-        policy={"compile_error": observe},
+        policy={"postcompile": observe},
     )
 
-    assert calls == []
+    assert len(calls) == 1
+    ctx = calls[0]
+    assert ctx["phase"] == "postcompile"
+    assert ctx["success"] is True
+    assert "error" not in ctx
+    summary = ctx["compile"]
+    assert isinstance(summary, CompileSummary)
+    assert summary.language == "cypher"
+    assert summary.success is True
+    assert summary.error_type is None
+    assert summary.message is None
+    assert summary.code is None
+    assert summary.context == {}
     assert result._nodes is not None
     assert result._nodes[["x"]].to_dict(orient="records") == [{"x": 1}, {"x": 2}, {"x": 3}]
 
 
-def test_compile_error_policy_fires_before_runtime_hooks() -> None:
+def test_postcompile_policy_fires_before_runtime_hooks() -> None:
     calls: List[str] = []
 
-    def observe_compile_error(ctx: PolicyContext) -> None:
+    def observe_postcompile(ctx: PolicyContext) -> None:
         calls.append(cast(str, ctx["phase"]))
 
     def observe_runtime(ctx: PolicyContext) -> None:
@@ -132,11 +150,47 @@ def test_compile_error_policy_fires_before_runtime_hooks() -> None:
         _mk_graph().gfql(
             "MATCH (a) MATCH ()-[a]->() RETURN a",
             policy={
-                "compile_error": observe_compile_error,
+                "postcompile": observe_postcompile,
                 "prechain": observe_runtime,
                 "precall": observe_runtime,
                 "postcall": observe_runtime,
             },
         )
 
-    assert calls == ["compile_error"]
+    assert calls == ["postcompile"]
+
+
+def test_precompile_policy_fires_once_before_compile() -> None:
+    calls: List[PolicyContext] = []
+
+    def observe(ctx: PolicyContext) -> None:
+        calls.append(ctx)
+
+    result = _mk_graph().gfql(
+        "UNWIND [1, 2, 3] AS x RETURN x ORDER BY x",
+        policy={"precompile": observe},
+    )
+
+    assert len(calls) == 1
+    ctx = calls[0]
+    assert ctx["phase"] == "precompile"
+    assert ctx["hook"] == "precompile"
+    assert ctx["compile_language"] == "cypher"
+    assert "compile" not in ctx
+    assert "success" not in ctx
+    assert result._nodes is not None
+
+
+def test_precompile_policy_can_deny_before_invalid_query_compiles() -> None:
+    calls: List[str] = []
+
+    def deny(ctx: PolicyContext) -> None:
+        calls.append(cast(str, ctx["phase"]))
+        raise PolicyException("precompile", "compiler disabled")
+
+    with pytest.raises(PolicyException) as exc_info:
+        _mk_graph().gfql("THIS IS NOT CYPHER", policy={"precompile": deny})
+
+    assert calls == ["precompile"]
+    assert exc_info.value.phase == "precompile"
+    assert exc_info.value.query_type == "chain"

--- a/graphistry/tests/compute/gfql/test_policy_shortcuts.py
+++ b/graphistry/tests/compute/gfql/test_policy_shortcuts.py
@@ -101,26 +101,31 @@ class TestExpandPolicyBasics:
         assert expand_policy({}) == {}
         assert expand_policy(None) == {}  # type: ignore
 
-    def test_compile_error_hook_is_direct_only(self):
+    def test_compile_hooks_are_direct_only(self):
         """Compiler hooks are opt-in direct keys, not runtime shortcut expansions."""
         def handler(ctx):
             pass
 
-        expanded = expand_policy({'pre': handler, 'compile_error': handler})
+        expanded = expand_policy({'pre': handler, 'post': handler, 'precompile': handler, 'postcompile': handler})
 
-        assert 'compile_error' in expanded
-        assert expanded['compile_error'] is handler
+        assert 'precompile' in expanded
+        assert expanded['precompile'] is handler
+        assert 'postcompile' in expanded
+        assert expanded['postcompile'] is handler
         assert 'preload' in expanded
         assert expanded['preload'] is handler
+        assert 'postload' in expanded
+        assert expanded['postload'] is handler
 
-    def test_compile_error_hook_appears_in_debug_policy(self):
+    def test_compile_hooks_appear_in_debug_policy(self):
         """Direct compiler hook is visible to policy expansion debugging."""
         def handler(ctx):
             pass
 
-        debug_info = debug_policy({'compile_error': handler})
+        debug_info = debug_policy({'precompile': handler, 'postcompile': handler})
 
-        assert debug_info['compile_error'] == [('handler', 'compile_error')]
+        assert debug_info['precompile'] == [('handler', 'precompile')]
+        assert debug_info['postcompile'] == [('handler', 'postcompile')]
 
     def test_full_hook_names_work_as_specific_overrides(self):
         """Test that full hook names work and override shortcuts."""

--- a/graphistry/tests/compute/gfql/test_policy_shortcuts.py
+++ b/graphistry/tests/compute/gfql/test_policy_shortcuts.py
@@ -101,6 +101,27 @@ class TestExpandPolicyBasics:
         assert expand_policy({}) == {}
         assert expand_policy(None) == {}  # type: ignore
 
+    def test_compile_error_hook_is_direct_only(self):
+        """Compiler hooks are opt-in direct keys, not runtime shortcut expansions."""
+        def handler(ctx):
+            pass
+
+        expanded = expand_policy({'pre': handler, 'compile_error': handler})
+
+        assert 'compile_error' in expanded
+        assert expanded['compile_error'] is handler
+        assert 'preload' in expanded
+        assert expanded['preload'] is handler
+
+    def test_compile_error_hook_appears_in_debug_policy(self):
+        """Direct compiler hook is visible to policy expansion debugging."""
+        def handler(ctx):
+            pass
+
+        debug_info = debug_policy({'compile_error': handler})
+
+        assert debug_info['compile_error'] == [('handler', 'compile_error')]
+
     def test_full_hook_names_work_as_specific_overrides(self):
         """Test that full hook names work and override shortcuts."""
         def handler(ctx):


### PR DESCRIPTION
Closes #1454.
Updates #1453.

## Summary
- Add experimental exact-key `precompile` and `postcompile` GFQL policy hooks for local string-query compilation.
- Expose a public `CompileSummary` payload on `postcompile` with language, success/error status, compiler phase, validation code/message, read-only structured context, and scalar-safe metadata.
- Keep runtime policy shortcuts unchanged: compiler hooks are not part of broad `pre`/`post` shortcut expansion.

## Validation
- `python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_compiler_policy.py graphistry/tests/compute/gfql/test_policy_shortcuts.py graphistry/tests/test_policy_hooks.py`
- `python3 -m pytest -q graphistry/tests/test_policy_hooks.py graphistry/tests/compute/gfql/test_policy_shortcuts.py graphistry/tests/compute/gfql/cypher/test_compiler_policy.py graphistry/tests/compute/gfql/cypher/test_binder.py graphistry/tests/compute/gfql/cypher/test_binder_cross_kind_rebind.py`
- `python3 -m ruff check graphistry/compute/gfql/policy/types.py graphistry/compute/gfql/policy/shortcuts.py graphistry/compute/gfql_unified.py graphistry/tests/compute/gfql/cypher/test_compiler_policy.py graphistry/tests/compute/gfql/test_policy_shortcuts.py`
- DGX RAPIDS 26.02 GFQL profile:
  `RAPIDS_VERSION=26.02 PROFILE=gfql WITH_GPU=1 WITH_IMAGE_BUILD=1 ... docker/test-rapids-official-local.sh`
  `36 passed`, import smoke `cudf 26.02.01`.
- DGX RAPIDS 25.02 GFQL profile:
  `RAPIDS_VERSION=25.02 PROFILE=gfql WITH_GPU=1 WITH_IMAGE_BUILD=1 ... docker/test-rapids-official-local.sh`
  `36 passed`, import smoke `cudf 25.02.02`.
