### PR TITLE
Add changed-line coverage hygiene gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,7 +764,7 @@ jobs:
       run: |
         source pygraphistry/bin/activate
         mkdir -p build/gfql-coverage-audit
-        COVERAGE_FILE=build/gfql-coverage-audit/.coverage python -B -m pytest -vv -n auto \
+        COVERAGE_FILE=build/gfql-coverage-audit/coverage.gfql-py3.12 python -B -m pytest -vv -n auto \
           --cov=graphistry/compute \
           --cov-report= \
           graphistry/tests/compute/test_ast.py \
@@ -780,7 +780,7 @@ jobs:
           --skip-tests \
           --engine-label ci-pandas-py3.12 \
           --output-dir build/gfql-coverage-audit \
-          --data-file build/gfql-coverage-audit/.coverage \
+          --data-file build/gfql-coverage-audit/coverage.gfql-py3.12 \
           --baseline-file graphistry/tests/compute/gfql/coverage_baselines/ci-pandas-py3.12.json
         cat build/gfql-coverage-audit/gfql-coverage-audit.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -814,6 +814,81 @@ jobs:
       run: |
         source pygraphistry/bin/activate
         python -B -m pytest -vv graphistry/tests/compute/gfql/test_rollout.py
+
+  changed-line-coverage:
+    # PR hygiene only: combine coverage collected by existing CPU test jobs and
+    # gate executable package lines touched by this PR. Historical uncovered
+    # lines outside the diff are intentionally ignored.
+    needs: [changes, test-core-python, test-gfql-core, generate-lockfiles]
+    if: ${{ github.event_name == 'pull_request' && (needs.changes.outputs.python == 'true' || needs.changes.outputs.gfql == 'true' || needs.changes.outputs.infra == 'true') && !(needs.changes.outputs.docs_only_latest == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Download lockfiles
+      uses: actions/download-artifact@v4
+      with:
+        name: lockfiles
+        path: requirements
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install coverage tooling
+      run: |
+        python -m venv pygraphistry
+        source pygraphistry/bin/activate
+        python -m pip install --upgrade pip uv
+        uv pip install --require-hashes -r requirements/test-py3.12.lock
+
+    - name: Download core coverage data
+      uses: actions/download-artifact@v4
+      with:
+        name: python-coverage-core-py3.14
+        path: build/changed-line-coverage/artifacts/core
+
+    - name: Download GFQL coverage data
+      uses: actions/download-artifact@v4
+      with:
+        name: gfql-coverage-audit-py3.12
+        path: build/changed-line-coverage/artifacts/gfql
+
+    - name: Changed-line coverage gate
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        source pygraphistry/bin/activate
+        mkdir -p build/changed-line-coverage
+        python -m coverage combine \
+          --data-file=build/changed-line-coverage/combined.coverage \
+          build/changed-line-coverage/artifacts/core/coverage.core-py3.14 \
+          build/changed-line-coverage/artifacts/gfql/coverage.gfql-py3.12
+        python bin/changed_line_coverage.py \
+          --data-file build/changed-line-coverage/combined.coverage \
+          --base-ref "$BASE_SHA" \
+          --head-ref "$HEAD_SHA" \
+          --min-percent 80 \
+          --output-dir build/changed-line-coverage
+        cat build/changed-line-coverage/changed-line-coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload changed-line coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: changed-line-coverage-pr
+        path: |
+          build/changed-line-coverage/changed-line-coverage.md
+          build/changed-line-coverage/changed-line-coverage.json
+        retention-days: 14
 
   test-pandas-compat:
     name: test-pandas-compat (${{ matrix.label }}, py${{ matrix.python-version }})
@@ -987,9 +1062,26 @@ jobs:
         uv pip install -e . --no-deps
 
     - name: Core tests
+      if: ${{ matrix.python-version != '3.14' }}
       run: |
         source pygraphistry/bin/activate
         ./bin/test.sh
+
+    - name: Core tests with changed-line coverage
+      if: ${{ matrix.python-version == '3.14' }}
+      run: |
+        source pygraphistry/bin/activate
+        mkdir -p "$RUNNER_TEMP/changed-line-coverage"
+        COVERAGE_FILE="$RUNNER_TEMP/changed-line-coverage/coverage.core-py3.14" \
+          ./bin/test.sh -n auto --cov=graphistry --cov-report=
+
+    - name: Upload core coverage data
+      if: ${{ matrix.python-version == '3.14' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-coverage-core-py3.14
+        path: ${{ runner.temp }}/changed-line-coverage/coverage.core-py3.14
+        retention-days: 14
 
   test-graphviz:
     needs: [ test-minimal-python, test-gfql-core, generate-lockfiles ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Added
+- **Changed-line coverage hygiene (#1533)**: Added a PR-only changed-line coverage gate that combines CPU coverage from the existing minimal and GFQL core test jobs, reports covered/missing executable package lines touched by a PR, and enforces an initial changed-line threshold without blocking on historical uncovered code.
 - **Coverage audit profiles (#1517)**: Added a coverage.py-backed audit helper with an initial GFQL dead-code triage profile that emits markdown/JSON zero-hit and low-hit reports for parser, lowering, row-pipeline, temporal, AST, unified, and chain files. CI now collects coverage inside the existing `test-gfql-core (3.12)` run via `pytest-cov`, uploads the pandas CPU audit artifact with per-file coverage lock-ins, and the RAPIDS Docker wrapper can run the same profile against periodic DGX RAPIDS 25.02 and 26.02 cuDF lock-ins.
 - **GFQL policy / Cypher compiler hooks (#1454)**: Added experimental exact-key `precompile` and `postcompile` policy hooks for local Cypher string-query compilation. `postcompile` reports success or failure using the existing policy `success`, `error`, and `error_type` fields plus a stable `CompileSummary` with scalar compiler metadata.
 

--- a/bin/changed_line_coverage.py
+++ b/bin/changed_line_coverage.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Changed-line coverage gate for Python PR hygiene.
+
+This tool consumes an existing coverage.py data file and a git diff, then
+reports coverage for changed executable lines only. It is intentionally about
+PR hygiene: it does not judge historical uncovered code and it does not provide
+dead-code deletion evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ZERO_SHA = "0000000000000000000000000000000000000000"
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+DEFAULT_INCLUDE = ("graphistry/*.py", "graphistry/**/*.py")
+DEFAULT_EXCLUDE = (
+    "graphistry/tests/*.py",
+    "graphistry/tests/**/*.py",
+    "graphistry/_version.py",
+)
+
+
+@dataclass(frozen=True)
+class ChangedFileCoverage:
+    path: str
+    changed_statement_lines: int
+    covered_lines: int
+    missing_lines: int
+    coverage_percent: float
+    missing_line_numbers: List[int]
+
+
+@dataclass(frozen=True)
+class ChangedLineReport:
+    base_ref: str
+    head_ref: str
+    generated_at: str
+    min_percent: float
+    status: str
+    changed_statement_lines: int
+    covered_lines: int
+    missing_lines: int
+    coverage_percent: float
+    files: List[ChangedFileCoverage]
+    skipped_files: List[str]
+
+
+class ChangedLineCoverageError(RuntimeError):
+    """Changed-line coverage setup or runtime failure."""
+
+
+def _load_coverage_module() -> Any:
+    try:
+        import coverage  # type: ignore
+    except Exception as exc:
+        raise ChangedLineCoverageError("coverage.py is required; install the test extra.") from exc
+    return coverage
+
+
+def _repo_rel(path: Path) -> str:
+    return path.resolve().relative_to(REPO_ROOT).as_posix()
+
+
+def _matches_any(path: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _is_eligible_path(path: str, includes: Sequence[str], excludes: Sequence[str]) -> bool:
+    return _matches_any(path, includes) and not _matches_any(path, excludes)
+
+
+def _parse_changed_lines(diff_text: str) -> Dict[str, Set[int]]:
+    changed: Dict[str, Set[int]] = {}
+    current_path: Optional[str] = None
+    new_line: Optional[int] = None
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ "):
+            value = raw_line[4:].strip()
+            current_path = None if value == "/dev/null" else (value[2:] if value.startswith("b/") else value)
+            if current_path is not None:
+                changed.setdefault(current_path, set())
+            new_line = None
+            continue
+
+        match = HUNK_RE.match(raw_line)
+        if match:
+            new_line = int(match.group(1))
+            continue
+
+        if current_path is None or new_line is None:
+            continue
+
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            changed[current_path].add(new_line)
+            new_line += 1
+        elif raw_line.startswith("-") and not raw_line.startswith("---"):
+            continue
+        else:
+            new_line += 1
+
+    return {path: lines for path, lines in changed.items() if lines}
+
+
+def _git_changed_lines(base_ref: str, head_ref: str) -> Dict[str, Set[int]]:
+    if not base_ref or base_ref == ZERO_SHA:
+        return {}
+    cmd = [
+        "git",
+        "diff",
+        "--unified=0",
+        "--no-color",
+        "--no-ext-diff",
+        f"{base_ref}...{head_ref}",
+        "--",
+        "*.py",
+    ]
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT), text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise ChangedLineCoverageError(
+            "git diff failed for changed-line coverage: " + (result.stderr.strip() or result.stdout.strip())
+        )
+    return _parse_changed_lines(result.stdout)
+
+
+def _file_line_coverage(cov: Any, path: Path, changed_lines: Set[int]) -> Optional[ChangedFileCoverage]:
+    if not path.exists():
+        return None
+
+    _, statements_raw, _, missing_raw, _ = cov.analysis2(str(path))
+    statements = set(statements_raw)
+    missing = set(missing_raw)
+    changed_statement_lines = sorted(changed_lines & statements)
+    if not changed_statement_lines:
+        return None
+
+    missing_changed = sorted(line for line in changed_statement_lines if line in missing)
+    covered = len(changed_statement_lines) - len(missing_changed)
+    percent = 100.0 * covered / len(changed_statement_lines)
+    return ChangedFileCoverage(
+        path=_repo_rel(path),
+        changed_statement_lines=len(changed_statement_lines),
+        covered_lines=covered,
+        missing_lines=len(missing_changed),
+        coverage_percent=round(percent, 2),
+        missing_line_numbers=missing_changed,
+    )
+
+
+def _build_report(
+    cov: Any,
+    changed_lines: Mapping[str, Set[int]],
+    base_ref: str,
+    head_ref: str,
+    min_percent: float,
+    includes: Sequence[str],
+    excludes: Sequence[str],
+) -> ChangedLineReport:
+    files: List[ChangedFileCoverage] = []
+    skipped: List[str] = []
+
+    for rel_path in sorted(changed_lines):
+        if not _is_eligible_path(rel_path, includes, excludes):
+            skipped.append(rel_path)
+            continue
+        item = _file_line_coverage(cov, REPO_ROOT / rel_path, changed_lines[rel_path])
+        if item is None:
+            skipped.append(rel_path)
+        else:
+            files.append(item)
+
+    changed_statement_lines = sum(item.changed_statement_lines for item in files)
+    covered_lines = sum(item.covered_lines for item in files)
+    missing_lines = sum(item.missing_lines for item in files)
+    coverage_percent = 100.0 * covered_lines / changed_statement_lines if changed_statement_lines else 100.0
+    status = "pass" if coverage_percent >= min_percent else "fail"
+
+    return ChangedLineReport(
+        base_ref=base_ref,
+        head_ref=head_ref,
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        min_percent=round(min_percent, 2),
+        status=status,
+        changed_statement_lines=changed_statement_lines,
+        covered_lines=covered_lines,
+        missing_lines=missing_lines,
+        coverage_percent=round(coverage_percent, 2),
+        files=sorted(files, key=lambda item: (item.coverage_percent, item.path)),
+        skipped_files=skipped,
+    )
+
+
+def _format_lines(lines: Sequence[int], limit: int = 20) -> str:
+    if not lines:
+        return ""
+    rendered = ", ".join(str(line) for line in lines[:limit])
+    if len(lines) > limit:
+        rendered += f", ... (+{len(lines) - limit})"
+    return rendered
+
+
+def _write_markdown(path: Path, report: ChangedLineReport) -> None:
+    lines = [
+        "# Changed-Line Coverage",
+        "",
+        f"- Generated: `{report.generated_at}`",
+        f"- Base: `{report.base_ref}`",
+        f"- Head: `{report.head_ref}`",
+        f"- Threshold: `{report.min_percent:.2f}%`",
+        f"- Status: `{report.status}`",
+        f"- Changed executable lines: `{report.changed_statement_lines}`",
+        f"- Coverage: `{report.covered_lines}/{report.changed_statement_lines} = {report.coverage_percent:.2f}%`",
+        "",
+        "Changed-line coverage is a PR hygiene gate. It ignores historical uncovered lines outside the diff.",
+        "",
+        "## Files",
+        "",
+    ]
+    if report.files:
+        lines.extend(
+            [
+                "| File | Changed stmt lines | Covered | Missing | Coverage | Missing changed lines |",
+                "|---|---:|---:|---:|---:|---|",
+            ]
+        )
+        for item in report.files:
+            lines.append(
+                "| {path} | {changed} | {covered} | {missing} | {percent:.2f}% | {lines} |".format(
+                    path=item.path,
+                    changed=item.changed_statement_lines,
+                    covered=item.covered_lines,
+                    missing=item.missing_lines,
+                    percent=item.coverage_percent,
+                    lines=_format_lines(item.missing_line_numbers) or "-",
+                )
+            )
+    else:
+        lines.append("No eligible changed executable package lines were found.")
+
+    if report.skipped_files:
+        lines.extend(["", "## Skipped Changed Python Files", ""])
+        lines.extend(f"- `{path}`" for path in report.skipped_files[:100])
+        if len(report.skipped_files) > 100:
+            lines.append(f"- ... (+{len(report.skipped_files) - 100})")
+
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_json(path: Path, report: ChangedLineReport) -> None:
+    path.write_text(json.dumps(asdict(report), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-file", required=True, help="coverage.py data file to analyze")
+    parser.add_argument("--base-ref", required=True, help="git base ref/SHA for the PR diff")
+    parser.add_argument("--head-ref", default="HEAD", help="git head ref/SHA for the PR diff")
+    parser.add_argument("--min-percent", type=float, default=80.0, help="Minimum changed-line coverage percentage")
+    parser.add_argument("--output-dir", default="build/changed-line-coverage", help="Directory for markdown/json reports")
+    parser.add_argument("--include", action="append", default=None, help="Eligible repo-relative fnmatch pattern")
+    parser.add_argument("--exclude", action="append", default=None, help="Excluded repo-relative fnmatch pattern")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    coverage = _load_coverage_module()
+    data_file = (REPO_ROOT / args.data_file).resolve()
+    output_dir = (REPO_ROOT / args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cov = coverage.Coverage(data_file=str(data_file))
+    cov.load()
+    changed_lines = _git_changed_lines(args.base_ref, args.head_ref)
+    report = _build_report(
+        cov=cov,
+        changed_lines=changed_lines,
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+        min_percent=args.min_percent,
+        includes=tuple(args.include or DEFAULT_INCLUDE),
+        excludes=tuple(args.exclude or DEFAULT_EXCLUDE),
+    )
+
+    markdown_path = output_dir / "changed-line-coverage.md"
+    json_path = output_dir / "changed-line-coverage.json"
+    _write_markdown(markdown_path, report)
+    _write_json(json_path, report)
+    print(f"Wrote {markdown_path}")
+    print(f"Wrote {json_path}")
+    if report.status != "pass":
+        print(
+            f"changed-line coverage {report.coverage_percent:.2f}% is below {report.min_percent:.2f}%",
+            file=sys.stderr,
+        )
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ChangedLineCoverageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/graphistry/tests/test_changed_line_coverage.py
+++ b/graphistry/tests/test_changed_line_coverage.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module() -> Any:
+    path = Path(__file__).resolve().parents[2] / "bin" / "changed_line_coverage.py"
+    spec = importlib.util.spec_from_file_location("changed_line_coverage", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_changed_lines_tracks_added_new_file_lines() -> None:
+    module = _load_module()
+    diff = """diff --git a/graphistry/example.py b/graphistry/example.py
+--- a/graphistry/example.py
++++ b/graphistry/example.py
+@@ -10,0 +11,2 @@
++first = 1
++second = 2
+"""
+
+    assert module._parse_changed_lines(diff) == {"graphistry/example.py": {11, 12}}
+
+
+def test_parse_changed_lines_tracks_modified_replacement_lines() -> None:
+    module = _load_module()
+    diff = """diff --git a/graphistry/example.py b/graphistry/example.py
+--- a/graphistry/example.py
++++ b/graphistry/example.py
+@@ -7 +7 @@
+-old = 1
++new = 2
+@@ -20,2 +20,3 @@
+ context = True
+-old_call()
++new_call()
++extra_call()
+"""
+
+    assert module._parse_changed_lines(diff) == {"graphistry/example.py": {7, 21, 22}}
+
+
+def test_eligible_path_defaults_include_package_and_exclude_tests() -> None:
+    module = _load_module()
+
+    assert module._is_eligible_path("graphistry/compute/foo.py", module.DEFAULT_INCLUDE, module.DEFAULT_EXCLUDE)
+    assert not module._is_eligible_path("graphistry/tests/test_foo.py", module.DEFAULT_INCLUDE, module.DEFAULT_EXCLUDE)
+    assert not module._is_eligible_path("bin/changed_line_coverage.py", module.DEFAULT_INCLUDE, module.DEFAULT_EXCLUDE)
+
+
+def test_build_report_passes_when_changed_statements_meet_threshold() -> None:
+    module = _load_module()
+    source = Path(module.REPO_ROOT) / "graphistry" / "__init__.py"
+
+    class FakeCov:
+        def analysis2(self, path: str) -> Any:
+            assert path == str(source)
+            return (path, [1, 2, 3], [], [3], "")
+
+    report = module._build_report(
+        cov=FakeCov(),
+        changed_lines={"graphistry/__init__.py": {1, 2, 3, 4}},
+        base_ref="base",
+        head_ref="head",
+        min_percent=60.0,
+        includes=module.DEFAULT_INCLUDE,
+        excludes=module.DEFAULT_EXCLUDE,
+    )
+
+    assert report.status == "pass"
+    assert report.changed_statement_lines == 3
+    assert report.covered_lines == 2
+    assert report.missing_lines == 1
+    assert report.coverage_percent == 66.67
+    assert report.files[0].missing_line_numbers == [3]
+
+
+def test_build_report_fails_below_threshold() -> None:
+    module = _load_module()
+    source = Path(module.REPO_ROOT) / "graphistry" / "__init__.py"
+
+    class FakeCov:
+        def analysis2(self, path: str) -> Any:
+            assert path == str(source)
+            return (path, [1, 2, 3, 4], [], [2, 3, 4], "")
+
+    report = module._build_report(
+        cov=FakeCov(),
+        changed_lines={"graphistry/__init__.py": {1, 2, 3, 4}},
+        base_ref="base",
+        head_ref="head",
+        min_percent=80.0,
+        includes=module.DEFAULT_INCLUDE,
+        excludes=module.DEFAULT_EXCLUDE,
+    )
+
+    assert report.status == "fail"
+    assert report.coverage_percent == 25.0


### PR DESCRIPTION
Closes #1533.

## Summary
- add `bin/changed_line_coverage.py` to report and gate coverage for changed executable package lines only
- reuse coverage collected in existing CI lanes: GFQL py3.12 coverage plus the py3.14 core-test leg, without adding coverage overhead to the 5-minute minimal sentinel
- add a PR-only combiner job that enforces an initial 80% changed-line threshold and uploads markdown/JSON reports

## Validation
- `python3 -m py_compile bin/changed_line_coverage.py bin/coverage_audit.py`
- `python3 -m pytest -q graphistry/tests/test_changed_line_coverage.py graphistry/tests/test_coverage_audit.py` (13 passed)
- `./bin/ruff.sh bin/changed_line_coverage.py graphistry/tests/test_changed_line_coverage.py`
- `./bin/typecheck.sh bin/changed_line_coverage.py`
- parsed `.github/workflows/ci.yml` with PyYAML
- `git diff --check`

## Notes
- CPU CI only; no DGX/RAPIDS validation needed because this changes CI hygiene and coverage reporting, not dataframe/GPU runtime behavior.
- Historical uncovered lines outside the PR diff remain non-blocking.
- The 5-minute `test-minimal-python` sentinel remains at 5 minutes and uninstrumented; changed-line coverage waits for later parallel/downstream coverage artifacts instead.
