### PR TITLE
feat(gfql): strengthen axis diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL policy / Cypher compiler hooks (#1454)**: Added experimental exact-key `precompile` and `postcompile` policy hooks for local Cypher string-query compilation. `postcompile` reports success or failure using the existing policy `success`, `error`, and `error_type` fields plus a stable `CompileSummary` with scalar compiler metadata.
 
 ### Changed
+- **GFQL axis/ring diagnostics (#1245)**: Strengthened `encode_axis` and ring-layout axis validators with anchored row-indexed diagnostics for documented radial/linear axis payload mistakes, while preserving extension-subtype compatibility.
 - **GFQL chain tag warning cleanup (#877)**: Avoided pandas object-dtype `fillna()` downcast warnings when merging named chain tag columns without warning filters or behavior changes.
 - **GFQL chain input docs (#1255)**: Clarified that native GFQL chains must be passed as materialized Python list/dict/`Chain` objects, while `g.gfql(str)` remains the Cypher string-query entrypoint rather than a parser for stringified Python or JSON chain literals.
 - **Compute hop min_hops label semantics (#878)**: `hop(..., min_hops=..., label_node_hops=...)` now labels nodes by the shortest retained path after `min_hops` pruning, instead of keeping a first-seen label from a shorter branch that was filtered out. The cuDF label-fill path now reliably uses merge-based mapping on RAPIDS 25.02+ instead of falling through to `cudf.Series.map(...)`.

--- a/graphistry/compute/gfql/call/validation.py
+++ b/graphistry/compute/gfql/call/validation.py
@@ -45,8 +45,9 @@ from graphistry.compute.gfql.call.support import (
     validate_hypergraph_opts,
 )
 from graphistry.validate import (
-    is_ring_categorical_axis_payload,
-    is_ring_continuous_axis_payload,
+    documented_axis_rows_payload_error,
+    ring_categorical_axis_payload_error,
+    ring_continuous_axis_payload_error,
 )
 from graphistry.compute.gfql.row.order_expr import (
     is_order_aggregate_alias_ast,
@@ -198,6 +199,42 @@ def _validate_list_of_dicts(name: str) -> ParamValidator:
         for i, item in enumerate(v):
             if not isinstance(item, dict):
                 return f"{name}[{i}] must be a dictionary"
+        return True
+    return _validator
+
+
+def _validate_encode_axis_rows(name: str) -> ParamValidator:
+    def _validator(v: object) -> ValidatorResult:
+        if not isinstance(v, list):
+            return f"{name} must be a list of dictionaries"
+        for i, item in enumerate(v):
+            if not isinstance(item, dict):
+                return f"{name}[{i}] must be a dictionary"
+        detail = documented_axis_rows_payload_error(v, name)
+        if detail is not None:
+            return detail
+        return True
+    return _validator
+
+
+def _validate_ring_continuous_axis(name: str) -> ParamValidator:
+    def _validator(v: object) -> ValidatorResult:
+        if v is None:
+            return True
+        detail = ring_continuous_axis_payload_error(v, name)
+        if detail is not None:
+            return detail
+        return True
+    return _validator
+
+
+def _validate_ring_categorical_axis(name: str) -> ParamValidator:
+    def _validator(v: object) -> ValidatorResult:
+        if v is None:
+            return True
+        detail = ring_categorical_axis_payload_error(v, name)
+        if detail is not None:
+            return detail
         return True
     return _validator
 
@@ -690,7 +727,7 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
             'v_start': lambda v: v is None or is_int_or_float(v),
             'v_end': lambda v: v is None or is_int_or_float(v),
             'v_step': lambda v: v is None or is_int_or_float(v),
-            'axis': lambda v: v is None or is_ring_continuous_axis_payload(v),
+            'axis': _validate_ring_continuous_axis('axis'),
             'normalize_ring_col': is_bool,
             'reverse': is_bool,
             'play_ms': lambda v: v is None or is_int(v),
@@ -715,7 +752,7 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
             'append_unhandled': is_bool,
             'min_r': lambda v: v is None or is_int_or_float(v),
             'max_r': lambda v: v is None or is_int_or_float(v),
-            'axis': lambda v: v is None or is_ring_categorical_axis_payload(v),
+            'axis': _validate_ring_categorical_axis('axis'),
             'reverse': is_bool,
             'play_ms': lambda v: v is None or is_int(v),
             'engine': lambda v: v is None or v in ('auto', 'pandas', 'cudf', 'dask', 'dask_cudf')
@@ -906,7 +943,7 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
         'allowed_params': {'rows'},
         'required_params': set(),
         'param_validators': {
-            'rows': _validate_list_of_dicts('rows')
+            'rows': _validate_encode_axis_rows('rows')
         },
         'description': 'Render radial and linear axes with optional labels',
         'schema_effects': NO_SCHEMA_EFFECTS

--- a/graphistry/tests/compute/test_gfql_call_validation.py
+++ b/graphistry/tests/compute/test_gfql_call_validation.py
@@ -379,6 +379,33 @@ class TestEncodeAxisValidation:
         validated = validate_call_params('encode_axis', params)
         assert validated == params
 
+    def test_valid_encode_axis_radial_row(self):
+        """Test documented radial axis row validation."""
+        params = {
+            'rows': [{'r': 10, 'external': True, 'label': 'outer'}]
+        }
+
+        validated = validate_call_params('encode_axis', params)
+        assert validated == params
+
+    def test_valid_encode_axis_linear_row(self):
+        """Test documented linear axis row validation."""
+        params = {
+            'rows': [{'y': 40, 'width': 20, 'bounds': {'min': 40, 'max': 400}}]
+        }
+
+        validated = validate_call_params('encode_axis', params)
+        assert validated == params
+
+    def test_encode_axis_allows_extension_subtype_rows(self):
+        """Test extension subtypes remain payload-compatible."""
+        params = {
+            'rows': [{'kind': 'polar-v2', 'radius': 10, 'label': 7}]
+        }
+
+        validated = validate_call_params('encode_axis', params)
+        assert validated == params
+
     def test_encode_axis_allows_default_rows(self):
         """Test that encode_axis mirrors direct Plottable default rows behavior."""
         params = {}
@@ -397,6 +424,36 @@ class TestEncodeAxisValidation:
 
         assert exc_info.value.message == (
             "Invalid value for parameter 'rows' in 'encode_axis': rows[1] must be a dictionary"
+        )
+
+    def test_encode_axis_rejects_radial_wrong_key(self):
+        """Test row-indexed diagnostics for documented radial row keys."""
+        params = {
+            'rows': [{'r': 10, 'radius': 10}]
+        }
+
+        with pytest.raises(GFQLTypeError) as exc_info:
+            validate_call_params('encode_axis', params)
+
+        assert exc_info.value.message == (
+            "Invalid value for parameter 'rows' in 'encode_axis': "
+            "rows[0] radial axis row has unexpected key 'radius'; expected keys: "
+            "axisKind, axis_subtype, bounds, external, internal, kind, label, r, space, width, x, y"
+        )
+
+    def test_encode_axis_rejects_missing_position_key(self):
+        """Test row-indexed diagnostics for axis rows missing required position keys."""
+        params = {
+            'rows': [{'label': 'missing position'}]
+        }
+
+        with pytest.raises(GFQLTypeError) as exc_info:
+            validate_call_params('encode_axis', params)
+
+        assert exc_info.value.message == (
+            "Invalid value for parameter 'rows' in 'encode_axis': "
+            "rows[0] axis row is missing required key one of r, x, y; expected keys: "
+            "axisKind, axis_subtype, bounds, external, internal, kind, label, r, space, width, x, y"
         )
 
     def test_encode_axis_rejects_non_list_rows(self):
@@ -665,7 +722,11 @@ class TestRingAxisValidation:
                 'ring_col': 'segment',
                 'axis': [{'label': 'missing_pos'}],
             })
-        assert 'axis' in exc_info.value.message
+        assert exc_info.value.message == (
+            "Invalid value for parameter 'axis' in 'ring_categorical_layout': "
+            "axis[0] is missing one of required position keys: r, x, y; expected keys: "
+            "bounds, external, internal, label, r, space, width, x, y"
+        )
 
     def test_ring_continuous_axis_accepts_string_labels(self):
         params = validate_call_params('ring_continuous_layout', {
@@ -687,7 +748,10 @@ class TestRingAxisValidation:
                 'ring_col': 'score',
                 'axis': [{'y': 40, 'bounds': {'min': '40', 'max': 100}}],
             })
-        assert 'axis' in exc_info.value.message
+        assert exc_info.value.message == (
+            "Invalid value for parameter 'axis' in 'ring_continuous_layout': "
+            "axis[0].bounds['min'] must be a number"
+        )
 
 
 if __name__ == '__main__':

--- a/graphistry/tests/test_gfql_remote_metadata.py
+++ b/graphistry/tests/test_gfql_remote_metadata.py
@@ -14,7 +14,8 @@ import pandas as pd
 import zipfile
 
 import graphistry
-from graphistry.compute.ast import ASTNode
+from graphistry.compute.ast import ASTNode, call
+from graphistry.compute.exceptions import GFQLTypeError
 
 
 # Mock metadata structures mirroring arrow uploader format
@@ -307,6 +308,51 @@ class TestGFQLRemoteMetadataHydration(unittest.TestCase):
         assert result._url_params["lockedX"] is True
         assert result._url_params["lockedY"] is True
         assert result._url_params["splashAfter"] is False
+
+    @patch('graphistry.compute.chain_remote.requests.post')
+    def test_encode_axis_validation_fails_pre_wire(self, mock_post):
+        self.g._dataset_id = "test_dataset_123"
+
+        with self.assertRaises(GFQLTypeError) as cm:
+            self.g.gfql_remote(
+                [call("encode_axis", {"rows": [{"r": 10, "radius": 10}]})],
+                format="json",
+                api_token="test_token",
+            )
+
+        self.assertEqual(
+            cm.exception.message,
+            "Invalid value for parameter 'rows' in 'encode_axis': "
+            "rows[0] radial axis row has unexpected key 'radius'; expected keys: "
+            "axisKind, axis_subtype, bounds, external, internal, kind, label, r, space, width, x, y",
+        )
+        mock_post.assert_not_called()
+
+    @patch('graphistry.compute.chain_remote.requests.post')
+    def test_ring_axis_validation_fails_pre_wire(self, mock_post):
+        self.g._dataset_id = "test_dataset_123"
+
+        with self.assertRaises(GFQLTypeError) as cm:
+            self.g.gfql_remote(
+                [
+                    call(
+                        "ring_continuous_layout",
+                        {
+                            "ring_col": "score",
+                            "axis": [{"y": 40, "bounds": {"min": "40", "max": 100}}],
+                        },
+                    )
+                ],
+                format="json",
+                api_token="test_token",
+            )
+
+        self.assertEqual(
+            cm.exception.message,
+            "Invalid value for parameter 'axis' in 'ring_continuous_layout': "
+            "axis[0].bounds['min'] must be a number",
+        )
+        mock_post.assert_not_called()
 
     @patch('graphistry.compute.chain_remote.requests.post')
     def test_empty_metadata_doesnt_break(self, mock_post):

--- a/graphistry/validate/__init__.py
+++ b/graphistry/validate/__init__.py
@@ -47,14 +47,23 @@ from graphistry.models.surfaces import (  # noqa: E402, F401
     apply_encodings_keys,
     SettingsValue,
 )
+from .validate_axis import (  # noqa: E402, F401
+    axis_bounds_payload_error,
+    is_axis_bounds_payload,
+    axis_row_payload_error,
+    is_axis_row_payload,
+    axis_rows_payload_error,
+    is_axis_rows_payload,
+    documented_axis_row_payload_error,
+    documented_axis_rows_payload_error,
+    ring_continuous_axis_payload_error,
+    is_ring_continuous_axis_payload,
+    ring_categorical_axis_payload_error,
+    is_ring_categorical_axis_payload,
+)
 from .validate_settings import (  # noqa: E402, F401
     normalize_url_params,
     normalize_react_settings,
-    is_axis_bounds_payload,
-    is_axis_row_payload,
-    is_axis_rows_payload,
-    is_ring_continuous_axis_payload,
-    is_ring_categorical_axis_payload,
     classify_axis_kind,
     apply_axis_url_defaults,
 )

--- a/graphistry/validate/validate_axis.py
+++ b/graphistry/validate/validate_axis.py
@@ -1,0 +1,207 @@
+"""Axis and ring-axis payload validation helpers."""
+
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
+
+from graphistry.models.surfaces.graphistry_frontend.axis import (
+    AXIS_BOUNDS_ALLOWED_KEYS,
+    AXIS_ROW_ALLOWED_KEYS,
+    AXIS_ROW_BOOL_KEYS,
+    AXIS_ROW_NUMERIC_KEYS,
+    AXIS_ROW_POSITION_KEYS,
+)
+
+
+def _is_non_bool_number(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _format_keys(keys: Iterable[str]) -> str:
+    return ", ".join(sorted(keys))
+
+
+def is_axis_bounds_payload(v: object) -> bool:
+    return axis_bounds_payload_error(v, "bounds") is None
+
+
+def axis_bounds_payload_error(v: object, path: str) -> Optional[str]:
+    if not isinstance(v, dict):
+        return f"{path} must be a dictionary"
+    allowed_keys = set(AXIS_BOUNDS_ALLOWED_KEYS)
+    for key in v.keys():
+        if key not in allowed_keys:
+            return f"{path} has unexpected key '{key}'; expected keys: {_format_keys(allowed_keys)}"
+    if "min" in v and not _is_non_bool_number(v["min"]):
+        return f"{path}['min'] must be a number"
+    if "max" in v and not _is_non_bool_number(v["max"]):
+        return f"{path}['max'] must be a number"
+    return None
+
+
+def is_axis_row_payload(v: object) -> bool:
+    return axis_row_payload_error(v, "row") is None
+
+
+def axis_row_payload_error(v: object, path: str) -> Optional[str]:
+    if not isinstance(v, dict):
+        return f"{path} must be a dictionary"
+    allowed_keys = set(AXIS_ROW_ALLOWED_KEYS)
+    for key in v.keys():
+        if key not in allowed_keys:
+            return f"{path} has unexpected key '{key}'; expected keys: {_format_keys(allowed_keys)}"
+    if "label" in v and not isinstance(v["label"], str):
+        return f"{path}['label'] must be a string"
+    for k in AXIS_ROW_NUMERIC_KEYS:
+        if k in v and not _is_non_bool_number(v[k]):
+            return f"{path}['{k}'] must be a number"
+    for k in AXIS_ROW_BOOL_KEYS:
+        if k in v and not isinstance(v[k], bool):
+            return f"{path}['{k}'] must be a boolean"
+    if "bounds" in v:
+        bounds_error = axis_bounds_payload_error(v["bounds"], f"{path}.bounds")
+        if bounds_error is not None:
+            return bounds_error
+    if all(k not in v for k in AXIS_ROW_POSITION_KEYS):
+        return (
+            f"{path} is missing one of required position keys: "
+            f"{_format_keys(AXIS_ROW_POSITION_KEYS)}; expected keys: {_format_keys(allowed_keys)}"
+        )
+    return None
+
+
+def is_axis_rows_payload(v: object) -> bool:
+    return axis_rows_payload_error(v, "rows") is None
+
+
+def axis_rows_payload_error(v: object, path: str) -> Optional[str]:
+    if not isinstance(v, list):
+        return f"{path} must be a list of axis row dictionaries"
+    for i, item in enumerate(v):
+        row_error = axis_row_payload_error(item, f"{path}[{i}]")
+        if row_error is not None:
+            return row_error
+    return None
+
+
+_AXIS_SUBTYPE_KEYS: Tuple[str, ...] = ("axis_subtype", "axisKind", "kind")
+_AXIS_DECLARATION_KEYS: Set[str] = set(_AXIS_SUBTYPE_KEYS)
+_RADIAL_AXIS_ROW_KEYS: Set[str] = set(AXIS_ROW_ALLOWED_KEYS).union(_AXIS_DECLARATION_KEYS)
+_LINEAR_AXIS_ROW_KEYS: Set[str] = (
+    set(AXIS_ROW_ALLOWED_KEYS).difference({"r"}).union(_AXIS_DECLARATION_KEYS)
+)
+
+
+def _declared_axis_kind(row: Dict[Any, Any]) -> Optional[str]:
+    for key in _AXIS_SUBTYPE_KEYS:
+        value = row.get(key)
+        if isinstance(value, str) and value != "":
+            return value.lower()
+    return None
+
+
+def _documented_axis_kind(row: Dict[Any, Any]) -> Optional[str]:
+    declared = _declared_axis_kind(row)
+    if declared is not None:
+        return declared if declared in {"radial", "linear"} else "extension"
+    if "r" in row:
+        return "radial"
+    if "x" in row or "y" in row:
+        return "linear"
+    if any(key in row for key in AXIS_ROW_ALLOWED_KEYS):
+        return "axis"
+    return None
+
+
+def documented_axis_row_payload_error(v: object, path: str) -> Optional[str]:
+    if not isinstance(v, dict):
+        return f"{path} must be a dictionary"
+    kind = _documented_axis_kind(v)
+    if kind == "extension" or kind is None:
+        return None
+
+    if kind == "radial":
+        allowed_keys = _RADIAL_AXIS_ROW_KEYS
+        required_msg = "'r'"
+        has_required = "r" in v
+        label = "radial axis row"
+    elif kind == "linear":
+        allowed_keys = _LINEAR_AXIS_ROW_KEYS
+        required_msg = "one of 'x' or 'y'"
+        has_required = "x" in v or "y" in v
+        label = "linear axis row"
+    else:
+        allowed_keys = set(AXIS_ROW_ALLOWED_KEYS).union(_AXIS_DECLARATION_KEYS)
+        required_msg = f"one of {_format_keys(AXIS_ROW_POSITION_KEYS)}"
+        has_required = any(key in v for key in AXIS_ROW_POSITION_KEYS)
+        label = "axis row"
+
+    for key in v.keys():
+        if key not in allowed_keys:
+            return f"{path} {label} has unexpected key '{key}'; expected keys: {_format_keys(allowed_keys)}"
+    if not has_required:
+        return f"{path} {label} is missing required key {required_msg}; expected keys: {_format_keys(allowed_keys)}"
+    for key in AXIS_ROW_NUMERIC_KEYS:
+        if key in v and not _is_non_bool_number(v[key]):
+            return f"{path}['{key}'] must be a number"
+    for key in AXIS_ROW_BOOL_KEYS:
+        if key in v and not isinstance(v[key], bool):
+            return f"{path}['{key}'] must be a boolean"
+    if "label" in v and not isinstance(v["label"], str):
+        return f"{path}['label'] must be a string"
+    if "bounds" in v:
+        bounds_error = axis_bounds_payload_error(v["bounds"], f"{path}.bounds")
+        if bounds_error is not None:
+            return bounds_error
+    return None
+
+
+def documented_axis_rows_payload_error(v: object, path: str) -> Optional[str]:
+    if not isinstance(v, list):
+        return f"{path} must be a list of axis row dictionaries"
+    for i, item in enumerate(v):
+        row_error = documented_axis_row_payload_error(item, f"{path}[{i}]")
+        if row_error is not None:
+            return row_error
+    return None
+
+
+def is_ring_continuous_axis_payload(v: object) -> bool:
+    return ring_continuous_axis_payload_error(v, "axis") is None
+
+
+def ring_continuous_axis_payload_error(v: object, path: str) -> Optional[str]:
+    rows_error = axis_rows_payload_error(v, path)
+    if rows_error is None:
+        return None
+    if isinstance(v, list):
+        if any(isinstance(item, dict) for item in v):
+            return rows_error
+        for i, item in enumerate(v):
+            if not isinstance(item, str):
+                return f"{path}[{i}] must be a string label or axis row dictionary"
+        return None
+    if isinstance(v, dict):
+        for key, val in v.items():
+            if not _is_non_bool_number(key):
+                return f"{path} key {key!r} must be a number"
+            if not isinstance(val, str):
+                return f"{path}[{key!r}] must be a string"
+        return None
+    return f"{path} must be axis rows, a list of string labels, or a numeric-to-string label map"
+
+
+def is_ring_categorical_axis_payload(v: object) -> bool:
+    return ring_categorical_axis_payload_error(v, "axis") is None
+
+
+def ring_categorical_axis_payload_error(v: object, path: str) -> Optional[str]:
+    rows_error = axis_rows_payload_error(v, path)
+    if rows_error is None:
+        return None
+    if isinstance(v, list):
+        return rows_error
+    if isinstance(v, dict):
+        for key, val in v.items():
+            if not isinstance(val, str):
+                return f"{path}[{key!r}] must be a string"
+        return None
+    return f"{path} must be axis rows or a categorical-to-string label map"

--- a/graphistry/validate/validate_settings.py
+++ b/graphistry/validate/validate_settings.py
@@ -1,13 +1,6 @@
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional
 
-from graphistry.models.surfaces.graphistry_frontend.axis import (
-    AXIS_BOUNDS_ALLOWED_KEYS,
-    AXIS_ROW_ALLOWED_KEYS,
-    AXIS_ROW_BOOL_KEYS,
-    AXIS_ROW_NUMERIC_KEYS,
-    AXIS_ROW_POSITION_KEYS,
-    AxisKind,
-)
+from graphistry.models.surfaces.graphistry_frontend.axis import AxisKind
 from graphistry.models.surfaces.graphistry_frontend.react_settings import (
     REACT_SETTING_NAMES,
     ReactSettingsDict,
@@ -21,62 +14,6 @@ from graphistry.models.surfaces.graphistry_frontend.settings_value import Settin
 from graphistry.models.types import ValidationMode, ValidationParam
 from graphistry.util import warn as emit_warn
 from graphistry.validate.common import normalize_validation_params
-
-
-def _is_non_bool_number(v: Any) -> bool:
-    return isinstance(v, (int, float)) and not isinstance(v, bool)
-
-
-def is_axis_bounds_payload(v: object) -> bool:
-    if not isinstance(v, dict):
-        return False
-    if any(k not in AXIS_BOUNDS_ALLOWED_KEYS for k in v.keys()):
-        return False
-    if "min" in v and not _is_non_bool_number(v["min"]):
-        return False
-    if "max" in v and not _is_non_bool_number(v["max"]):
-        return False
-    return True
-
-
-def is_axis_row_payload(v: object) -> bool:
-    if not isinstance(v, dict):
-        return False
-    if any(k not in AXIS_ROW_ALLOWED_KEYS for k in v.keys()):
-        return False
-    if "label" in v and not isinstance(v["label"], str):
-        return False
-    for k in AXIS_ROW_NUMERIC_KEYS:
-        if k in v and not _is_non_bool_number(v[k]):
-            return False
-    for k in AXIS_ROW_BOOL_KEYS:
-        if k in v and not isinstance(v[k], bool):
-            return False
-    if "bounds" in v and not is_axis_bounds_payload(v["bounds"]):
-        return False
-    if all(k not in v for k in AXIS_ROW_POSITION_KEYS):
-        return False
-    return True
-
-
-def is_axis_rows_payload(v: object) -> bool:
-    return isinstance(v, list) and all(is_axis_row_payload(item) for item in v)
-
-
-def is_ring_continuous_axis_payload(v: object) -> bool:
-    if is_axis_rows_payload(v):
-        return True
-    if isinstance(v, list):
-        return all(isinstance(item, str) for item in v)
-    if isinstance(v, dict):
-        return all(_is_non_bool_number(k) and isinstance(val, str) for k, val in v.items())
-    return False
-
-
-def is_ring_categorical_axis_payload(v: object) -> bool:
-    if is_axis_rows_payload(v):
-        return True
-    return isinstance(v, dict) and all(isinstance(val, str) for val in v.values())
 
 
 def _issue(


### PR DESCRIPTION
## Summary
- Strengthen GFQL `encode_axis` validation with row-indexed diagnostics for documented radial/linear axis rows.
- Add detail-returning ring axis validators so `ring_continuous_layout(axis=...)` and `ring_categorical_layout(axis=...)` fail with anchored payload paths instead of generic type errors.
- Factor axis/ring payload diagnostics into `graphistry.validate.validate_axis`, keeping `graphistry.validate` public exports stable and leaving `validate_settings.py` focused on settings normalization/defaults.
- Add mocked `gfql_remote()` pre-wire tests proving axis/ring misuse is caught client-side before `requests.post`.

Closes #1245

## Anchored Diagnostic Samples
- `encode_axis`: `Invalid value for parameter 'rows' in 'encode_axis': rows[0] radial axis row has unexpected key 'radius'; expected keys: axisKind, axis_subtype, bounds, external, internal, kind, label, r, space, width, x, y`
- `encode_axis`: `Invalid value for parameter 'rows' in 'encode_axis': rows[0] axis row is missing required key one of r, x, y; expected keys: axisKind, axis_subtype, bounds, external, internal, kind, label, r, space, width, x, y`
- `ring_categorical_layout`: `Invalid value for parameter 'axis' in 'ring_categorical_layout': axis[0] is missing one of required position keys: r, x, y; expected keys: bounds, external, internal, label, r, space, width, x, y`
- `ring_continuous_layout`: `Invalid value for parameter 'axis' in 'ring_continuous_layout': axis[0].bounds['min'] must be a number`

## Compatibility
- Public viz payload compatibility is not narrowed for direct `g.encode_axis(...)`.
- GFQL `call('encode_axis', ...)` remains tolerant for unknown/extension subtypes: declared non-`radial`/`linear` subtype rows are not key-narrowed.
- Documented radial/linear rows get strict diagnostics when their shape is explicit or inferable.

## LOC Buckets
- Production: +264 / -74, net +190 LOC
- Tests: +113 / -3, net +110 LOC
- Docs/changelog: +1 / -0, net +1 LOC

## Compiler-Plan Surface Touched
No. This is runtime call validation and remote preflight diagnostic coverage only; no logical/physical planning semantics, route names, dispatch contracts, compiler diagnostic context, source spans, pass/verifier hooks, schema/type-system hooks, IR metadata, remote schema hooks, public compatibility shims, or compat executor surfaces were changed.

## Validation
- `python3 -m pytest -q graphistry/tests/compute/test_gfql_call_validation.py graphistry/tests/compute/test_call_operations.py -k "axis or ring or encode"` -> 34 passed, 37 deselected
- `python3 -m pytest -q graphistry/tests/test_gfql_remote_metadata.py graphistry/tests/test_validate_settings.py` -> 33 passed
- `./bin/ruff.sh graphistry/validate/validate_axis.py graphistry/validate/validate_settings.py graphistry/validate/__init__.py graphistry/compute/gfql/call/validation.py graphistry/tests/compute/test_gfql_call_validation.py graphistry/tests/test_gfql_remote_metadata.py` -> passed
- `./bin/typecheck.sh graphistry/validate/validate_axis.py graphistry/validate/validate_settings.py graphistry/validate/__init__.py graphistry/compute/gfql/call/validation.py` -> passed
- `git -C /home/lmeyerov/Work/pygraphistry3 diff --check` -> passed

## DGX / RAPIDS
Skipped. This PR changes runtime validation and mocked remote preflight coverage only; no DataFrame, cuDF, GPU, or row-pipeline execution path was touched.
