### PR TITLE
docs(gfql): clarify chain string input contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - **GFQL chain tag warning cleanup (#877)**: Avoided pandas object-dtype `fillna()` downcast warnings when merging named chain tag columns without warning filters or behavior changes.
+- **GFQL chain input docs (#1255)**: Clarified that native GFQL chains must be passed as materialized Python list/dict/`Chain` objects, while `g.gfql(str)` remains the Cypher string-query entrypoint rather than a parser for stringified Python or JSON chain literals.
 - **GFQL temporal implementation shrink (#1563)**: DRYed temporal value timezone/scalar helpers, shared duration token parsing and day-time duration formatting ownership, and separated temporal AST traversal from constructor-folding decisions while preserving `temporal_text` compatibility and runtime behavior.
 - **Legacy API-key compatibility deprecation (#1539)**: Deprecated the removed api=1 `api_key()` compatibility surface so explicit key use warns and is ignored, stale `GRAPHISTRY_API_KEY` environment values are not loaded, api=1/2 fail locally before upload, and remote integration docs now point to api=3 JWT or personal key ID/secret authentication.
 - **GFQL Cypher reentry cleanup (#1555)**: DRYed duplicated carried-endpoint reentry flattening tests and direct reentry carrier backend tests, and trimmed stale private reentry helper export/comment scaffolding while preserving runtime behavior.

--- a/docs/source/gfql/quick.rst
+++ b/docs/source/gfql/quick.rst
@@ -29,14 +29,25 @@ Basic Usage
 - **query**: Sequence of graph node/edge matchers and optional row-pipeline call steps (for example, `rows()`, `where_rows()`, `return_()`, `order_by()`, `limit()`), or an equivalent GFQL chain object.
 - **engine**: Optional execution engine. Engine is typically not set, defaulting to `'auto'`. Use `'cudf'` for GPU acceleration and `'pandas'` for CPU.
 
+Native GFQL chains are typed Python inputs. Pass the list, dict envelope, or
+``Chain`` object itself; strings passed to ``g.gfql(...)`` are interpreted as
+query text for the selected string language.
+
 Use this page as a quick MATCH/chain reference.
 For row-pipeline RETURN semantics, see :doc:`return`.
 
 Choose The Right Entrypoint
 ---------------------------
 
-- Use `g.gfql([...])` for native GFQL operators and `g.gfql("MATCH ...")` for Cypher syntax on the current graph.
-- Use `g.gfql_remote([...])` for remote GFQL when the dataset size or hardware profile calls for remote execution, including remote GPU execution. See :ref:`gfql-remote`.
+- Use ``g.gfql([...])`` for native GFQL operators and
+  ``g.gfql("MATCH ...")`` for Cypher syntax on the current graph.
+- If a tool receives a serialized native chain such as ``"[{'type': ...}]"``,
+  decode it into a real Python list/dict/``Chain`` before calling
+  ``g.gfql(...)``. ``g.gfql(str)`` is reserved for Cypher query text by
+  default.
+- Use ``g.gfql_remote([...])`` for remote GFQL when the dataset size or
+  hardware profile calls for remote execution, including remote GPU execution.
+  See :ref:`gfql-remote`.
 
 .. warning::
    `graphistry.cypher("...")` and `g.cypher("...")` are a separate remote database Cypher path
@@ -56,6 +67,10 @@ Cypher Strings Through ``g.gfql()``
 Use ``g.gfql("MATCH ...")`` when you want Cypher syntax and declarative graph
 semantics on a bound graph instead of writing the equivalent GFQL chain by
 hand:
+
+Do not pass stringified Python or JSON native-chain literals to
+``g.gfql(...)``. Materialize those serialized values before calling GFQL, or
+emit Cypher text intentionally.
 
 .. doc-test: xfail
 

--- a/docs/source/gfql/spec/python_embedding.md
+++ b/docs/source/gfql/spec/python_embedding.md
@@ -54,6 +54,12 @@ nodes_df = result._nodes  # Filtered nodes DataFrame
 edges_df = result._edges  # Filtered edges DataFrame
 ```
 
+Native GFQL chains are Python-embedded values, not source strings. Pass actual
+Python `list`, `dict` envelope, or `Chain` objects to `g.gfql(...)`; a `str`
+query is treated as Cypher text and is not decoded as a Python literal or JSON
+chain. Tooling that receives serialized native chains should decode them before
+calling `g.gfql(...)`, or intentionally emit Cypher query text.
+
 ### Row-Pipeline Query Execution (`MATCH ... RETURN` style)
 
 ```python


### PR DESCRIPTION
## Summary

Closes #1255 via the documentation path the issue allowed: keep `g.gfql(str)` as the Cypher string-query entrypoint and document that native GFQL chains must be materialized Python objects.

Runtime inspection showed accepting stringified Python/JSON native chains inside `g.gfql(str)` would be broader than a focused PR because:

- `g.gfql(str)` fires string-query policy/precompile hooks and compiles through the Cypher path.
- `g.gfql_validate(str)` validates strings as Cypher.
- `g.gfql_remote(str)` parses/compiles Cypher before serializing for remote execution.

Changes:

- Clarified `docs/source/gfql/quick.rst` entrypoint guidance for native chains vs Cypher strings.
- Clarified `docs/source/gfql/spec/python_embedding.md` that native chains are Python-embedded values, not source strings.
- Added a changelog entry.

## LOC Buckets

- Production: +0 / -0, net 0 LOC
- Tests / fixtures / baselines: +0 / -0, net 0 LOC
- Comments / docs / changelog: +24 / -2, net +22 LOC

## Compiler-Plan Surface

Compiler-plan surface touched: no. This is docs/changelog only; no logical/physical planning, route names, dispatch contracts, structured errors, source spans, pass/verifier hooks, schema/type hooks, IR metadata, or compatibility executor code changed.

## Validation

- `git diff --check`
- Review skill converged after Wave 1 style wrap plus two no-finding waves.
- Sphinx docs build attempted with `python3 -m sphinx -b html -W docs/source /tmp/pygraphistry-docs-1255`, but local docs config stops before changed docs are parsed because Graphviz `dot` is not installed.
- DGX/cuDF: out of scope; docs-only change and no runtime/DataFrame/cuDF paths touched.
