### PR TITLE
infra(ci): cancel stale branch workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 
   #Regular dev
   push:
+    branches:
+      - master
   pull_request:
 
   #Enable UI-driven branch testing
@@ -22,6 +24,12 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  # Cancel stale same-branch PR/manual runs. Branch push CI is master-only;
+  # branch validation happens via pull_request or workflow_dispatch.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   # 6-day dependency cooldown: refuse packages uploaded less than 6 days ago
@@ -41,6 +49,7 @@ jobs:
       gfql: ${{ steps.filter.outputs.gfql }}
       cypher_frontend_ci: ${{ steps.filter.outputs.cypher_frontend_ci }}
       benchmarks: ${{ steps.filter.outputs.benchmarks }}
+      ai: ${{ steps.filter.outputs.ai }}
       docs_only_latest: ${{ steps.docs_only_latest.outputs.docs_only_latest }}
     steps:
     - uses: actions/checkout@v4
@@ -58,7 +67,7 @@ jobs:
         HEAD_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
-        keys=(infra python spark gfql cypher_frontend_ci benchmarks docs)
+        keys=(infra python spark gfql cypher_frontend_ci benchmarks ai docs)
 
         emit_all() {
           # $1 = "true" or "false" — emit the same value for every key
@@ -189,6 +198,33 @@ jobs:
         emit benchmarks \
           '^benchmarks/'
 
+        # AI/UMAP/text featurization lanes. Keep shared public entrypoints and
+        # dependency lock generation conservative; GFQL-only internals should
+        # not drag the expensive AI matrix unless they touch UMAP/CALL surfaces.
+        emit ai \
+          '^setup\.py$' \
+          '^\.github/workflows/ci\.yml$' \
+          '^bin/generate-lockfiles\.sh$' \
+          '^bin/test-(ai|features|umap-learn-core|text|dbscan|embed|dgl)\.sh$' \
+          '^graphistry/Plottable\.py$' \
+          '^graphistry/PlotterBase\.py$' \
+          '^graphistry/Engine\.py$' \
+          '^graphistry/compute/chain\.py$' \
+          '^graphistry/compute/cluster\.py$' \
+          '^graphistry/dgl_utils\.py$' \
+          '^graphistry/feature_utils\.py$' \
+          '^graphistry/features\.py$' \
+          '^graphistry/networks\.py$' \
+          '^graphistry/text_utils\.py$' \
+          '^graphistry/umap_utils\.py$' \
+          '^graphistry/utils/lazy_import\.py$' \
+          '^graphistry/plugins_types/(embed|umap)_types\.py$' \
+          '^graphistry/compute/gfql/call/' \
+          '^graphistry/tests/test_(compute_cluster|feature_utils|text_utils|umap_utils)\.py$' \
+          '^graphistry/tests/compute/test_call_engine_coercion\.py$' \
+          '^graphistry/tests/data/reddit\.csv$' \
+          '^requirements/(test-ai|test-umap)-py.*\.lock$'
+
         # Documentation: docs tree + any md/rst at any depth + demos + notebooks.
         emit docs \
           '^docs/' \
@@ -259,7 +295,7 @@ jobs:
 
   generate-lockfiles:
     needs: changes
-    if: ${{ needs.changes.outputs.python == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    if: ${{ needs.changes.outputs.python == 'true' || needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -433,7 +469,7 @@ jobs:
   python-lint-types:
     needs: [changes, generate-lockfiles]
     # Run if Python files changed OR infrastructure changed OR manual/scheduled run
-    if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
+    if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     
@@ -604,7 +640,7 @@ jobs:
     # run in test-minimal-python-rest alongside the middle versions (3.9-3.13).
     needs: [changes, python-lint-types, generate-lockfiles]
     # Run if Python files changed OR infrastructure changed OR manual/scheduled run
-    if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
+    if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -724,7 +760,7 @@ jobs:
   # Runs in parallel with downstream jobs instead of blocking them.
   test-gfql-core:
     needs: [changes, python-lint-types, generate-lockfiles]
-    if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.gfql == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
+    if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.gfql == 'true' || needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -1193,9 +1229,8 @@ jobs:
         ./bin/test-polars.sh
 
   test-core-umap:
-    needs: [ test-minimal-python, test-gfql-core, generate-lockfiles ]
-    # Inherit condition from test-minimal-python
-    if: ${{ success() }}
+    needs: [changes, test-minimal-python, test-gfql-core, generate-lockfiles]
+    if: ${{ success() && (needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -1315,9 +1350,8 @@ jobs:
         ./bin/test-umap-learn-core.sh
 
   test-full-ai:
-    needs: [ test-minimal-python, test-gfql-core, generate-lockfiles ]
-    # Inherit condition from test-minimal-python
-    if: ${{ success() }}
+    needs: [changes, test-minimal-python, test-gfql-core, generate-lockfiles]
+    if: ${{ success() && (needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

Optimizes the common PR CI path while preserving the budget-protecting staged gates.

- Restricts `push` CI to `master`; same-repo branch validation now runs through `pull_request` or `workflow_dispatch`.
- Keeps top-level concurrency for stale PR/manual runs, without relying on cancelled branch-push runs as the duplicate-control mechanism.
- Adds a conservative `ai` path-filter dimension and uses it to skip `test-full-ai` + `test-core-umap` on non-AI Python/GFQL changes.
- Keeps AI-owned data/lock/script changes behind the existing cheap sentinels by including `ai` in `generate-lockfiles`, `python-lint-types`, `test-minimal-python`, and `test-gfql-core`.

## Audit Evidence

Recent successful PR CI sample:

- 15 successful PR runs averaged ~11.15m wall-clock and ~105.35 runner-minutes.
- Representative current full/infra run `26180763638`: 12.72m wall-clock, 105.73 runner-minutes, 68 jobs.
- Critical tail on that run: `test-full-ai (3.9)` ended at 12.70m.
- Largest runner-minute families on that run:
  - `test-full-ai`: 23.43 runner-minutes
  - `test-core-python`: 21.48 runner-minutes
  - `test-minimal-python-rest`: 10.63 runner-minutes
  - `test-gfql-core`: 7.70 runner-minutes
  - `test-docs`: 6.38 runner-minutes
  - `tck-gfql`: 5.47 runner-minutes
  - `test-core-umap`: 4.72 runner-minutes

Duplicate run/day evidence as of 2026-05-20 18Z:

- 93 recent CI runs today: 38 PR runs, 55 push runs.
- 45 non-master branch push runs and 38 same-head push+PR pairs.
- Completed non-master branch push runs today: 42 runs, 3364.43 runner-minutes total, 104.65 runner-minute median.
- Completed PR runs today: 36 runs, 2997.03 runner-minutes total, 98.37 runner-minute median.

Expected impact:

- Typical same-repo PR push: removes the duplicate branch-push run entirely, cutting consumed runner-minutes from roughly ~210 to ~105 for full Python/GFQL PRs, while avoiding stale cancelled `push` checks in the PR rollup.
- Typical GFQL/internal PR after this PR lands: additionally skips `test-full-ai` + `test-core-umap` unless AI/UMAP/CALL/public-entrypoint/infra paths changed, saving ~28 runner-minutes and removing the current `test-full-ai` critical tail.
- Typical day from today’s sample: removing non-master branch push CI alone would save ~3364 runner-minutes from the measured 2026-05-20 workload, roughly half of the PR+branch-push development CI spend.

## Safety

- Does not weaken merge-to-master CI.
- Does not fan out expensive jobs earlier; lint/type/minimal/GFQL sentinels still gate bigger work.
- This PR touches `ci.yml`, so `infra=true` and the full matrix still validates the workflow change before rollout.
- `workflow_dispatch` remains available for explicit branch validation.
- No changelog entry: CI runtime-only maintenance.

## Validation

- `git diff --check`
- YAML parsed with local PyYAML
- Review skill wave 4:
  - credentials gate clean
  - path-filter spot checks:
    - `graphistry/compute/gfql/cypher/lowering.py ai=false`
    - `graphistry/compute/gfql/call/validation.py ai=true`
    - `graphistry/umap_utils.py ai=true`
    - `.github/workflows/ci.yml ai=true`
  - fixed AI data/lockfile sentinel edge case before push
