### PR TITLE
Fix Cypher literal binder classification

### DIFF
--- a/graphistry/compute/gfql/frontends/cypher/binder.py
+++ b/graphistry/compute/gfql/frontends/cypher/binder.py
@@ -89,7 +89,7 @@ _PARAMETER_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
 _COUNT_CALL_RE = re.compile(r"(?i)^count\s*\(")
 _COLLECT_ALIAS_CALL_RE = re.compile(r"(?is)^collect\s*\(\s*(?:distinct\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\)$")
 _SINGLE_ALIAS_LIST_LITERAL_RE = re.compile(r"^\[\s*([A-Za-z_][A-Za-z0-9_]*)\s*\]$")
-_STRING_LITERAL_RE = re.compile(r"'(?:''|[^'])*'")
+_STRING_LITERAL_RE = re.compile(r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"")
 _QUANTIFIER_COMPREHENSION_RE = re.compile(
     r"(?i)\b(?:all|any|none|single)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s+IN\b"
 )
@@ -1150,16 +1150,17 @@ def _infer_expression_binding(
         alias_list_match = _SINGLE_ALIAS_LIST_LITERAL_RE.fullmatch(text)
         if alias_list_match is not None:
             alias = alias_list_match.group(1)
-            source = scope.get(alias)
-            if source is None:
-                raise _unresolved_name_error(identifier=alias, visible_scope=scope)
-            return _ExpressionBinding(
-                logical_type=ListType(element_type=source.logical_type),
-                entity_kind="scalar",
-                nullable=False,
-                null_extended_from=source.null_extended_from,
-                schema_confidence=_demote_confidence(confidence.get(alias, "propagated")),
-            )
+            if alias.upper() not in _KEYWORDS:
+                source = scope.get(alias)
+                if source is None:
+                    raise _unresolved_name_error(identifier=alias, visible_scope=scope)
+                return _ExpressionBinding(
+                    logical_type=ListType(element_type=source.logical_type),
+                    entity_kind="scalar",
+                    nullable=False,
+                    null_extended_from=source.null_extended_from,
+                    schema_confidence=_demote_confidence(confidence.get(alias, "propagated")),
+                )
         return _ExpressionBinding(
             logical_type=ListType(element_type=ScalarType(kind="unknown", nullable=True)),
             entity_kind="scalar",
@@ -1682,7 +1683,7 @@ def _is_null_literal(text: str) -> bool:
 
 
 def _is_string_literal(text: str) -> bool:
-    return len(text) >= 2 and text[0] == "'" and text[-1] == "'"
+    return len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}
 
 
 def _looks_like_list_literal(text: str) -> bool:

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -12606,6 +12606,32 @@ def test_gfql_executes_size_null_and_sqrt_constant_expressions() -> None:
     )
 
 
+def test_gfql_executes_double_quoted_string_literal_projection() -> None:
+    _assert_query_rows('RETURN "a" AS literal', [{"literal": "a"}])
+
+
+def test_gfql_executes_bool_and_null_list_literal_projections() -> None:
+    _assert_query_rows(
+        "RETURN [true] AS trues, [false] AS falses, [null] AS nulls",
+        [{"trues": [True], "falses": [False], "nulls": [None]}],
+    )
+
+
+def test_gfql_preserves_single_alias_list_projection() -> None:
+    _assert_query_rows(
+        "MATCH (n) WITH [n] AS ns RETURN size(ns) AS size",
+        [{"size": 1}, {"size": 1}],
+        nodes_df=pd.DataFrame({"id": ["a", "b"]}),
+    )
+
+
+def test_gfql_rejects_unresolved_single_alias_list_projection() -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _mk_empty_graph().gfql("RETURN [missingAlias] AS xs")
+
+    assert "missingAlias" in str(exc_info.value)
+
+
 def test_gfql_executes_substring_and_tointeger_expressions() -> None:
     _assert_query_rows(
         "WITH 82.9 AS weight "


### PR DESCRIPTION
## Summary

- fixes Cypher binder classification for double-quoted string literals
- prevents `[false]` and `[null]` from being treated as single-alias list shorthand
- adds focused lowering tests for the tck-gfql#140 literal regressions

## Context

tck-gfql#140 found three direct-Cypher overlap regressions where runtime binding treated literals as unresolved identifiers:

- `expr-literals6-11`: `RETURN "a" AS literal`
- `expr-literals7-2`: `RETURN [false] AS literal`
- `expr-literals7-3`: `RETURN [null] AS literal`

The tck-gfql harness parser already models these forms as literals, so the concrete bug is in pygraphistry's Cypher binder.

## Validation

- `PYTHONPATH=/tmp/tck-gfql-pygraphistry-ci /tmp/tck-gfql-ci-venv312/bin/python -m pytest graphistry/tests/compute/gfql/cypher/test_lowering.py -q -k "double_quoted_string_literal_projection or bool_and_null_list_literal_projections or preserves_single_alias_list_projection or rejects_unresolved_single_alias_list_projection"`: 4 passed, 1077 deselected
- Paired tck-gfql targeted direct-Cypher reproduction now passes for `expr-literals6-11`, `expr-literals7-2`, and `expr-literals7-3`
- Paired full tck-gfql local CI: 4034 passed, 701 xfailed
