### PR TITLE
feat(schemas): export tooling contract artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         emit python \
           '\.py$' \
           '^graphistry/' \
+          '^schemas/' \
           '^setup\.py$' \
           '^setup\.cfg$' \
           '^pytest\.ini$' \
@@ -292,6 +293,24 @@ jobs:
           echo "$plans_files"
           exit 1
         fi
+
+  schema-artifacts:
+    needs: changes
+    if: ${{ needs.changes.outputs.python == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install package
+      run: python -m pip install -e .
+    - name: Check schema artifacts
+      run: python -m graphistry.devschemas.export --check
 
   generate-lockfiles:
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Added
+- **Schema artifacts for tooling contracts (#1326)**: Added committed structural JSON Schema artifacts for encodings, React settings, and URL params, plus a stdlib exporter/checker and CI drift guard for downstream LLM/tooling contract generation.
 - **Viz settings public contracts (#1234)**: Added `graphistry.viz_settings` as a public facade for canonical URL-parameter and React-facing visualization setting key constants, `Literal` key aliases, typed settings payloads, and frontend contract metadata for downstream type-checking.
 - **GFQL encode call parity (#1241)**: Added GFQL `call()` support for `encode_edge_icon` and `encode_axis`, plus deeper encode validator diagnostics for palette and categorical mapping payloads before remote or local execution.
 - **Changed-line coverage hygiene (#1533)**: Added a PR-only changed-line coverage gate that combines CPU coverage from the existing minimal and GFQL core test jobs, reports covered/missing executable package lines touched by a PR, and enforces an initial changed-line threshold without blocking on historical uncovered code.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include graphistry/_version.py
 include graphistry/py.typed
+include schemas/*.schema.json

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -18,3 +18,4 @@ See the article on :ref:`10min-pygraphistry` for a high-level overview of bindin
    utils/index
    layout/index
    plugins/index
+   schema_artifacts

--- a/docs/source/api/schema_artifacts.rst
+++ b/docs/source/api/schema_artifacts.rst
@@ -1,0 +1,17 @@
+Schema Artifacts
+================
+
+PyGraphistry ships structural JSON Schema artifacts for downstream tooling and LLM contract generation:
+
+- ``schemas/encodings.schema.json``
+- ``schemas/react-settings.schema.json``
+- ``schemas/url-params.schema.json``
+
+Generate or check them with:
+
+.. code-block:: bash
+
+   python -m graphistry.devschemas.export
+   python -m graphistry.devschemas.export --check
+
+These schemas are structural contracts. Runtime semantic validation remains owned by the existing PyGraphistry validators.

--- a/graphistry/devschemas/__init__.py
+++ b/graphistry/devschemas/__init__.py
@@ -1,0 +1,1 @@
+"""Development-only JSON Schema artifact generation."""

--- a/graphistry/devschemas/export.py
+++ b/graphistry/devschemas/export.py
@@ -1,0 +1,236 @@
+"""Generate structural JSON Schema artifacts for public tooling contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from graphistry.io.types import PLOTTABLE_SIMPLE_ENCODING_BIND_KEYS
+from graphistry.models.surfaces.graphistry_frontend import (
+    APPLY_ENCODINGS_REACT_KEYS,
+    GRAPHISTRY_FRONTEND_CONTRACT_SIGNATURE,
+    GRAPHISTRY_FRONTEND_CONTRACT_VERSION,
+    GRAPHISTRY_FRONTEND_UPSTREAM_VERSIONS,
+    REACT_SETTING_NAMES,
+    URL_PARAM_NAMES,
+)
+
+JsonDict = Dict[str, Any]
+
+SCHEMA_FILENAMES: Mapping[str, str] = {
+    "encodings": "encodings.schema.json",
+    "react_settings": "react-settings.schema.json",
+    "url_params": "url-params.schema.json",
+}
+
+
+def _settings_value_ref() -> JsonDict:
+    return {"$ref": "#/$defs/settingsValue"}
+
+
+def _contract_metadata() -> JsonDict:
+    return {
+        "graphistry_frontend_contract_version": GRAPHISTRY_FRONTEND_CONTRACT_VERSION,
+        "graphistry_frontend_contract_signature": GRAPHISTRY_FRONTEND_CONTRACT_SIGNATURE,
+        "graphistry_frontend_upstream_versions": dict(GRAPHISTRY_FRONTEND_UPSTREAM_VERSIONS),
+    }
+
+
+def _settings_value_def() -> JsonDict:
+    return {
+        "description": "Structural JSON value accepted by settings validators. Deeper semantics remain in pygraphistry validators.",
+        "anyOf": [
+            {"type": "null"},
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "boolean"},
+            {"type": "array", "items": {"$ref": "#/$defs/settingsValue"}},
+            {
+                "type": "object",
+                "additionalProperties": {"$ref": "#/$defs/settingsValue"},
+            },
+        ],
+    }
+
+
+def _object_with_known_settings(keys: tuple[str, ...], title: str, description: str) -> JsonDict:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": f"https://schemas.graphistry.com/pygraphistry/{title.lower().replace(' ', '-')}.schema.json",
+        "title": title,
+        "description": description,
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {key: _settings_value_ref() for key in keys},
+        "$defs": {"settingsValue": _settings_value_def()},
+        "x-graphistry": _contract_metadata(),
+    }
+
+
+def url_params_schema() -> JsonDict:
+    return _object_with_known_settings(
+        URL_PARAM_NAMES,
+        "Graphistry URL Params",
+        "Structural contract for graph.html/embed URL parameters accepted by pygraphistry settings(url_params=...).",
+    )
+
+
+def react_settings_schema() -> JsonDict:
+    schema = _object_with_known_settings(
+        REACT_SETTING_NAMES,
+        "Graphistry React Settings",
+        "Structural contract for React-facing visualization settings. Semantic validation remains in pygraphistry validators.",
+    )
+    schema["x-graphistry"]["apply_encodings_react_keys"] = list(APPLY_ENCODINGS_REACT_KEYS)
+    return schema
+
+
+def _complex_encoding_schema() -> JsonDict:
+    return {
+        "type": "object",
+        "description": "Structural complex encoding payload. Detailed semantic checks remain in validate_encodings().",
+        "required": ["attribute", "variation"],
+        "properties": {
+            "attribute": {"type": "string"},
+            "variation": {"enum": ["categorical", "continuous"]},
+            "graphType": {"enum": ["point", "edge"]},
+            "encodingType": {"type": "string"},
+            "mapping": {"type": "object", "additionalProperties": True},
+            "colors": {"type": "array", "items": {"type": "string"}},
+            "asText": {"type": "boolean"},
+            "style": {"type": "object", "additionalProperties": {"type": "number"}},
+            "blendMode": {"type": "string"},
+            "border": {"type": "object", "additionalProperties": True},
+            "shape": {"type": "string"},
+            "name": {"type": "string"},
+        },
+        "additionalProperties": True,
+    }
+
+
+def encodings_schema() -> JsonDict:
+    simple_properties = {
+        key: {"type": "string"}
+        for key in PLOTTABLE_SIMPLE_ENCODING_BIND_KEYS
+    }
+    complex_modes = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "default": {
+                "type": "object",
+                "additionalProperties": {"$ref": "#/$defs/complexEncoding"},
+            },
+            "current": {
+                "type": "object",
+                "additionalProperties": {"$ref": "#/$defs/complexEncoding"},
+            },
+        },
+    }
+    node_edge_properties: JsonDict = {
+        "bindings": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+        "complex": {"$ref": "#/$defs/complexModes"},
+    }
+    node_edge_encodings = {
+        "type": "object",
+        "required": ["bindings"],
+        "properties": node_edge_properties,
+        "additionalProperties": True,
+    }
+    edge_encodings = {
+        **node_edge_encodings,
+        "properties": {
+            **node_edge_properties,
+            "bindings": {
+                "type": "object",
+                "required": ["source", "destination"],
+                "additionalProperties": {"type": "string"},
+            },
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://schemas.graphistry.com/pygraphistry/encodings.schema.json",
+        "title": "Graphistry Encodings",
+        "description": "Structural contract for simple and complex visualization encodings. Runtime validators remain canonical for semantic checks.",
+        "oneOf": [
+            {"$ref": "#/$defs/metadataEncodings"},
+            {"$ref": "#/$defs/nodeEdgeEncodingsPayload"},
+        ],
+        "$defs": {
+            "metadataEncodings": {
+                "type": "object",
+                "properties": {
+                    **simple_properties,
+                    "complex_encodings": {"$ref": "#/$defs/complexEncodings"},
+                },
+                "additionalProperties": False,
+            },
+            "nodeEdgeEncodingsPayload": {
+                "type": "object",
+                "required": ["node_encodings", "edge_encodings"],
+                "properties": {
+                    "node_encodings": node_edge_encodings,
+                    "edge_encodings": edge_encodings,
+                },
+                "additionalProperties": False,
+            },
+            "complexEncodings": {
+                "type": "object",
+                "required": ["node_encodings", "edge_encodings"],
+                "properties": {
+                    "node_encodings": {"$ref": "#/$defs/complexModes"},
+                    "edge_encodings": {"$ref": "#/$defs/complexModes"},
+                },
+                "additionalProperties": False,
+            },
+            "complexModes": complex_modes,
+            "complexEncoding": _complex_encoding_schema(),
+        },
+        "x-graphistry": _contract_metadata(),
+    }
+
+
+def build_schemas() -> Mapping[str, JsonDict]:
+    return {
+        "encodings": encodings_schema(),
+        "react_settings": react_settings_schema(),
+        "url_params": url_params_schema(),
+    }
+
+
+def _render(schema: JsonDict) -> str:
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def export_schemas(output_dir: Path, check: bool = False) -> bool:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ok = True
+    for name, schema in build_schemas().items():
+        path = output_dir / SCHEMA_FILENAMES[name]
+        rendered = _render(schema)
+        if check:
+            current = path.read_text(encoding="utf-8") if path.exists() else None
+            if current != rendered:
+                print(f"schema drift: {path}")
+                ok = False
+        else:
+            path.write_text(rendered, encoding="utf-8")
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="schemas", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    return 0 if export_schemas(args.output_dir, check=args.check) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/graphistry/tests/test_schema_artifacts.py
+++ b/graphistry/tests/test_schema_artifacts.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from graphistry.devschemas.export import SCHEMA_FILENAMES, build_schemas
+from graphistry.io.types import PLOTTABLE_SIMPLE_ENCODING_BIND_KEYS
+from graphistry.viz_settings import (
+    APPLY_ENCODINGS_REACT_KEYS,
+    REACT_SETTING_NAMES,
+    URL_PARAM_NAMES,
+)
+
+
+SCHEMA_DIR = Path(__file__).resolve().parents[2] / "schemas"
+
+
+def _load(name: str):
+    with (SCHEMA_DIR / SCHEMA_FILENAMES[name]).open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_committed_schema_artifacts_match_exporter():
+    assert _load("url_params") == build_schemas()["url_params"]
+    assert _load("react_settings") == build_schemas()["react_settings"]
+    assert _load("encodings") == build_schemas()["encodings"]
+
+
+def test_settings_schema_keys_match_public_contracts():
+    assert set(_load("url_params")["properties"]) == set(URL_PARAM_NAMES)
+    assert set(_load("react_settings")["properties"]) == set(REACT_SETTING_NAMES)
+    assert (
+        _load("react_settings")["x-graphistry"]["apply_encodings_react_keys"]
+        == list(APPLY_ENCODINGS_REACT_KEYS)
+    )
+
+
+def test_encodings_schema_simple_keys_match_io_contract():
+    simple_props = _load("encodings")["$defs"]["metadataEncodings"]["properties"]
+    assert {k for k in simple_props if k != "complex_encodings"} == set(PLOTTABLE_SIMPLE_ENCODING_BIND_KEYS)
+    assert "node_encodings" in _load("encodings")["$defs"]["nodeEdgeEncodingsPayload"]["properties"]

--- a/graphistry/tests/test_schema_artifacts.py
+++ b/graphistry/tests/test_schema_artifacts.py
@@ -1,7 +1,10 @@
 import json
+import runpy
+import sys
 from pathlib import Path
 
-from graphistry.devschemas.export import SCHEMA_FILENAMES, build_schemas
+from graphistry.devschemas import export as schema_export
+from graphistry.devschemas.export import SCHEMA_FILENAMES, build_schemas, export_schemas
 from graphistry.io.types import PLOTTABLE_SIMPLE_ENCODING_BIND_KEYS
 from graphistry.viz_settings import (
     APPLY_ENCODINGS_REACT_KEYS,
@@ -37,3 +40,31 @@ def test_encodings_schema_simple_keys_match_io_contract():
     simple_props = _load("encodings")["$defs"]["metadataEncodings"]["properties"]
     assert {k for k in simple_props if k != "complex_encodings"} == set(PLOTTABLE_SIMPLE_ENCODING_BIND_KEYS)
     assert "node_encodings" in _load("encodings")["$defs"]["nodeEdgeEncodingsPayload"]["properties"]
+
+
+def test_schema_exporter_writes_and_checks_artifacts(tmp_path, capsys):
+    assert export_schemas(tmp_path) is True
+    assert export_schemas(tmp_path, check=True) is True
+
+    (tmp_path / SCHEMA_FILENAMES["url_params"]).write_text("{}\n", encoding="utf-8")
+
+    assert export_schemas(tmp_path, check=True) is False
+    assert "schema drift:" in capsys.readouterr().out
+
+
+def test_schema_exporter_cli_main(tmp_path, monkeypatch):
+    export_schemas(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["export.py", "--output-dir", str(tmp_path), "--check"])
+
+    assert schema_export.main() == 0
+
+
+def test_schema_exporter_module_entrypoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["export.py", "--output-dir", str(tmp_path)])
+
+    try:
+        runpy.run_path(str(Path(schema_export.__file__)), run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code == 0
+    else:
+        raise AssertionError("module entrypoint did not exit")

--- a/schemas/encodings.schema.json
+++ b/schemas/encodings.schema.json
@@ -1,0 +1,236 @@
+{
+  "$defs": {
+    "complexEncoding": {
+      "additionalProperties": true,
+      "description": "Structural complex encoding payload. Detailed semantic checks remain in validate_encodings().",
+      "properties": {
+        "asText": {
+          "type": "boolean"
+        },
+        "attribute": {
+          "type": "string"
+        },
+        "blendMode": {
+          "type": "string"
+        },
+        "border": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "colors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "encodingType": {
+          "type": "string"
+        },
+        "graphType": {
+          "enum": [
+            "point",
+            "edge"
+          ]
+        },
+        "mapping": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string"
+        },
+        "style": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "type": "object"
+        },
+        "variation": {
+          "enum": [
+            "categorical",
+            "continuous"
+          ]
+        }
+      },
+      "required": [
+        "attribute",
+        "variation"
+      ],
+      "type": "object"
+    },
+    "complexEncodings": {
+      "additionalProperties": false,
+      "properties": {
+        "edge_encodings": {
+          "$ref": "#/$defs/complexModes"
+        },
+        "node_encodings": {
+          "$ref": "#/$defs/complexModes"
+        }
+      },
+      "required": [
+        "node_encodings",
+        "edge_encodings"
+      ],
+      "type": "object"
+    },
+    "complexModes": {
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "additionalProperties": {
+            "$ref": "#/$defs/complexEncoding"
+          },
+          "type": "object"
+        },
+        "default": {
+          "additionalProperties": {
+            "$ref": "#/$defs/complexEncoding"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "metadataEncodings": {
+      "additionalProperties": false,
+      "properties": {
+        "complex_encodings": {
+          "$ref": "#/$defs/complexEncodings"
+        },
+        "edge_badge": {
+          "type": "string"
+        },
+        "edge_color": {
+          "type": "string"
+        },
+        "edge_destination_color": {
+          "type": "string"
+        },
+        "edge_icon": {
+          "type": "string"
+        },
+        "edge_label": {
+          "type": "string"
+        },
+        "edge_opacity": {
+          "type": "string"
+        },
+        "edge_size": {
+          "type": "string"
+        },
+        "edge_source_color": {
+          "type": "string"
+        },
+        "edge_title": {
+          "type": "string"
+        },
+        "edge_weight": {
+          "type": "string"
+        },
+        "point_badge": {
+          "type": "string"
+        },
+        "point_color": {
+          "type": "string"
+        },
+        "point_icon": {
+          "type": "string"
+        },
+        "point_label": {
+          "type": "string"
+        },
+        "point_opacity": {
+          "type": "string"
+        },
+        "point_size": {
+          "type": "string"
+        },
+        "point_title": {
+          "type": "string"
+        },
+        "point_x": {
+          "type": "string"
+        },
+        "point_y": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "nodeEdgeEncodingsPayload": {
+      "additionalProperties": false,
+      "properties": {
+        "edge_encodings": {
+          "additionalProperties": true,
+          "properties": {
+            "bindings": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [
+                "source",
+                "destination"
+              ],
+              "type": "object"
+            },
+            "complex": {
+              "$ref": "#/$defs/complexModes"
+            }
+          },
+          "required": [
+            "bindings"
+          ],
+          "type": "object"
+        },
+        "node_encodings": {
+          "additionalProperties": true,
+          "properties": {
+            "bindings": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "complex": {
+              "$ref": "#/$defs/complexModes"
+            }
+          },
+          "required": [
+            "bindings"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "node_encodings",
+        "edge_encodings"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://schemas.graphistry.com/pygraphistry/encodings.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Structural contract for simple and complex visualization encodings. Runtime validators remain canonical for semantic checks.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/metadataEncodings"
+    },
+    {
+      "$ref": "#/$defs/nodeEdgeEncodingsPayload"
+    }
+  ],
+  "title": "Graphistry Encodings",
+  "x-graphistry": {
+    "graphistry_frontend_contract_signature": "bf54644c941670c46000fd7590077e33bfbda881095e77ebcf2f11821045edbd",
+    "graphistry_frontend_contract_version": 1,
+    "graphistry_frontend_upstream_versions": {
+      "graphistry_js_client_api": null,
+      "graphistry_js_client_api_react": null,
+      "graphistry_server": null
+    }
+  }
+}

--- a/schemas/react-settings.schema.json
+++ b/schemas/react-settings.schema.json
@@ -1,0 +1,216 @@
+{
+  "$defs": {
+    "settingsValue": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/settingsValue"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/settingsValue"
+          },
+          "type": "object"
+        }
+      ],
+      "description": "Structural JSON value accepted by settings validators. Deeper semantics remain in pygraphistry validators."
+    }
+  },
+  "$id": "https://schemas.graphistry.com/pygraphistry/graphistry-react-settings.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Structural contract for React-facing visualization settings. Semantic validation remains in pygraphistry validators.",
+  "properties": {
+    "axes": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "backgroundColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "controls": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "dissuadeHubs": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "edgeCurvature": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "edgeInfluence": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "edgeOpacity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "encodeAxis": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "encodeEdgeColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "encodeEdgeIcons": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "encodePointColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "encodePointIcons": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "encodePointSize": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "exclusions": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "filters": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "gravity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "iframeStyle": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "labelBackground": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "labelColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "labelOpacity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "linLog": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "lockedR": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "lockedX": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "lockedY": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "neighborhoodHighlight": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "neighborhoodHighlightHops": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "play": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointOpacity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointSize": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointsOfInterestMax": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "precisionVsSpeed": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pruneOrphans": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "scalingRatio": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showArrows": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showHistograms": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showInfo": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showInspector": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabelActions": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabelInspector": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabelOnHover": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabelPropertiesOnHover": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabels": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showMenu": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showPointsOfInterest": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showPointsOfInterestLabel": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showSplashScreen": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showTimebars": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showToolbar": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "strongGravity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "ticks": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "type": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "workbook": {
+      "$ref": "#/$defs/settingsValue"
+    }
+  },
+  "title": "Graphistry React Settings",
+  "type": "object",
+  "x-graphistry": {
+    "apply_encodings_react_keys": [
+      "encodePointColor",
+      "encodeEdgeColor",
+      "encodePointSize",
+      "encodePointIcons",
+      "encodePointIcon",
+      "encodeEdgeIcons",
+      "encodeEdgeIcon",
+      "encodeAxis"
+    ],
+    "graphistry_frontend_contract_signature": "bf54644c941670c46000fd7590077e33bfbda881095e77ebcf2f11821045edbd",
+    "graphistry_frontend_contract_version": 1,
+    "graphistry_frontend_upstream_versions": {
+      "graphistry_js_client_api": null,
+      "graphistry_js_client_api_react": null,
+      "graphistry_server": null
+    }
+  }
+}

--- a/schemas/url-params.schema.json
+++ b/schemas/url-params.schema.json
@@ -1,0 +1,203 @@
+{
+  "$defs": {
+    "settingsValue": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/settingsValue"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/settingsValue"
+          },
+          "type": "object"
+        }
+      ],
+      "description": "Structural JSON value accepted by settings validators. Deeper semantics remain in pygraphistry validators."
+    }
+  },
+  "$id": "https://schemas.graphistry.com/pygraphistry/graphistry-url-params.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Structural contract for graph.html/embed URL parameters accepted by pygraphistry settings(url_params=...).",
+  "properties": {
+    "bg": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "bottom": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "collections": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "collectionsGlobalEdgeColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "collectionsGlobalNodeColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "dissuadeHubs": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "edgeCurvature": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "edgeInfluence": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "edgeOpacity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "favicon": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "gravity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "info": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "labelBackground": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "labelColor": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "labelOpacity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "left": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "linLog": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "lockedR": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "lockedX": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "lockedY": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "logoAutoInvert": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "logoMaxHeight": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "logoMaxWidth": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "logoPosition": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "logoUrl": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "menu": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "neighborhoodHighlight": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "neighborhoodHighlightHops": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pageTitle": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "play": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointOpacity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointSize": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointStrokeWidth": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "pointsOfInterestMax": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "precisionVsSpeed": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "right": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "scalingRatio": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "shortenLabels": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showActions": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showArrows": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showCollections": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showHistograms": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showInspector": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabelOnHover": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabelPropertiesOnHover": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showLabels": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showPointsOfInterest": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "showPointsOfInterestLabel": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "splashAfter": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "strongGravity": {
+      "$ref": "#/$defs/settingsValue"
+    },
+    "top": {
+      "$ref": "#/$defs/settingsValue"
+    }
+  },
+  "title": "Graphistry URL Params",
+  "type": "object",
+  "x-graphistry": {
+    "graphistry_frontend_contract_signature": "bf54644c941670c46000fd7590077e33bfbda881095e77ebcf2f11821045edbd",
+    "graphistry_frontend_contract_version": 1,
+    "graphistry_frontend_upstream_versions": {
+      "graphistry_js_client_api": null,
+      "graphistry_js_client_api_react": null,
+      "graphistry_server": null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add committed structural JSON Schema artifacts for encodings, React settings, and URL params.
- Add a stdlib `graphistry.devschemas.export` generator/checker and schema drift test coverage.
- Add a CI `schema-artifacts` drift guard plus a short API docs note.

Closes #1326

## Artifacts
- `schemas/encodings.schema.json`
- `schemas/react-settings.schema.json`
- `schemas/url-params.schema.json`

## Scope notes
- No hard pydantic/runtime dependency was added.
- JSON Schema artifacts are structural contracts. Existing PyGraphistry validators remain canonical for semantic validation.
- `MANIFEST.in` includes `schemas/*.schema.json` so source distributions carry the committed artifacts.

## LOC buckets
- Production/tooling: +237 / -0, net +237 LOC
- Tests: +71 / -0, net +71 LOC
- Schema artifacts: +655 / -0, net +655 LOC
- CI/packaging: +20 / -0, net +20 LOC
- Docs/changelog: +19 / -0, net +19 LOC

## Compiler-plan surface touched
No. This is schema artifact generation and public tooling metadata only; no GFQL compiler-plan semantics, route names, execution dispatch, diagnostics, schema/type-system runtime hooks, IR metadata, remote schema hooks, or compatibility executors were changed.

## Validation
- `python3 -m graphistry.devschemas.export --check` -> passed
- `python3 -m pytest -q graphistry/tests/test_schema_artifacts.py graphistry/tests/test_viz_settings.py graphistry/tests/test_validate_settings.py` -> 28 passed
- `python3 -m coverage run --data-file=/tmp/schema-artifacts.coverage -m pytest -q graphistry/tests/test_schema_artifacts.py && python3 bin/changed_line_coverage.py --data-file /tmp/schema-artifacts.coverage --base-ref origin/master --head-ref HEAD --min-percent 80 --output-dir /tmp/schema-artifacts-changed-coverage` -> passed, 57/57 changed executable lines covered
- `./bin/ruff.sh graphistry/devschemas graphistry/tests/test_schema_artifacts.py` -> passed
- `./bin/typecheck.sh graphistry/devschemas graphistry/tests/test_schema_artifacts.py` -> passed
- `git diff --check` -> passed
- Review skill converged: wave 1 fixed sdist MANIFEST coverage; waves 2 and 3 no findings
- DGX/cuDF: skipped; no runtime, DataFrame, cuDF, or GPU path touched