### PR TITLE
Shrink GFQL physical dispatch route scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Internal
 - **GFQL IR metadata/verifier cleanup (#1566)**: Deleted the private `ir.metadata` helper layer, inlined the remaining nullable reads at IR consumers, and trimmed verifier helper scaffolding while preserving logical-plan verifier behavior.
+- **GFQL physical dispatch cleanup (#1565)**: Removed stale runtime coupling to physical-executor wrapper classes so dispatch keys off `PhysicalPlan.route`, while preserving the existing planner wrapper/metadata contract and same-path, row-pipeline, procedure-call, and wavefront route behavior.
 - **GFQL row pipeline cleanup tranche (#1557)**: Centralized private node entity/label text formatting in the row entity-props helpers, removed unused private ordering-family helpers, and DRYed duplicated row-pipeline pandas/cuDF regression fixtures while preserving runtime behavior.
 - **GFQL / Cypher binder fixture cleanup (#1556)**: Deleted stale strict-runtime binder baseline scaffolding, consolidated cross-kind rebind coverage, and trimmed binder expr-tree tests to public binder-consumption behavior while preserving validator/runtime parity coverage.
 - **GFQL policy/validation/rollout test cleanup (#1554)**: Consolidated duplicated policy shortcut and rollout gate test scaffolding while preserving public deprecated validation APIs and GFQL policy/rollout behavior.

--- a/graphistry/compute/gfql/physical_planner.py
+++ b/graphistry/compute/gfql/physical_planner.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Iterator, Literal, Mapping, Sequence, Tuple, Union
+from typing import Dict, Iterator, Literal, Sequence, Tuple, Union
 
 from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 from graphistry.compute.gfql.ir.compilation import PhysicalPlan, PlanContext

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -63,13 +63,7 @@ from graphistry.compute.dataframe import (
 )
 from graphistry.compute.gfql.ir.compilation import PhysicalPlan, PlanContext
 from graphistry.compute.gfql.ir.logical_plan import LogicalPlan
-from graphistry.compute.gfql.physical_planner import (
-    PhysicalPlanner,
-    ProcedureCallExecutorWrapper,
-    RowPipelineExecutorWrapper,
-    SamePathExecutorWrapper,
-    WavefrontExecutorWrapper,
-)
+from graphistry.compute.gfql.physical_planner import PhysicalPlanner
 from graphistry.compute.gfql.passes import DEFAULT_LOGICAL_PASSES, DEFAULT_TIER2_PASSES, PassManager
 from graphistry.compute.gfql.row.pipeline import is_row_pipeline_call
 from graphistry.compute.typing import DataFrameT, SeriesT
@@ -751,17 +745,6 @@ def _execute_compiled_query_via_physical_plan(
     connected_match_join = None if compiled_extras is None else compiled_extras.connected_match_join
     connected_optional_match = None if compiled_extras is None else compiled_extras.connected_optional_match
 
-    if len(physical_plan.operators) != 1:
-        raise GFQLValidationError(
-            ErrorCode.E108,
-            "PhysicalPlan currently requires exactly one operator wrapper in this lane",
-            field="physical_plan.operators",
-            value=len(physical_plan.operators),
-            suggestion="Use a covered single-operator M3 route or extend the runtime dispatcher.",
-            language="cypher",
-        )
-
-    operator = physical_plan.operators[0]
     if connected_match_join is not None:
         return _apply_connected_match_join(
             base_graph,
@@ -780,7 +763,7 @@ def _execute_compiled_query_via_physical_plan(
             context=context,
         )
 
-    if isinstance(operator, (SamePathExecutorWrapper, RowPipelineExecutorWrapper)):
+    if physical_plan.route in ("same_path", "row_pipeline"):
         return _execute_compiled_query_chain_non_union(
             base_graph,
             compiled_query=compiled_query,
@@ -790,7 +773,7 @@ def _execute_compiled_query_via_physical_plan(
             start_nodes=start_nodes,
         )
 
-    if isinstance(operator, ProcedureCallExecutorWrapper):
+    if physical_plan.route == "procedure_call":
         if compiled_query.procedure_call is None:
             raise GFQLValidationError(
                 ErrorCode.E108,
@@ -811,7 +794,7 @@ def _execute_compiled_query_via_physical_plan(
             start_nodes=start_nodes,
         )
 
-    if isinstance(operator, WavefrontExecutorWrapper):
+    if physical_plan.route == "wavefront":
         raise GFQLValidationError(
             ErrorCode.E108,
             "Cypher wavefront physical route selected but compiled query has no connected join payload to execute",
@@ -823,10 +806,10 @@ def _execute_compiled_query_via_physical_plan(
 
     raise GFQLValidationError(
         ErrorCode.E108,
-        "Cypher physical plan produced an unknown operator wrapper",
-        field="physical_plan.operator",
-        value=type(operator).__name__,
-        suggestion="Use a covered M3 wrapper type or extend the runtime dispatcher.",
+        "Cypher physical plan produced an unknown route",
+        field="physical_plan.route",
+        value=physical_plan.route,
+        suggestion="Use a covered M3 route or extend the runtime dispatcher.",
         language="cypher",
     )
 

--- a/graphistry/tests/compute/gfql/test_ir_compilation.py
+++ b/graphistry/tests/compute/gfql/test_ir_compilation.py
@@ -1,5 +1,5 @@
 from dataclasses import is_dataclass
-from typing import Any, get_args, get_origin, get_type_hints
+from typing import Any, get_args, get_type_hints
 
 
 def test_compilation_module_surface() -> None:
@@ -138,10 +138,27 @@ def test_compilation_state_is_mutable_dataclass() -> None:
     assert state.query_text.startswith("MATCH")
 
 
-def test_physical_plan_type_hints_resolve_runtime_forward_refs() -> None:
+def test_physical_plan_type_hints_expose_route_contract() -> None:
+    import graphistry.compute.gfql.ir.compilation as compilation
     from graphistry.compute.gfql.ir.compilation import PhysicalPlan
+    from graphistry.compute.gfql.physical_planner import PhysicalOperator
 
-    hints = get_type_hints(PhysicalPlan)
+    hints = get_type_hints(PhysicalPlan, globalns={**vars(compilation), "PhysicalOperator": PhysicalOperator})
 
-    assert "operators" in hints
-    assert get_origin(hints["operators"]) is tuple
+    assert set(get_args(hints["route"])) == {"same_path", "wavefront", "row_pipeline", "procedure_call"}
+    assert get_args(hints["operators"])[0] is PhysicalOperator
+
+
+def test_physical_planner_exports_wrapper_compatibility_shims() -> None:
+    import graphistry.compute.gfql.physical_planner as physical_planner
+
+    expected = {
+        "PhysicalOperator",
+        "PhysicalPlanner",
+        "ProcedureCallExecutorWrapper",
+        "RowPipelineExecutorWrapper",
+        "SamePathExecutorWrapper",
+        "WavefrontExecutorWrapper",
+    }
+
+    assert set(physical_planner.__all__) == expected

--- a/graphistry/tests/compute/gfql/test_runtime_physical_cutover.py
+++ b/graphistry/tests/compute/gfql/test_runtime_physical_cutover.py
@@ -16,13 +16,7 @@ from graphistry.compute.gfql.defer_codes import (
 )
 from graphistry.compute.gfql.ir.compilation import PhysicalPlan
 from graphistry.compute.gfql.ir.logical_plan import PatternMatch, iter_children
-from graphistry.compute.gfql.physical_planner import (
-    PhysicalPlanner,
-    ProcedureCallExecutorWrapper,
-    RowPipelineExecutorWrapper,
-    SamePathExecutorWrapper,
-    WavefrontExecutorWrapper,
-)
+from graphistry.compute.gfql.physical_planner import PhysicalPlanner
 
 
 def _mk_graph():
@@ -73,7 +67,7 @@ def _assert_runtime_missing_logical_plan_context(
         assert "logical_plan_defer_reason" not in exc.context
 
 
-def _spy_physical_routes(monkeypatch, wrapper_cls=None, *, optional_only=False):
+def _spy_physical_routes(monkeypatch, *, optional_only=False):
     routes = []
     original_plan = PhysicalPlanner.plan
 
@@ -81,8 +75,6 @@ def _spy_physical_routes(monkeypatch, wrapper_cls=None, *, optional_only=False):
         physical_plan = original_plan(self, logical_plan, ctx)
         if not optional_only or _has_optional_pattern_match(logical_plan):
             routes.append(physical_plan.route)
-            if wrapper_cls is not None:
-                assert isinstance(physical_plan.operators[0], wrapper_cls)
         return physical_plan
 
     monkeypatch.setattr(PhysicalPlanner, "plan", _spy_plan)
@@ -98,23 +90,18 @@ def _assert_planned_query(query: str) -> None:
 
 def _assert_same_path_rows(monkeypatch, query: str, expected_rows, *, graph=None):
     _assert_planned_query(query)
-    routes = _spy_physical_routes(monkeypatch, SamePathExecutorWrapper)
+    routes = _spy_physical_routes(monkeypatch)
     result = (graph or _mk_graph()).gfql(query)
     assert routes == ["same_path"]
     assert result._nodes.to_dict(orient="records") == expected_rows
 
 
-def _force_physical_route(monkeypatch, route, wrapper):
+def _force_physical_route(monkeypatch, route):
     planner_calls = []
 
     def _force_plan(self, logical_plan, ctx):
         planner_calls.append(type(logical_plan).__name__)
-        return PhysicalPlan(
-            route=route,
-            operators=(wrapper(),),
-            logical_op_ids=(),
-            metadata={},
-        )
+        return PhysicalPlan(route=route)
 
     monkeypatch.setattr(PhysicalPlanner, "plan", _force_plan)
     return planner_calls
@@ -157,7 +144,7 @@ def test_gfql_wavefront_optional_match_parity():
 
 def test_call_route_uses_procedure_physical_route(monkeypatch):
     g = _mk_graph()
-    planner_routes = _spy_physical_routes(monkeypatch, ProcedureCallExecutorWrapper)
+    planner_routes = _spy_physical_routes(monkeypatch)
     result = g.gfql("CALL graphistry.degree() RETURN degree ORDER BY degree")
 
     assert planner_routes == ["procedure_call"]
@@ -166,7 +153,7 @@ def test_call_route_uses_procedure_physical_route(monkeypatch):
 
 def test_top_level_optional_match_matched_case_uses_same_path_physical_route(monkeypatch):
     g = _mk_graph()
-    planner_routes = _spy_physical_routes(monkeypatch, SamePathExecutorWrapper)
+    planner_routes = _spy_physical_routes(monkeypatch)
     result = g.gfql("OPTIONAL MATCH (n) RETURN n.id AS id ORDER BY id")
 
     assert planner_routes == ["same_path"]
@@ -177,7 +164,7 @@ def test_top_level_optional_match_unmatched_case_null_extends_via_same_path_rout
     nodes = pd.DataFrame({"id": ["a", "b", "c"], "label__Missing": [False, False, False]})
     edges = pd.DataFrame({"s": ["a", "b"], "d": ["b", "c"]})
     g = graphistry.bind(source="s", destination="d", node="id").nodes(nodes).edges(edges)
-    planner_routes = _spy_physical_routes(monkeypatch, SamePathExecutorWrapper)
+    planner_routes = _spy_physical_routes(monkeypatch)
     result = g.gfql("OPTIONAL MATCH (n:Missing) RETURN n.id AS id")
     rows = result._nodes.reset_index(drop=True)
 
@@ -188,7 +175,7 @@ def test_top_level_optional_match_unmatched_case_null_extends_via_same_path_rout
 
 def test_optional_reentry_route_uses_same_path_and_null_fills(monkeypatch):
     g = _mk_graph()
-    optional_routes = _spy_physical_routes(monkeypatch, SamePathExecutorWrapper, optional_only=True)
+    optional_routes = _spy_physical_routes(monkeypatch, optional_only=True)
     result = g.gfql(
         "MATCH (a) WITH a, a.id AS aid "
         "OPTIONAL MATCH (a)-->(b) "
@@ -208,7 +195,7 @@ def test_optional_reentry_route_uses_same_path_when_all_rows_match(monkeypatch):
     nodes = pd.DataFrame({"id": ["a", "b"]})
     edges = pd.DataFrame({"s": ["a", "b"], "d": ["b", "a"]})
     g = graphistry.bind(source="s", destination="d", node="id").nodes(nodes).edges(edges)
-    optional_routes = _spy_physical_routes(monkeypatch, SamePathExecutorWrapper, optional_only=True)
+    optional_routes = _spy_physical_routes(monkeypatch, optional_only=True)
     result = g.gfql(
         "MATCH (a) WITH a "
         "OPTIONAL MATCH (a)-->(b) "
@@ -225,7 +212,7 @@ def test_optional_reentry_route_uses_same_path_when_all_rows_match(monkeypatch):
 
 def test_same_path_route_uses_same_path_physical_route(monkeypatch):
     g = _mk_graph()
-    planner_routes = _spy_physical_routes(monkeypatch, SamePathExecutorWrapper)
+    planner_routes = _spy_physical_routes(monkeypatch)
     result = g.gfql("MATCH (n) RETURN n.id AS id ORDER BY id")
 
     assert planner_routes == ["same_path"]
@@ -234,7 +221,7 @@ def test_same_path_route_uses_same_path_physical_route(monkeypatch):
 
 def test_row_pipeline_route_uses_row_pipeline_physical_route(monkeypatch):
     g = _mk_graph()
-    planner_routes = _spy_physical_routes(monkeypatch, RowPipelineExecutorWrapper)
+    planner_routes = _spy_physical_routes(monkeypatch)
     result = g.gfql("RETURN 1 AS x")
 
     assert planner_routes == ["row_pipeline"]
@@ -435,12 +422,7 @@ def test_wavefront_route_without_join_payload_raises(monkeypatch):
     g = _mk_graph()
 
     def _force_wavefront_plan(self, logical_plan, ctx):
-        return PhysicalPlan(
-            route="wavefront",
-            operators=(WavefrontExecutorWrapper(),),
-            logical_op_ids=(),
-            metadata={},
-        )
+        return PhysicalPlan(route="wavefront")
 
     monkeypatch.setattr(PhysicalPlanner, "plan", _force_wavefront_plan)
 
@@ -460,7 +442,7 @@ def test_connected_match_join_uses_physical_route(monkeypatch):
         "type": ["IS_LOCATED_IN", "IS_LOCATED_IN"],
     })
     g = graphistry.bind(source="s", destination="d", node="id").nodes(nodes).edges(edges)
-    planner_calls = _force_physical_route(monkeypatch, "row_pipeline", RowPipelineExecutorWrapper)
+    planner_calls = _force_physical_route(monkeypatch, "row_pipeline")
 
     result = g.gfql(
         "MATCH "
@@ -475,7 +457,7 @@ def test_connected_match_join_uses_physical_route(monkeypatch):
 
 def test_connected_optional_match_uses_physical_route(monkeypatch):
     g = _mk_graph()
-    planner_calls = _force_physical_route(monkeypatch, "row_pipeline", RowPipelineExecutorWrapper)
+    planner_calls = _force_physical_route(monkeypatch, "row_pipeline")
 
     result = g.gfql(
         "MATCH (a)-->(b) "


### PR DESCRIPTION
Closes #1565.

## Summary
- Remove stale runtime coupling to physical executor wrapper classes in GFQL execution.
- Dispatch compiled Cypher execution by the existing `PhysicalPlan.route` contract while preserving connected-match payload precedence and procedure-call validation.
- Preserve compiler-plan architecture and compatibility surfaces: `PhysicalPlan.operators`, `logical_op_ids`, `metadata`, `PhysicalOperator`, wrapper classes, route names, planner wrapper construction, pass/defer/diagnostic/schema hooks, and public exports remain intact.

## Coordinator Boundary
This PR does **not** delete compiler-plan architecture. It does not remove logical/physical planning contracts, route names, dispatch semantics, pass/verifier extension points, defer-code/source-span/diagnostic context, schema/type hooks, remote-schema hooks, or public compatibility shims.

Candidate wrapper deletion was flagged and not cut because the wrappers are exported and may be part of the compiler/type/remote plan. Final production cleanup is limited to stale runtime wrapper-dispatch residue.

## LOC Receipt
- Production code: `+9 / -26`, net `-17` LOC
  - `graphistry/compute/gfql_unified.py`: `+8 / -25`
  - `graphistry/compute/gfql/physical_planner.py`: `+1 / -1` unused import cleanup only
- Tests: `+37 / -38`, net `-1` LOC
- Changelog/docs: `CHANGELOG.md` `+1 / -0`

This is intentionally below the original 300-600 LOC target after applying the coordinator boundary correction. The larger deletion candidate would have removed exported physical-planner wrapper/typing surfaces, so it was not cut.

## Validation
- `PYTHONPATH=/home/lmeyerov/Work/pygraphistry3 python3 -m pytest /home/lmeyerov/Work/pygraphistry3/graphistry/tests/compute/gfql/test_runtime_physical_cutover.py /home/lmeyerov/Work/pygraphistry3/graphistry/tests/compute/gfql/test_ir_compilation.py -q -k 'not cudf'`
  - `39 passed, 1 deselected`
- `/home/lmeyerov/Work/pygraphistry3/bin/typecheck.sh graphistry/compute/gfql/ir/compilation.py graphistry/compute/gfql/physical_planner.py graphistry/compute/gfql_unified.py`
  - `Success: no issues found in 3 source files`
- `/home/lmeyerov/Work/pygraphistry3/bin/ruff.sh graphistry/compute/gfql/ir/compilation.py graphistry/compute/gfql/physical_planner.py graphistry/compute/gfql_unified.py graphistry/tests/compute/gfql/test_ir_compilation.py graphistry/tests/compute/gfql/test_runtime_physical_cutover.py`
  - `Ruff check completed successfully`
- `PYTHONPATH=/home/lmeyerov/Work/pygraphistry3 python3 -m py_compile /home/lmeyerov/Work/pygraphistry3/graphistry/compute/gfql/ir/compilation.py /home/lmeyerov/Work/pygraphistry3/graphistry/compute/gfql/physical_planner.py /home/lmeyerov/Work/pygraphistry3/graphistry/compute/gfql_unified.py`
  - ok
- `git -C /home/lmeyerov/Work/pygraphistry3 diff --check`
  - ok
- Earlier DGX targeted cuDF route smoke before boundary correction:
  - RAPIDS 25.02: `1 passed`
  - RAPIDS 26.02: `1 passed`
  - The correction restored planner metadata/wrappers and did not change cuDF dataframe behavior.

## Review
- Review skill previously converged after compatibility concerns were found.
- Coordinator boundary correction applied afterward; wrapper/plan compatibility surfaces are now preserved and covered by tests.
