### PR TITLE
Fix GFQL chain tag fillna warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL policy / Cypher compiler hooks (#1454)**: Added experimental exact-key `precompile` and `postcompile` policy hooks for local Cypher string-query compilation. `postcompile` reports success or failure using the existing policy `success`, `error`, and `error_type` fields plus a stable `CompileSummary` with scalar compiler metadata.
 
 ### Changed
+- **GFQL chain tag warning cleanup (#877)**: Avoided pandas object-dtype `fillna()` downcast warnings when merging named chain tag columns without warning filters or behavior changes.
 - **GFQL temporal implementation shrink (#1563)**: DRYed temporal value timezone/scalar helpers, shared duration token parsing and day-time duration formatting ownership, and separated temporal AST traversal from constructor-folding decisions while preserving `temporal_text` compatibility and runtime behavior.
 - **Legacy API-key compatibility deprecation (#1539)**: Deprecated the removed api=1 `api_key()` compatibility surface so explicit key use warns and is ignored, stale `GRAPHISTRY_API_KEY` environment values are not loaded, api=1/2 fail locally before upload, and remote integration docs now point to api=3 JWT or personal key ID/secret authentication.
 - **GFQL Cypher reentry cleanup (#1555)**: DRYed duplicated carried-endpoint reentry flattening tests and direct reentry carrier backend tests, and trimmed stale private reentry helper export/comment scaffolding while preserving runtime behavior.

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -355,7 +355,7 @@ def combine_steps(
             out_df = safe_merge(out_df, step_df, on=id, how='left', engine=engine)
             x_name, y_name = f'{op._name}_x', f'{op._name}_y'
             if x_name in out_df.columns and y_name in out_df.columns:
-                out_df[op._name] = out_df[x_name].fillna(out_df[y_name])
+                out_df[op._name] = out_df[x_name].where(out_df[x_name].notna(), out_df[y_name])
                 out_df = out_df.drop(columns=[x_name, y_name])
             label_col = out_df[op._name]
             if engine == Engine.PANDAS:

--- a/graphistry/tests/test_compute_chain.py
+++ b/graphistry/tests/test_compute_chain.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Dict, List
 import logging
+import warnings
 import pandas as pd
 
 from common import NoAuthTestCase
@@ -143,6 +144,27 @@ class TestComputeChainMixin(NoAuthTestCase):
         assert sorted(g2._edges[ g2._edges.e2 ][g2._source].to_list()) == ["g", "l"]
         assert sorted(g2._edges[ g2._edges.e2 ][g2._destination].to_list()) == ["a", "b"]
         assert sorted(g2._nodes[ g2._nodes.n2 ][g2._node].to_list()) == ["a", "b"]
+
+    def test_chain_named_tags_no_fillna_futurewarning(self):
+        g = hops_graph()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", FutureWarning)
+            g2 = g.gfql([
+                n({g._node: "e"}, name="n1"),
+                e_forward({}, hops=1),
+                e_forward({}, hops=1, name="e2"),
+                n(name="n2"),
+            ])
+
+        downcast_warnings = [
+            warning for warning in caught
+            if "Downcasting object dtype arrays on .fillna" in str(warning.message)
+        ]
+        assert downcast_warnings == []
+        assert g2._nodes[g2._nodes.n1][g2._node].to_list() == ["e"]
+        assert sorted(g2._edges[g2._edges.e2][g2._source].to_list()) == ["g", "l"]
+        assert sorted(g2._nodes[g2._nodes.n2][g2._node].to_list()) == ["a", "b"]
 
     def test_chain_predicate_is_in(self):
         g = hops_graph()


### PR DESCRIPTION
## Summary
- Fixes #877.
- Avoids pandas object-dtype `fillna()` downcast warnings in named GFQL chain tag merging by using an engine-compatible `where(notna, other)` merge expression.
- Adds a focused warning-capture regression for named chain tags.
- Adds a changelog entry.

## Required Reporting
- Production: +1 / -1, net 0 LOC
- Tests / fixtures / baselines: +22 / -0, net +22 LOC
- Comments / docs / changelog: +1 / -0, net +1 LOC
- Compiler-plan surface touched: no; this only changes the `compute/chain.py` tag-column merge expression.
- cuDF coverage: covered on `ssh dgx-spark` RAPIDS 25.02 and 26.02 focused chain/fillna tests; no #872 work targeted.

## Validation
- `python3 -m pytest -q -W error::FutureWarning graphistry/tests/test_compute_chain.py graphistry/tests/compute/test_gfql_exceptions.py::TestChainFillnaNoFutureWarning` -> 75 passed, 9 skipped
- `python3 -m pytest -W error::FutureWarning -q graphistry/tests/compute -k 'hop or chain or tag'` -> local CUDA/no-device failures only because cuDF is installed without a GPU; no pandas FutureWarning failure
- `./bin/ruff.sh graphistry/compute/chain.py graphistry/tests/test_compute_chain.py` -> pass
- `./bin/typecheck.sh graphistry/compute/chain.py` -> pass
- `./bin/typecheck.sh graphistry/compute/chain.py graphistry/tests/test_compute_chain.py` -> blocked by pre-existing test harness typing noise (`common`/`pytest` imports, abstract `CGFull`), production file passes
- `git diff --check` -> pass
- DGX RAPIDS 26.02: `RAPIDS_VERSION=26.02 PROFILE=gfql TEST_FILES="graphistry/tests/test_compute_chain.py::TestComputeChainMixin::test_chain_named_tags_no_fillna_futurewarning graphistry/tests/compute/test_gfql_exceptions.py::TestChainFillnaNoFutureWarning::test_chain_hop_no_future_warning_cudf" docker/test-rapids-official-local.sh` -> 2 passed
- DGX RAPIDS 25.02: same focused command with `RAPIDS_VERSION=25.02` -> 2 passed, 1 known RAPIDS driver-version warning

## CI Matrix Expectation
- PR CI includes pandas 2.x compatibility jobs and pandas >=3.x GFQL/latest compatibility jobs per `.github/workflows/ci.yml`; will loop until green.
