### PR TITLE
infra(ci): slim minimal Python GFQL coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,8 +636,7 @@ jobs:
 
   test-minimal-python:
     # Lite sentinel: oldest + newest Python only, heavy test files excluded. Gates all downstream.
-    # Heavy deferred files (test_hyper_dask, test_compute_chain, test_chain_let, test_hop, test_plotter)
-    # run in test-minimal-python-rest alongside the middle versions (3.9-3.13).
+    # Non-GFQL deferred files run in test-minimal-python-rest; GFQL-heavy files run in test-gfql-core.
     needs: [changes, python-lint-types, generate-lockfiles]
     # Run if Python files changed OR infrastructure changed OR manual/scheduled run
     if: ${{ (needs.changes.outputs.python == 'true' || needs.changes.outputs.ai == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && !(needs.changes.outputs.docs_only_latest == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')) }}
@@ -702,11 +701,11 @@ jobs:
         echo "- cypher-frontend-strict-typing (py3.12)"
         echo "- cypher-frontend-differential-parity (py3.12)"
         echo "- cypher-frontend-surface-guard"
-        echo "- test-minimal-python (full-suite sentinel gate)"
+        echo "- test-minimal-python (lite sentinel gate)"
 
 
   test-minimal-python-rest:
-    # Middle versions (3.9-3.13) + deferred heavy files, run after sentinel passes in parallel with downstream.
+    # Middle versions (3.9-3.13) + non-GFQL deferred files, run after sentinel + GFQL core pass.
     needs: [changes, test-minimal-python, test-gfql-core, generate-lockfiles]
     if: ${{ success() }}
     runs-on: ubuntu-latest
@@ -750,7 +749,7 @@ jobs:
       run: |
         ./docker/test-pip-install.sh
 
-    - name: Minimal full tests (includes deferred heavy files from sentinel)
+    - name: Minimal rest tests (middle versions and non-GFQL deferred files)
       run: |
         source pygraphistry/bin/activate
         ./bin/test-minimal.sh -n auto
@@ -803,13 +802,22 @@ jobs:
         COVERAGE_FILE=build/gfql-coverage-audit/coverage.gfql-py3.12 python -B -m pytest -vv -n auto \
           --cov=graphistry/compute \
           --cov-report= \
+          graphistry/tests/benchmarks/gfql \
           graphistry/tests/compute/test_ast.py \
           graphistry/tests/compute/test_chain.py \
           graphistry/tests/compute/test_chain_let.py \
           graphistry/tests/compute/test_chain_concat.py \
           graphistry/tests/compute/test_dataframe_primitives.py \
+          graphistry/tests/compute/test_gfql.py \
+          graphistry/tests/compute/test_gfql_call_validation.py \
+          graphistry/tests/compute/test_gfql_exceptions.py \
+          graphistry/tests/compute/test_gfql_hypergraph.py \
+          graphistry/tests/compute/test_gfql_validate_only.py \
+          graphistry/tests/compute/test_gfql_validation.py \
           graphistry/tests/compute/test_hop.py \
           graphistry/tests/compute/gfql \
+          graphistry/tests/test_gfql_remote_metadata.py \
+          graphistry/tests/test_gfql_remote_persistence.py \
           tests/gfql/ref
         python bin/coverage_audit.py \
           --profile gfql \
@@ -838,8 +846,17 @@ jobs:
           graphistry/tests/compute/test_chain_let.py \
           graphistry/tests/compute/test_chain_concat.py \
           graphistry/tests/compute/test_dataframe_primitives.py \
+          graphistry/tests/benchmarks/gfql \
+          graphistry/tests/compute/test_gfql.py \
+          graphistry/tests/compute/test_gfql_call_validation.py \
+          graphistry/tests/compute/test_gfql_exceptions.py \
+          graphistry/tests/compute/test_gfql_hypergraph.py \
+          graphistry/tests/compute/test_gfql_validate_only.py \
+          graphistry/tests/compute/test_gfql_validation.py \
           graphistry/tests/compute/test_hop.py \
           graphistry/tests/compute/gfql \
+          graphistry/tests/test_gfql_remote_metadata.py \
+          graphistry/tests/test_gfql_remote_persistence.py \
           tests/gfql/ref
 
     - name: T5 rollout gate — execution-path canary (env=true)

--- a/bin/test-minimal-lite.sh
+++ b/bin/test-minimal-lite.sh
@@ -4,19 +4,31 @@ set -ex
 # Fast sentinel gate: runs the minimal suite minus the heaviest test files.
 # Target: <60s. Gates all downstream CI jobs.
 #
-# Excluded from this script (deferred to test-minimal-python-rest pool):
+# Excluded from this script (deferred to test-minimal-python-rest or test-gfql-core):
 #   test_hyper_dask.py       — heavy dask.distributed / LocalCUDACluster setup
 #   test_compute_chain.py    — large suite (~78 tests)
 #   compute/test_chain_let.py — largest suite (~91 tests)
 #   compute/test_hop.py       — 8x parametrize combinatorics (~54 tests)
 #   test_plotter.py           — large suite with dask refs (~61 tests)
+#   GFQL/core/ref tests       — dedicated test-gfql-core owner
 #
 # Run from project root
 # Args get passed to pytest
 
-python -m pytest --version
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+    if command -v python >/dev/null 2>&1; then
+        PYTHON_BIN=python
+    else
+        PYTHON_BIN=python3
+    fi
+fi
 
-python -B -m pytest -vv \
+"$PYTHON_BIN" -m pytest --version
+
+"$PYTHON_BIN" -B -m pytest -vv \
+    --ignore=plans \
+    --ignore=test_env \
     --ignore=graphistry/tests/test_bolt_util.py \
     --ignore=graphistry/tests/test_gremlin.py \
     --ignore=graphistry/tests/test_ipython.py \
@@ -28,9 +40,21 @@ python -B -m pytest -vv \
     --ignore=graphistry/tests/test_embed_utils.py \
     --ignore=graphistry/tests/test_kusto.py \
     --ignore=graphistry/tests/test_spanner.py \
-    --ignore=graphistry/tests/compute/gfql/cypher/test_lowering.py \
-    --ignore=graphistry/tests/compute/gfql/test_row_pipeline_ops.py \
-    --ignore=graphistry/tests/compute/gfql/cypher/test_parser.py \
+    --ignore=graphistry/tests/benchmarks/gfql \
+    --ignore=graphistry/tests/compute/gfql \
+    --ignore=graphistry/tests/compute/test_ast.py \
+    --ignore=graphistry/tests/compute/test_chain.py \
+    --ignore=graphistry/tests/compute/test_chain_concat.py \
+    --ignore=graphistry/tests/compute/test_dataframe_primitives.py \
+    --ignore=graphistry/tests/compute/test_gfql.py \
+    --ignore=graphistry/tests/compute/test_gfql_call_validation.py \
+    --ignore=graphistry/tests/compute/test_gfql_exceptions.py \
+    --ignore=graphistry/tests/compute/test_gfql_hypergraph.py \
+    --ignore=graphistry/tests/compute/test_gfql_validate_only.py \
+    --ignore=graphistry/tests/compute/test_gfql_validation.py \
+    --ignore=graphistry/tests/test_gfql_remote_metadata.py \
+    --ignore=graphistry/tests/test_gfql_remote_persistence.py \
+    --ignore=tests/gfql/ref \
     --ignore=graphistry/tests/test_hyper_dask.py \
     --ignore=graphistry/tests/test_compute_chain.py \
     --ignore=graphistry/tests/test_plotter.py \

--- a/bin/test-minimal.sh
+++ b/bin/test-minimal.sh
@@ -7,9 +7,20 @@ set -ex
 
 # Assume minimal env (pandas); no extras (neo4j, gremlin, ...)
 
-python -m pytest --version
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+    if command -v python >/dev/null 2>&1; then
+        PYTHON_BIN=python
+    else
+        PYTHON_BIN=python3
+    fi
+fi
 
-python -B -m pytest -vv \
+"$PYTHON_BIN" -m pytest --version
+
+"$PYTHON_BIN" -B -m pytest -vv \
+    --ignore=plans \
+    --ignore=test_env \
     --ignore=graphistry/tests/test_bolt_util.py \
     --ignore=graphistry/tests/test_gremlin.py \
     --ignore=graphistry/tests/test_ipython.py \
@@ -21,7 +32,21 @@ python -B -m pytest -vv \
     --ignore=graphistry/tests/test_embed_utils.py \
     --ignore=graphistry/tests/test_kusto.py \
     --ignore=graphistry/tests/test_spanner.py \
-    --ignore=graphistry/tests/compute/gfql/cypher/test_lowering.py \
-    --ignore=graphistry/tests/compute/gfql/test_row_pipeline_ops.py \
-    --ignore=graphistry/tests/compute/gfql/cypher/test_parser.py \
+    --ignore=graphistry/tests/benchmarks/gfql \
+    --ignore=graphistry/tests/compute/gfql \
+    --ignore=graphistry/tests/compute/test_ast.py \
+    --ignore=graphistry/tests/compute/test_chain.py \
+    --ignore=graphistry/tests/compute/test_chain_concat.py \
+    --ignore=graphistry/tests/compute/test_chain_let.py \
+    --ignore=graphistry/tests/compute/test_dataframe_primitives.py \
+    --ignore=graphistry/tests/compute/test_gfql.py \
+    --ignore=graphistry/tests/compute/test_gfql_call_validation.py \
+    --ignore=graphistry/tests/compute/test_gfql_exceptions.py \
+    --ignore=graphistry/tests/compute/test_gfql_hypergraph.py \
+    --ignore=graphistry/tests/compute/test_gfql_validate_only.py \
+    --ignore=graphistry/tests/compute/test_gfql_validation.py \
+    --ignore=graphistry/tests/compute/test_hop.py \
+    --ignore=graphistry/tests/test_gfql_remote_metadata.py \
+    --ignore=graphistry/tests/test_gfql_remote_persistence.py \
+    --ignore=tests/gfql/ref \
     "$@"


### PR DESCRIPTION
## Summary

Closes #1049. Coordinates #944.

This finishes the minimal-lane split on top of the current post-#1573 baseline:

- move remaining GFQL/ref/chain-heavy test surfaces out of `test-minimal-python` / `test-minimal-python-rest`
- keep that coverage in the dedicated `test-gfql-core` job
- keep the existing uv lockfile install path, with timing evidence below
- make `bin/test-minimal*.sh` runnable in local shells that only have `python3`, and ignore local-only `plans/` / `test_env/` work areas

## Before / after evidence

| Metric | Before | After / expected | Evidence |
|---|---:|---:|---|
| `test-minimal-python` lite collection | 3510 tests | 1846 tests | Local pre-split run observed 3510 collected; post-split `./bin/test-minimal-lite.sh --collect-only -q` collected 1846 in 9.80s |
| `test-minimal-python-rest` collection | broad minimal + deferred heavy/GFQL residue | 2082 tests | Post-split `./bin/test-minimal.sh --collect-only -q` collected 2082 in 10.03s |
| Dedicated GFQL owner | partial GFQL owner | 3309 tests | Post-split dedicated GFQL target list collected 3309 in 7.01s |
| Current CI lite pytest step | 68-85s | should drop after smaller collection | Recent runs: 26183296654, 26183832524, 26184435876 |
| Current CI uv install step | 8-13s | unchanged; keep uv | Recent minimal/lint/GFQL jobs install from generated uv lockfiles in ~8-13s |
| Old pip-era minimal overhead | ~59s non-pytest overhead | current uv+Docker path ~31-36s | #944 baseline vs recent CI step timings |

## Heaviest / moved surfaces

Moved out of the minimal lanes and into `test-gfql-core`:

- `graphistry/tests/compute/gfql/**`
- `tests/gfql/ref/**`
- `graphistry/tests/compute/test_ast.py`
- `graphistry/tests/compute/test_chain.py`
- `graphistry/tests/compute/test_chain_let.py`
- `graphistry/tests/compute/test_chain_concat.py`
- `graphistry/tests/compute/test_dataframe_primitives.py`
- `graphistry/tests/compute/test_hop.py`
- public GFQL API/validation/remote tests: `graphistry/tests/compute/test_gfql*.py`, `graphistry/tests/test_gfql_remote_*.py`
- `graphistry/tests/benchmarks/gfql/**`

Coverage is not removed; it is owned by the GFQL job that already runs alongside the post-minimal matrix.

## uv evaluation

Current `origin/master` already uses generated uv lockfiles for the minimal lane:

```text
python -m pip install --upgrade pip uv
uv pip install --require-hashes -r requirements/test-py${version}.lock
uv pip install -e . --no-deps
```

Recent CI timing shows install steps are no longer the dominant minimal-lane cost: roughly 8-13s in lint/minimal/GFQL jobs. The old #944 baseline had roughly 59s non-pytest overhead including pip/install/Docker work, so this PR keeps uv and focuses the remaining win on shrinking the pytest surface.

## Validation

- [x] `git diff --check`
- [x] `bash -n bin/test-minimal.sh`
- [x] `bash -n bin/test-minimal-lite.sh`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml ok')"`
- [x] credentials diff scan clean
- [x] `./bin/test-minimal-lite.sh --collect-only -q` -> 1846 tests
- [x] `./bin/test-minimal.sh --collect-only -q` -> 2082 tests
- [x] dedicated GFQL target collect-only -> 3309 tests
- [ ] PR CI green

Local full execution is intentionally not used as final timing proof here: this workstation has cudf/text extras installed but no GPU, while CI minimal uses generated lockfiles without those extras. PR CI is the authoritative wall-clock measurement.

## Notes

DGX RAPIDS testing is not required for this PR: no runtime code or cuDF behavior changed; only CI test ownership changed.
