### PR TITLE
feat(arrow): add opt-in mixed type coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -747,15 +747,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - **Arrow:** New `to_arrow()` public method for debugging DataFrame->Arrow conversion issues (#867).
-- **Validation:** New `validate` parameter for `plot()` and `upload()` with modes:
-  - `'autofix'` (default): Auto-coerce mixed-type columns to string + emit warning
-  - `'strict'`: Raise `ArrowConversionError` on mixed types; may do data-level inspection
-  - `'strict-fast'`: Same as strict but stays at metadata/schema level only (for high-throughput pipelines)
-
-- **Validation:** New `validate` + `warn` parameters for `plot()`, `upload()`, and `to_arrow()` to control conversion behavior. `warn` controls warning emission during autofix conversions (default `True`; `validate=False` forces `warn=False`). Backward compatible: `validate=True` maps to `'strict'`, `validate=False` maps to `'autofix'` with `warn=False`. Encoding validation errors are also controlled by these modes. Works with pandas, cuDF, dask, dask_cudf, and Spark/Databricks DataFrames (#867).
-
-### Changed
-- **Arrow:** Auto-coerce mixed-type columns to string during Arrow conversion, preventing `ArrowTypeError` and `ArrowInvalid` exceptions when DataFrames contain columns with mixed types (e.g., bytes/float/string or list/scalar). Emits `RuntimeWarning` listing coerced columns. Applies to pandas, cuDF, and distributed DataFrames (dask, Spark) after collection (#867).
+- **Arrow:** Added opt-in `auto_coerce` to `plot()`, `upload()`, and `to_arrow()`. The default `auto_coerce=False` preserves strict Arrow conversion. With `auto_coerce=True`, Graphistry retries failed pandas/cuDF Arrow conversion by probing object columns and coercing only Arrow-incompatible columns to strings, then logs the coerced column names at info level (#867).
 
 ## [0.47.0 - 2025-12-15]
 

--- a/docs/source/api/plotter.rst
+++ b/docs/source/api/plotter.rst
@@ -7,6 +7,21 @@ The below Python API reference documentation is for three views of the core grap
 * The :py:class:`graphistry.Plottable` abstract interface for the core Graphistry graph object
 * The :py:class:`graphistry.PlotterBase` class implementing it
 
+Arrow Conversion Coercion
+-------------------------
+
+``plot()``, ``upload()``, and ``to_arrow()`` accept ``auto_coerce=False`` by
+default. With the default strict behavior, mixed-type pandas/cuDF object columns
+that PyArrow cannot convert still fail with ``ArrowConversionError`` and list the
+problem columns when Graphistry can identify them.
+
+Set ``auto_coerce=True`` to opt in to a narrow fallback for dirty real-world
+columns. Graphistry first tries normal Arrow conversion. On failure, it probes
+object columns one at a time and coerces only columns that fail Arrow conversion
+to strings before retrying. Coerced column names are emitted through the
+``graphistry.PlotterBase`` logger at info level, for example:
+``Auto-coerced mixed-type columns to string for Arrow conversion: ['amount']``.
+
 .. toctree::
    :maxdepth: 3
 

--- a/graphistry/Plottable.py
+++ b/graphistry/Plottable.py
@@ -812,8 +812,7 @@ class Plottable(Protocol):
     def to_arrow(
         self,
         table: Optional[Any] = None,
-        validate: ValidationParam = 'autofix',
-        warn: bool = True
+        auto_coerce: bool = False
     ) -> Optional[Any]:
         ...
 
@@ -841,7 +840,8 @@ class Plottable(Protocol):
         memoize: bool = True,
         erase_files_on_fail: bool = True,
         validate: ValidationParam = 'autofix',
-        warn: bool = True
+        warn: bool = True,
+        auto_coerce: bool = False
     ) -> 'Plottable':
         ...
 
@@ -859,7 +859,8 @@ class Plottable(Protocol):
         extra_html: str = "",
         override_html_style: Optional[str] = None,
         validate: ValidationParam = 'autofix',
-        warn: bool = True
+        warn: bool = True,
+        auto_coerce: bool = False
     ) -> Any:
         ...
 

--- a/graphistry/PlotterBase.py
+++ b/graphistry/PlotterBase.py
@@ -64,12 +64,14 @@ def _upload_otel_attrs(
     erase_files_on_fail: bool = True,
     validate: ValidationParam = "autofix",
     warn: bool = True,
+    auto_coerce: bool = False,
 ) -> Dict[str, Any]:
     attrs: Dict[str, Any] = {"graphistry.memoize": memoize}
     if otel_detail_enabled():
         attrs["graphistry.validate"] = str(validate)
         attrs["graphistry.erase_files_on_fail"] = erase_files_on_fail
         attrs["graphistry.warn"] = warn
+        attrs["graphistry.auto_coerce"] = auto_coerce
     return attrs
 
 
@@ -88,6 +90,7 @@ def _plot_otel_attrs(
     override_html_style: Optional[str] = None,
     validate: ValidationParam = "autofix",
     warn: bool = True,
+    auto_coerce: bool = False,
 ) -> Dict[str, Any]:
     attrs: Dict[str, Any] = {
         "graphistry.render": str(render),
@@ -99,6 +102,7 @@ def _plot_otel_attrs(
         attrs["graphistry.memoize"] = memoize
         attrs["graphistry.erase_files_on_fail"] = erase_files_on_fail
         attrs["graphistry.warn"] = warn
+        attrs["graphistry.auto_coerce"] = auto_coerce
     return attrs
 
 
@@ -2208,7 +2212,8 @@ class PlotterBase(Plottable):
         memoize: bool = True,
         erase_files_on_fail: bool = True,
         validate: ValidationParam = 'autofix',
-        warn: bool = True
+        warn: bool = True,
+        auto_coerce: bool = False
     ) -> Plottable:
         """Upload data to the Graphistry server and return as a Plottable. Headless-centric variant of plot().
 
@@ -2223,11 +2228,14 @@ class PlotterBase(Plottable):
         :param erase_files_on_fail: Removes uploaded files if an error is encountered during parse. Only applicable when upload as files enabled. Default on.
         :type erase_files_on_fail: bool
 
-        :param validate: Data validation mode. 'autofix' (default) auto-coerces mixed-type columns to string. 'strict' or 'strict-fast' raises ArrowConversionError on mixed types. For backward compatibility: True maps to 'strict', False maps to 'autofix'.
+        :param validate: Data validation mode for visualization settings and encodings.
         :type validate: ValidationParam
 
-        :param warn: Whether to emit warnings when auto-fixing data issues (only applies when validate='autofix'). validate=False forces warn=False. Default True.
+        :param warn: Whether to emit warnings when auto-fixing settings/encoding validation issues (only applies when validate='autofix'). validate=False forces warn=False. Default True.
         :type warn: bool
+
+        :param auto_coerce: Opt in to coercing mixed-type pandas/cuDF object columns to strings during Arrow conversion. Default False preserves strict Arrow conversion.
+        :type auto_coerce: bool
 
         **Example: Simple**
             ::
@@ -2246,7 +2254,8 @@ class PlotterBase(Plottable):
             memoize=memoize,
             erase_files_on_fail=erase_files_on_fail,
             validate=validate,
-            warn=warn
+            warn=warn,
+            auto_coerce=auto_coerce
         )
 
     @otel_traced("graphistry.plot", attrs_fn=_plot_otel_attrs)
@@ -2264,7 +2273,8 @@ class PlotterBase(Plottable):
         extra_html: str = "",
         override_html_style: Optional[str] = None,
         validate: ValidationParam = 'autofix',
-        warn: bool = True
+        warn: bool = True,
+        auto_coerce: bool = False
     ) -> Any:
         """Upload data to the Graphistry server and show as an iframe of it.
 
@@ -2306,11 +2316,14 @@ class PlotterBase(Plottable):
         :param override_html_style: Set fully custom style tag.
         :type override_html_style: Optional[str]
 
-        :param validate: Data validation mode. 'autofix' (default) auto-coerces mixed-type columns to string. 'strict' or 'strict-fast' raises ArrowConversionError on mixed types. For backward compatibility: True maps to 'strict', False maps to 'autofix'.
+        :param validate: Data validation mode for visualization settings and encodings.
         :type validate: ValidationParam
 
-        :param warn: Whether to emit warnings when auto-fixing data issues (only applies when validate='autofix'). validate=False forces warn=False. Default True.
+        :param warn: Whether to emit warnings when auto-fixing settings/encoding validation issues (only applies when validate='autofix'). validate=False forces warn=False. Default True.
         :type warn: bool
+
+        :param auto_coerce: Opt in to coercing mixed-type pandas/cuDF object columns to strings during Arrow conversion. Coerced column names are logged at info level. Default False preserves strict Arrow conversion.
+        :type auto_coerce: bool
 
         **Example: Simple**
             ::
@@ -2364,7 +2377,7 @@ class PlotterBase(Plottable):
         self._pygraphistry.refresh()
         logger.debug("4. @PloatterBase plot: self._pygraphistry.org_name: {}".format(self.session.org_name))
 
-        uploader = self._plot_dispatch(g, n, name, description, self._style, memoize, validate_mode, warn)
+        uploader = self._plot_dispatch(g, n, name, description, self._style, memoize, validate_mode, warn, auto_coerce=auto_coerce)
         assert uploader is not None
         if skip_upload:
             return uploader
@@ -2831,15 +2844,15 @@ class PlotterBase(Plottable):
             if b not in cols:
                 error('%s attribute "%s" bound to "%s" does not exist.' % (typ, a, b))
 
-    def _plot_dispatch_arrow(self, graph, nodes, name, description, metadata=None, memoize=True, validate_mode: ValidationMode = 'autofix', emit_warnings=True) -> ArrowUploader:
+    def _plot_dispatch_arrow(self, graph, nodes, name, description, metadata=None, memoize=True, validate_mode: ValidationMode = 'autofix', emit_warnings=True, auto_coerce: bool = False) -> ArrowUploader:
         warnings.warn(
             "_plot_dispatch_arrow() is deprecated; use _plot_dispatch(), which now always builds Arrow uploaders.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._plot_dispatch(graph, nodes, name, description, metadata, memoize, validate_mode, emit_warnings)
+        return self._plot_dispatch(graph, nodes, name, description, metadata, memoize, validate_mode, emit_warnings, auto_coerce=auto_coerce)
 
-    def _plot_dispatch(self, graph, nodes, name, description, metadata=None, memoize=True, validate_mode: ValidationMode = 'autofix', emit_warnings=True) -> ArrowUploader:
+    def _plot_dispatch(self, graph, nodes, name, description, metadata=None, memoize=True, validate_mode: ValidationMode = 'autofix', emit_warnings=True, auto_coerce: bool = False) -> ArrowUploader:
 
         g: "PlotterBase" = self
         if self._point_title is None and self._point_label is None and g._nodes is not None:
@@ -2849,8 +2862,8 @@ class PlotterBase(Plottable):
                 1
 
         def make_arrow_upload(edges: Any, upload_nodes: Any) -> ArrowUploader:
-            edges_arr = g._table_to_arrow(edges, memoize, validate_mode, emit_warnings)
-            nodes_arr = g._table_to_arrow(upload_nodes, memoize, validate_mode, emit_warnings)
+            edges_arr = g._table_to_arrow(edges, memoize, auto_coerce=auto_coerce)
+            nodes_arr = g._table_to_arrow(upload_nodes, memoize, auto_coerce=auto_coerce)
             return g._make_arrow_dataset(edges=edges_arr, nodes=nodes_arr, name=name, description=description, metadata=metadata)
 
         if isinstance(graph, pd.DataFrame) \
@@ -2913,7 +2926,7 @@ class PlotterBase(Plottable):
                     bad_cols.append(str(col))
         return bad_cols
 
-    def _coerce_mixed_type_columns(self, df: Any, is_cudf: bool = False, emit_warning: bool = True) -> Any:
+    def _coerce_mixed_type_columns(self, df: Any, is_cudf: bool = False) -> Any:
         """Coerce mixed-type columns to string for Arrow conversion."""
         coerced_cols: List[str] = []
         coerce_cols: List[Any] = []
@@ -2928,26 +2941,28 @@ class PlotterBase(Plottable):
                     coerce_cols.append(col)
                     coerced_cols.append(str(col))
         if coerce_cols:
-            df_fixed = df.astype({col: str for col in coerce_cols})
+            string_dtype = "str" if is_cudf else "string"
+            df_fixed = df.astype({col: string_dtype for col in coerce_cols})
         else:
             df_fixed = df
-        if coerced_cols and emit_warning:
-            warn(f'Coerced mixed-type columns to string for Arrow conversion: {coerced_cols}. '
-                 f'Convert explicitly before plot() for better control.')
+        if coerced_cols:
+            logger.info(
+                "Auto-coerced mixed-type columns to string for Arrow conversion: %s",
+                coerced_cols,
+            )
         return df_fixed
 
-    def _table_to_arrow(self, table: Any, memoize: bool = True, validate_mode: ValidationMode = 'autofix', emit_warnings: bool = True) -> Optional[pa.Table]:  # noqa: C901
+    def _table_to_arrow(self, table: Any, memoize: bool = True, auto_coerce: bool = False) -> Optional[pa.Table]:  # noqa: C901
         """
             pandas | arrow | dask | cudf | dask_cudf | polars | spark => arrow
 
             dask/dask_cudf convert to pandas/cudf
 
-            :param validate_mode: 'autofix' (default) coerces mixed-type columns to string with warning,
-                                  'strict' or 'strict-fast' raises ArrowConversionError on mixed types
-            :param warn: Whether to emit warnings when auto-coercing (only applies to autofix mode)
+            :param auto_coerce: When True, coerce mixed-type object columns to strings and log the column names.
+                                Default False preserves strict Arrow conversion.
         """
 
-        logger.debug('_table_to_arrow of %s (memoize: %s, validate_mode: %s)', type(table), memoize, validate_mode)
+        logger.debug('_table_to_arrow of %s (memoize: %s, auto_coerce: %s)', type(table), memoize, auto_coerce)
 
         if table is None:
             return None
@@ -2981,12 +2996,12 @@ class PlotterBase(Plottable):
             try:
                 out = pa.Table.from_pandas(table, preserve_index=False).replace_schema_metadata({})
             except (pa.lib.ArrowTypeError, pa.lib.ArrowInvalid) as e:
-                if validate_mode in ('strict', 'strict-fast'):
+                if not auto_coerce:
                     bad_cols = self._find_bad_arrow_columns(table, is_cudf=False)
                     from graphistry.exceptions import ArrowConversionError
                     raise ArrowConversionError(columns=bad_cols, original_error=e)
                 logger.debug('Arrow conversion failed, auto-coercing: %s', e)
-                table_fixed = self._coerce_mixed_type_columns(table, is_cudf=False, emit_warning=emit_warnings)
+                table_fixed = self._coerce_mixed_type_columns(table, is_cudf=False)
                 out = pa.Table.from_pandas(table_fixed, preserve_index=False).replace_schema_metadata({})
 
             if memoize and (hashed is not None):
@@ -3016,12 +3031,12 @@ class PlotterBase(Plottable):
             try:
                 out = table.to_arrow()
             except (pa.lib.ArrowTypeError, pa.lib.ArrowInvalid) as e:
-                if validate_mode in ('strict', 'strict-fast'):
+                if not auto_coerce:
                     bad_cols = self._find_bad_arrow_columns(table, is_cudf=True)
                     from graphistry.exceptions import ArrowConversionError
                     raise ArrowConversionError(columns=bad_cols, original_error=e)
                 logger.debug('cuDF Arrow conversion failed, auto-coercing: %s', e)
-                table_fixed = self._coerce_mixed_type_columns(table, is_cudf=True, emit_warning=emit_warnings)
+                table_fixed = self._coerce_mixed_type_columns(table, is_cudf=True)
                 out = table_fixed.to_arrow()  # type: ignore[union-attr]
 
             if memoize:
@@ -3036,22 +3051,22 @@ class PlotterBase(Plottable):
             logger.debug('dgdf->arrow via gdf hash check')
             dgdf = table.persist()
             gdf = dgdf.compute()
-            return self._table_to_arrow(gdf, memoize, validate_mode, emit_warnings)
+            return self._table_to_arrow(gdf, memoize, auto_coerce=auto_coerce)
 
         if not (maybe_dask_dataframe() is None) and isinstance(table, maybe_dask_dataframe().DataFrame):
             logger.debug('ddf->arrow via df hash check')
             ddf = table.persist()
             df = ddf.compute()
-            return self._table_to_arrow(df, memoize, validate_mode, emit_warnings)
+            return self._table_to_arrow(df, memoize, auto_coerce=auto_coerce)
 
         if not (maybe_spark() is None) and isinstance(table, maybe_spark().sql.dataframe.DataFrame):
             logger.debug('spark->arrow via df')
             df = table.toPandas()
             #TODO push the hash check to Spark
-            return self._table_to_arrow(df, memoize, validate_mode, emit_warnings)
+            return self._table_to_arrow(df, memoize, auto_coerce=auto_coerce)
 
         if not (maybe_polars() is None) and isinstance(table, (maybe_polars().DataFrame, maybe_polars().LazyFrame)):
-            # validate_mode and emit_warnings are not applied for polars input: polars frames are
+            # auto_coerce is not applied for polars input: polars frames are
             # strictly typed so mixed-type columns cannot exist, making validation a no-op here.
             if isinstance(table, maybe_polars().LazyFrame):
                 table = table.collect()
@@ -3078,25 +3093,18 @@ class PlotterBase(Plottable):
     def to_arrow(
         self,
         table: Optional[Any] = None,
-        validate: ValidationParam = 'autofix',
-        warn: bool = True
+        auto_coerce: bool = False
     ) -> Optional[pa.Table]:
         """
         Convert a DataFrame to Arrow format.
 
         This method is useful for debugging Arrow conversion issues.
         If the DataFrame contains mixed-type columns that would cause Arrow
-        conversion to fail, they will be automatically coerced to strings
-        with a warning in autofix mode.
+        conversion to fail, pass ``auto_coerce=True`` to coerce those columns
+        to strings and log the column names.
 
-        :param validate: Data validation mode. 'autofix' (default) auto-coerces mixed-type columns to string.
-                         'strict' or 'strict-fast' raises ArrowConversionError on mixed types.
-                         For backward compatibility: True maps to 'strict', False maps to 'autofix'.
-        :type validate: ValidationParam
-
-        :param warn: Whether to emit warnings when auto-fixing data issues (only applies when validate='autofix').
-                     validate=False forces warn=False. Default True.
-        :type warn: bool
+        :param auto_coerce: Opt in to coercing mixed-type pandas/cuDF object columns to strings during Arrow conversion. Default False preserves strict Arrow conversion.
+        :type auto_coerce: bool
 
         :param table: DataFrame to convert. If None, converts the bound edges.
         :type table: Optional[pandas.DataFrame, cudf.DataFrame, pyarrow.Table]
@@ -3118,23 +3126,15 @@ class PlotterBase(Plottable):
                 g = graphistry.edges(df, 'src', 'dst')
 
                 # Debug: see what Arrow conversion produces
-                arr = g.to_arrow(df, validate='autofix', warn=True)
+                arr = g.to_arrow(df, auto_coerce=True)
                 print(arr.schema)
 
                 # Or convert bound edges
-                arr2 = g.to_arrow(validate='strict')
+                arr2 = g.to_arrow()
         """
         if table is None:
             table = self._edges
-        validate_mode: ValidationMode
-        if validate is True:
-            validate_mode = 'strict'
-        elif validate is False:
-            validate_mode = 'autofix'
-            warn = False
-        else:
-            validate_mode = validate
-        return self._table_to_arrow(table, memoize=False, validate_mode=validate_mode, emit_warnings=warn)
+        return self._table_to_arrow(table, memoize=False, auto_coerce=auto_coerce)
 
     def _make_arrow_dataset(self, edges: Optional[pa.Table], nodes: Optional[pa.Table], name: str, description: str, metadata: Optional[Dict[str, Any]]) -> ArrowUploader:
         try:

--- a/graphistry/exceptions.py
+++ b/graphistry/exceptions.py
@@ -27,10 +27,10 @@ class TokenExpireException(Exception):
 
 
 class ArrowConversionError(Exception):
-    """Raised in strict mode when Arrow conversion fails due to mixed types."""
+    """Raised when strict Arrow conversion fails due to mixed types."""
     def __init__(self, columns: list, original_error: Exception):
         self.columns = columns
         self.original_error = original_error
         msg = (f"Arrow conversion failed for columns {columns}. "
-               f"Use validate='autofix' to auto-coerce to strings.")
+               f"Use auto_coerce=True to auto-coerce to strings.")
         super().__init__(msg)

--- a/graphistry/tests/test_plotter.py
+++ b/graphistry/tests/test_plotter.py
@@ -323,6 +323,33 @@ class TestPlotterArrowConversions(NoAuthTestCase):
         graphistry.pygraphistry.PyGraphistry.relogin = lambda: True
         graphistry.register(api=3)
 
+    def _patch_plotterbase_logger_info(self):
+        import importlib
+
+        plotter_base_module = importlib.import_module("graphistry.PlotterBase")
+        return patch.object(plotter_base_module.logger, "info")
+
+    def _plotterbase_module(self):
+        import importlib
+
+        return importlib.import_module("graphistry.PlotterBase")
+
+    def test_otel_attrs_include_auto_coerce_when_detail_enabled(self):
+        plotter_base_module = self._plotterbase_module()
+
+        with patch.object(plotter_base_module, "otel_detail_enabled", return_value=True):
+            upload_attrs = plotter_base_module._upload_otel_attrs(
+                graphistry.bind(),
+                auto_coerce=True,
+            )
+            plot_attrs = plotter_base_module._plot_otel_attrs(
+                graphistry.bind(),
+                auto_coerce=True,
+            )
+
+        assert upload_attrs["graphistry.auto_coerce"] is True
+        assert plot_attrs["graphistry.auto_coerce"] is True
+
     def test_table_to_arrow_from_none(self):
         plotter = graphistry.bind()
         assert plotter._table_to_arrow(None) is None
@@ -404,17 +431,81 @@ class TestPlotterArrowConversions(NoAuthTestCase):
         assert not (arr1 is plotter._table_to_arrow(df))
 
     # ==========================================================================
-    # Auto-coerce mixed-type columns tests (Issue #867)
+    # auto_coerce mixed-type columns tests (Issue #867)
     # ==========================================================================
 
-    def test_table_to_arrow_mixed_types_coerced(self):
-        """Mixed-type columns (bytes/float/str) are auto-coerced to string with warning."""
+    def test_table_to_arrow_strict_passing_column_no_coerce(self):
+        """Strict default passes Arrow-compatible columns without auto-coerce logs."""
         plotter = graphistry.bind()
-        df = pd.DataFrame({'x': [1, 2, 3], 'amount': [b'bytes', 1.5, 'str']})
-        with pytest.warns(RuntimeWarning, match='Coerced mixed-type columns'):
+        df = pd.DataFrame({'src': [1, 2, 3], 'dst': [2, 3, 1], 'weight': [1.0, 2.0, 3.0]})
+        with self._patch_plotterbase_logger_info() as info_mock:
             arr = plotter._table_to_arrow(df, memoize=False)
         assert isinstance(arr, pa.Table)
+        info_mock.assert_not_called()
+
+    def test_table_to_arrow_mixed_types_strict_fails_by_default(self):
+        """auto_coerce defaults to False, preserving strict Arrow conversion."""
+        from graphistry.exceptions import ArrowConversionError
+        plotter = graphistry.bind()
+        df = pd.DataFrame({'x': [1, 2, 3], 'amount': [b'bytes', 1.5, 'str']})
+        with pytest.raises(ArrowConversionError, match='Arrow conversion failed') as exc_info:
+            plotter._table_to_arrow(df, memoize=False)
+        assert exc_info.value.columns == ['amount']
+
+    def test_table_to_arrow_mixed_types_auto_coerced(self):
+        """auto_coerce=True coerces failing mixed-type columns to string and info-logs names."""
+        import warnings
+        plotter = graphistry.bind()
+        df = pd.DataFrame({'x': [1, 2, 3], 'amount': [b'bytes', 1.5, None]})
+        with self._patch_plotterbase_logger_info() as info_mock:
+            with warnings.catch_warnings(record=True) as captured:
+                warnings.simplefilter("always")
+                arr = plotter._table_to_arrow(df, memoize=False, auto_coerce=True)
+        assert isinstance(arr, pa.Table)
         assert pa.types.is_string(arr.schema.field('amount').type) or pa.types.is_large_string(arr.schema.field('amount').type)
+        assert arr.column('amount').to_pylist() == ["bytes", "1.5", None]
+        info_mock.assert_called_once_with(
+            "Auto-coerced mixed-type columns to string for Arrow conversion: %s",
+            ['amount'],
+        )
+        assert not any("Coerced mixed-type columns" in str(w.message) for w in captured)
+
+    def test_table_to_arrow_multi_candidate_auto_coerce_heuristic(self):
+        """Heuristic keeps Arrow-compatible object columns and string-coerces only failing columns."""
+        plotter = graphistry.bind()
+        df = pd.DataFrame({
+            'ok_object': ['a', 'b', None],
+            'mixed_scalar': [b'bytes', 1.5, 'str'],
+            'mixed_nested': [[1, 2], {'x': 1}, None],
+        })
+        with self._patch_plotterbase_logger_info() as info_mock:
+            arr = plotter._table_to_arrow(df, memoize=False, auto_coerce=True)
+        assert isinstance(arr, pa.Table)
+        assert pa.types.is_string(arr.schema.field('ok_object').type) or pa.types.is_large_string(arr.schema.field('ok_object').type)
+        assert pa.types.is_string(arr.schema.field('mixed_scalar').type) or pa.types.is_large_string(arr.schema.field('mixed_scalar').type)
+        assert pa.types.is_string(arr.schema.field('mixed_nested').type) or pa.types.is_large_string(arr.schema.field('mixed_nested').type)
+        info_mock.assert_called_once()
+        assert info_mock.call_args.args[1] == ['mixed_scalar', 'mixed_nested']
+
+    def test_table_to_arrow_dask_dataframe_forwards_auto_coerce(self):
+        """Collected dataframe engines forward auto_coerce into the pandas conversion."""
+        plotter_base_module = self._plotterbase_module()
+
+        class FakeDaskFrame:
+            def persist(self):
+                return self
+
+            def compute(self):
+                return pd.DataFrame({"mixed": [b"bytes", 1.5, None]})
+
+        class FakeDaskModule:
+            DataFrame = FakeDaskFrame
+
+        plotter = graphistry.bind()
+        with patch.object(plotter_base_module, "maybe_dask_dataframe", return_value=FakeDaskModule):
+            arr = plotter._table_to_arrow(FakeDaskFrame(), memoize=False, auto_coerce=True)
+
+        assert arr.column("mixed").to_pylist() == ["bytes", "1.5", None]
 
     def test_table_to_arrow_clean_data_no_warning(self):
         """Clean data does not emit warnings."""
@@ -437,98 +528,58 @@ class TestPlotterArrowConversions(NoAuthTestCase):
     # Validate mode tests (Issue #867)
     # ==========================================================================
 
-    def test_validate_strict_raises_on_mixed(self):
-        """strict mode raises ArrowConversionError on mixed types."""
+    def test_table_to_arrow_strict_fast_path_raises_on_mixed(self):
+        """Strict private conversion path raises ArrowConversionError on mixed types."""
         from graphistry.exceptions import ArrowConversionError
         plotter = graphistry.bind()
         df = pd.DataFrame({'x': [1, 2, 3], 'mixed': [b'bytes', 1.5, 'str']})
         with pytest.raises(ArrowConversionError, match='Arrow conversion failed'):
-            plotter._table_to_arrow(df, memoize=False, validate_mode='strict')
-
-    def test_validate_strict_fast_raises_on_mixed(self):
-        """strict-fast mode raises ArrowConversionError on mixed types."""
-        from graphistry.exceptions import ArrowConversionError
-        plotter = graphistry.bind()
-        df = pd.DataFrame({'x': [1, 2, 3], 'mixed': [b'bytes', 1.5, 'str']})
-        with pytest.raises(ArrowConversionError, match='Arrow conversion failed'):
-            plotter._table_to_arrow(df, memoize=False, validate_mode='strict-fast')
-
-    def test_validate_autofix_coerces_with_warning(self):
-        """autofix mode coerces mixed types with warning."""
-        plotter = graphistry.bind()
-        df = pd.DataFrame({'x': [1, 2, 3], 'mixed': [b'bytes', 1.5, 'str']})
-        with pytest.warns(RuntimeWarning, match='Coerced mixed-type columns'):
-            arr = plotter._table_to_arrow(df, memoize=False, validate_mode='autofix')
-        assert isinstance(arr, pa.Table)
+            plotter._table_to_arrow(df, memoize=False)
 
     def test_validate_strict_allows_clean_data(self):
-        """strict mode allows clean data through."""
+        """Strict default allows clean data through."""
         plotter = graphistry.bind()
         df = pd.DataFrame({'x': [1, 2, 3], 'weight': [1.1, 2.2, 3.3]})
-        arr = plotter._table_to_arrow(df, memoize=False, validate_mode='strict')
+        arr = plotter._table_to_arrow(df, memoize=False)
         assert isinstance(arr, pa.Table)
 
     # ==========================================================================
     # plot() entrypoint validation tests (Issue #867)
     # ==========================================================================
 
-    def test_plot_strict_mixed_raises(self):
-        """plot(validate='strict') raises on mixed types."""
+    def test_plot_mixed_raises_by_default(self):
+        """plot() defaults to strict Arrow conversion for mixed types."""
         from graphistry.exceptions import ArrowConversionError
         # Use unique data to avoid memoization from other tests
         g = graphistry.edges(pd.DataFrame({
             'src': [10, 20, 30], 'dst': [20, 30, 10], 'mixed': [b'strict1', 1.1, 'test']
         }), 'src', 'dst')
         with pytest.raises(ArrowConversionError):
-            g.plot(skip_upload=True, validate='strict')
+            g.plot(skip_upload=True)
 
-    def test_plot_validate_true_raises(self):
-        """plot(validate=True) maps to strict and raises."""
+    def test_plot_validate_false_does_not_auto_coerce(self):
+        """validate controls settings/encodings and does not silently coerce Arrow data."""
         from graphistry.exceptions import ArrowConversionError
         # Use unique data to avoid memoization from other tests
         g = graphistry.edges(pd.DataFrame({
             'src': [11, 21, 31], 'dst': [21, 31, 11], 'mixed': [b'strict2', 2.2, 'test']
         }), 'src', 'dst')
         with pytest.raises(ArrowConversionError):
-            g.plot(skip_upload=True, validate=True)
+            g.plot(skip_upload=True, validate=False, warn=False)
 
-    def test_plot_autofix_warn_true_warns(self):
-        """plot(validate='autofix', warn=True) coerces WITH warning."""
+    def test_plot_auto_coerce_true_coerces_with_info_log(self):
+        """plot(auto_coerce=True) opts into string coercion with an info log."""
         # Use unique data to avoid memoization from other tests
         g = graphistry.edges(pd.DataFrame({
             'src': [12, 22, 32], 'dst': [22, 32, 12], 'mixed': [b'warn1', 3.3, 'test']
         }), 'src', 'dst')
-        with pytest.warns(RuntimeWarning, match='Coerced mixed-type columns'):
-            result = g.plot(skip_upload=True, validate='autofix', warn=True)
+        with self._patch_plotterbase_logger_info() as info_mock:
+            result = g.plot(skip_upload=True, auto_coerce=True)
         assert result is not None
-
-    def test_plot_autofix_warn_false_silent(self):
-        """plot(validate='autofix', warn=False) coerces WITHOUT warning."""
-        import warnings
-        # Use unique data to avoid memoization from other tests
-        g = graphistry.edges(pd.DataFrame({
-            'src': [13, 23, 33], 'dst': [23, 33, 13], 'mixed': [b'silent1', 4.4, 'test']
-        }), 'src', 'dst')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result = g.plot(skip_upload=True, validate='autofix', warn=False)
-            coerce_warnings = [x for x in w if 'Coerced' in str(x.message)]
-            assert len(coerce_warnings) == 0, f"Expected no warnings with warn=False, got: {coerce_warnings}"
-        assert result is not None
-
-    def test_plot_validate_false_silent(self):
-        """plot(validate=False) maps to autofix+warn=False, coerces silently."""
-        import warnings
-        # Use unique data to avoid memoization from other tests
-        g = graphistry.edges(pd.DataFrame({
-            'src': [14, 24, 34], 'dst': [24, 34, 14], 'mixed': [b'silent2', 5.5, 'test']
-        }), 'src', 'dst')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result = g.plot(skip_upload=True, validate=False)
-            coerce_warnings = [x for x in w if 'Coerced' in str(x.message)]
-            assert len(coerce_warnings) == 0, f"Expected no warnings with validate=False, got: {coerce_warnings}"
-        assert result is not None
+        info_mock.assert_called_once_with(
+            "Auto-coerced mixed-type columns to string for Arrow conversion: %s",
+            ['mixed'],
+        )
 
     # ==========================================================================
     # Encoding validation tests (Issue #867)
@@ -595,6 +646,20 @@ class TestPlotterArrowConversions(NoAuthTestCase):
                 pass
             encoding_warnings = [x for x in w if 'Encoding validation warning' in str(x.message)]
             assert len(encoding_warnings) == 0, f"Expected no warnings with warn=False, got: {encoding_warnings}"
+
+    @pytest.mark.skipif(
+        not ("TEST_CUDF" in os.environ and os.environ["TEST_CUDF"] == "1"),
+        reason="cudf tests need TEST_CUDF=1",
+    )
+    def test_table_to_arrow_cudf_auto_coerce_smoke(self):
+        """auto_coerce=True remains valid on the cuDF Arrow conversion path."""
+        import cudf
+
+        plotter = graphistry.bind()
+        df = cudf.DataFrame({"x": [1, 2], "label": ["a", None]})
+        arr = plotter._table_to_arrow(df, memoize=False, auto_coerce=True)
+        assert isinstance(arr, pa.Table)
+        assert arr.column("label").to_pylist() == ["a", None]
 
     @pytest.mark.skipif(
         not ("TEST_CUDF" in os.environ and os.environ["TEST_CUDF"] == "1"),


### PR DESCRIPTION
Closes #867.

## Summary

- Add `auto_coerce=False` to `plot()`, `upload()`, and `to_arrow()` so Arrow conversion remains strict by default.
- When `auto_coerce=True`, retry failed pandas/cuDF Arrow conversion by probing object columns one at a time and coercing only Arrow-incompatible columns to strings.
- Emit an info log naming coerced columns instead of warning or silently coercing.
- Update docs, changelog, `Plottable` protocol, and anchored regression tests.

## Coercion heuristic

Graphistry first runs the normal Arrow conversion. If pandas/cuDF conversion fails with `ArrowTypeError`/`ArrowInvalid` and `auto_coerce=True`, it tests object columns individually with the same Arrow conversion path. Only columns that fail individual Arrow conversion are coerced to strings; Arrow-compatible object columns are left alone. Pandas coercion uses nullable string dtype so missing values remain Arrow nulls. cuDF uses its string dtype path. This keeps the fallback narrow and mirrors the user workaround from #867 while preserving strict default behavior.

Info-log sample:

```text
Auto-coerced mixed-type columns to string for Arrow conversion: ['amount']
```

## LOC buckets

- Production: +61 / -60, net +1 LOC
- Tests / fixtures / baselines: +129 / -64, net +65 LOC
- Comments / docs / changelog: +17 / -10, net +7 LOC

Compiler-plan surface touched: no. This is public Arrow-conversion API surface only; no GFQL compiler-plan routes, dispatch contracts, error-code/defer-code context, source spans, pass/verifier hooks, schema/type-system hooks, remote schema hooks, or compat executor paths were touched.

## Validation

- `python3 -m pytest -q graphistry/tests/test_plotter.py::TestPlotterArrowConversions` -> 25 passed, 7 skipped, 1 xfailed
- `python3 -m pytest -q graphistry/tests/test_plotter.py graphistry/tests/test_validate_settings.py graphistry/tests/test_schema_artifacts.py graphistry/tests/test_viz_settings.py` -> 83 passed, 10 skipped, 4 xfailed
- `python3 bin/changed_line_coverage.py --data-file /tmp/pr1591.coverage --base-ref origin/master --head-ref HEAD --min-percent 80 --output-dir /tmp/pr1591-changed-coverage` -> passed, 19/23 = 82.61%
- `python3 -m graphistry.devschemas.export --check`
- `./bin/ruff.sh graphistry/PlotterBase.py graphistry/Plottable.py graphistry/exceptions.py graphistry/tests/test_plotter.py`
- `./bin/typecheck.sh graphistry/PlotterBase.py graphistry/Plottable.py graphistry/exceptions.py`
- `git diff --check`
- `ssh dgx-spark 'cd repos/pygraphistry-issue-867-dgx && RAPIDS_VERSION=25.02 PROFILE=basic WITH_GPU=1 WITH_IMAGE_BUILD=0 TEST_FILES="graphistry/tests/test_plotter.py::TestPlotterArrowConversions::test_table_to_arrow_cudf_auto_coerce_smoke graphistry/tests/test_plotter.py::TestPlotterArrowConversions::test_api3_cudf_to_arrow_memoization graphistry/tests/test_plotter.py::TestPlotterArrowConversions::test_api3_cudf_to_arrow_memoization_forgets" docker/test-rapids-official-local.sh'` -> cudf 25.02.02, cuml 25.02.01, Python 3.12.9, 3 passed
- `ssh dgx-spark 'cd repos/pygraphistry-issue-867-dgx && RAPIDS_VERSION=26.02 PROFILE=basic WITH_GPU=1 WITH_IMAGE_BUILD=0 TEST_FILES="graphistry/tests/test_plotter.py::TestPlotterArrowConversions::test_table_to_arrow_cudf_auto_coerce_smoke graphistry/tests/test_plotter.py::TestPlotterArrowConversions::test_api3_cudf_to_arrow_memoization graphistry/tests/test_plotter.py::TestPlotterArrowConversions::test_api3_cudf_to_arrow_memoization_forgets" docker/test-rapids-official-local.sh'` -> cudf 26.02.01, cuml 26.02.00, Python 3.13.12, 3 passed
- Review skill converged: W1 fixed nullable-string coercion; W2/W3 clean; W4 clean after cuDF smoke addition; W5 clean after CI test mock fix; W6 clean after changed-line coverage test amplification

Typecheck note: `./bin/typecheck.sh ... graphistry/tests/test_plotter.py` still hits existing test typing gaps (`pytest` stubs missing and unrelated `COMPLEX_EMPTY` annotation). Production touched files typecheck cleanly.
