### PR TITLE
feat(gfql): expose layout chain predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Added
+- **GFQL layout-chain predicate (#1254)**: Added public `is_layout_chain()` and `is_layout_kind()` helpers plus canonical layout/radial registry constants so downstream tooling can detect safelisted layout calls from GFQL `Chain` objects, chain lists, wire dictionaries, and legitimate pre-parse strings without maintaining brittle string-match lists. Also exposed `circle_layout`, `tree_layout`, `mercator_layout`, and `modularity_weighted_layout` as GFQL `call()` operations.
 - **Schema artifacts for tooling contracts (#1326)**: Added committed structural JSON Schema artifacts for encodings, React settings, and URL params, plus a stdlib exporter/checker and CI drift guard for downstream LLM/tooling contract generation.
 - **Viz settings public contracts (#1234)**: Added `graphistry.viz_settings` as a public facade for canonical URL-parameter and React-facing visualization setting key constants, `Literal` key aliases, typed settings payloads, and frontend contract metadata for downstream type-checking.
 - **GFQL encode call parity (#1241)**: Added GFQL `call()` support for `encode_edge_icon` and `encode_axis`, plus deeper encode validator diagnostics for palette and categorical mapping payloads before remote or local execution.

--- a/docs/source/gfql/builtin_calls.rst
+++ b/docs/source/gfql/builtin_calls.rst
@@ -41,6 +41,40 @@ All Call operations:
 
 Call operations stay in graph state: the result remains a traversable graph with meaningful `_edges`, so you can keep matching or compose additional graph stages with `let()` / `ref()`. If you want row/tabular output, switch into row-pipeline operators such as `rows()`, `with_()`, `select()`, `return_()`, `group_by()`, or use a row-returning local Cypher `CALL ... YIELD ... RETURN ...` query.
 
+Layout-aware consumers can detect layout helper calls without maintaining their
+own string lists:
+
+.. code-block:: python
+
+    from graphistry.compute import call
+    from graphistry.compute.gfql import (
+        LAYOUT_FUNCTION_NAMES,
+        RADIAL_LAYOUT_FUNCTION_NAMES,
+        RADIAL_LAYOUT_KINDS,
+        is_layout_chain,
+        is_layout_kind,
+    )
+
+    chain = [call('time_ring_layout', {'time_col': 'ts'})]
+    kind = is_layout_kind(chain)
+
+    assert is_layout_chain(chain)
+    assert kind == 'time_ring'
+    assert kind in RADIAL_LAYOUT_KINDS
+    assert 'time_ring_layout' in RADIAL_LAYOUT_FUNCTION_NAMES
+    assert 'group_in_a_box_layout' in LAYOUT_FUNCTION_NAMES
+    assert 'tree_layout' in LAYOUT_FUNCTION_NAMES
+
+The helpers accept materialized GFQL ``Chain`` objects, list/tuple chains, Chain
+wire dictionaries, and direct ``Call`` objects/dicts. Opaque strings are not
+parsed, so pass native GFQL structures rather than substring-matching query
+text. For legitimate pre-parse string diagnostics, use
+``LAYOUT_FUNCTION_NAMES`` or ``RADIAL_LAYOUT_FUNCTION_NAMES`` as the canonical
+safelisted function-name registries instead of maintaining local copies.
+These registries reflect GFQL ``call()`` safelist names. Legacy ``radial_*``
+names are not safelisted pygraphistry function names; normalize them before
+calling these helpers.
+
 Graph Transformation Methods
 ----------------------------
 
@@ -1025,6 +1059,219 @@ PyGraphistry's implementation is optimized for large graphs on both CPU and GPU.
     ])
 
 **Schema Effects:** Modifies node positions and optionally adds color encoding.
+
+circle_layout
+~~~~~~~~~~~~~
+
+Arrange nodes in a circular layout.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Parameter
+     - Type
+     - Required
+     - Description
+   * - bounding_box
+     - list[number]
+     - No
+     - ``[cx, cy, width, height]`` bounding box. If omitted, the graph must already have ``x``/``y`` node positions.
+   * - ring_spacing
+     - number
+     - No
+     - Spacing between rings
+   * - point_spacing
+     - number
+     - No
+     - Spacing between points
+   * - partition_by
+     - string or list[string]
+     - No
+     - Node column(s) for partitioned circles
+   * - sort_by
+     - string or list[string]
+     - No
+     - Node column(s) for sort order
+   * - ascending
+     - boolean or list[boolean]
+     - No
+     - Sort direction
+   * - na_position
+     - string
+     - No
+     - ``'first'`` or ``'last'``
+   * - ignore_index
+     - boolean
+     - No
+     - Whether to ignore index during sort
+   * - engine
+     - string
+     - No
+     - Engine (``'auto'``, ``'pandas'``, ``'cudf'``, ``'dask'``, ``'dask_cudf'``)
+
+**Example:**
+
+.. code-block:: python
+
+    g.gfql([
+        call('circle_layout', {
+            'bounding_box': [0, 0, 1000, 1000],
+            'engine': 'pandas'
+        })
+    ])
+
+**Schema Effects:** Modifies node positions.
+
+tree_layout
+~~~~~~~~~~~
+
+Apply the Sugiyama-style tree layout.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Parameter
+     - Type
+     - Required
+     - Description
+   * - level_col
+     - string
+     - No
+     - Output level column
+   * - level_sort_values_by
+     - string or list[string]
+     - No
+     - Column(s) for ordering nodes within levels
+   * - level_sort_values_by_ascending
+     - boolean
+     - No
+     - Sort direction for level ordering
+   * - width
+     - number
+     - No
+     - Layout width multiplier
+   * - height
+     - number
+     - No
+     - Layout height multiplier
+   * - rotate
+     - number
+     - No
+     - Rotation in degrees
+   * - allow_cycles
+     - boolean
+     - No
+     - Whether to tolerate cyclic inputs
+   * - root
+     - string/number/boolean
+     - No
+     - Optional root node id
+
+**Example:**
+
+.. code-block:: python
+
+    g.gfql([
+        call('tree_layout', {'level_col': 'level'})
+    ])
+
+**Schema Effects:** Modifies node positions and adds a level column.
+
+mercator_layout
+~~~~~~~~~~~~~~~
+
+Project latitude/longitude node columns into local Mercator coordinates.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Parameter
+     - Type
+     - Required
+     - Description
+   * - scale_for_graphistry
+     - boolean
+     - No
+     - Use scaled coordinates suitable for Graphistry visualization
+
+**Example:**
+
+.. code-block:: python
+
+    geo_nodes = pd.DataFrame({
+        'id': ['nyc', 'sf'],
+        'latitude': [40.7128, 37.7749],
+        'longitude': [-74.0060, -122.4194],
+    })
+
+    graphistry.nodes(geo_nodes, 'id').gfql([
+        call('mercator_layout')
+    ])
+
+**Schema Effects:** Modifies node positions.
+
+modularity_weighted_layout
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prepare a community-weighted layout by weighting edges within and across communities.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Parameter
+     - Type
+     - Required
+     - Description
+   * - community_col
+     - string
+     - No
+     - Existing node community column
+   * - community_alg
+     - string
+     - No
+     - Community algorithm when ``community_col`` is omitted
+   * - community_params
+     - dict
+     - No
+     - Community algorithm parameters
+   * - same_community_weight
+     - number
+     - No
+     - Edge weight for within-community edges
+   * - cross_community_weight
+     - number
+     - No
+     - Edge weight for cross-community edges
+   * - edge_influence
+     - number
+     - No
+     - Graphistry edge influence setting
+   * - engine
+     - string
+     - No
+     - Engine (``'auto'``, ``'pandas'``, ``'cudf'``)
+
+**Example:**
+
+.. code-block:: python
+
+    g.gfql([
+        call('modularity_weighted_layout', {'community_col': 'department'})
+    ])
+
+**Schema Effects:** Adds edge weight columns and binds edge weight. May add a community column when ``community_col`` is omitted.
 
 Filtering and Transformation Methods
 ------------------------------------

--- a/docs/source/gfql/spec/language.md
+++ b/docs/source/gfql/spec/language.md
@@ -477,6 +477,11 @@ For security and stability, Call operations are restricted to a predefined safel
 - `ring_continuous_layout`: Radial layout driven by numeric attributes
 - `ring_categorical_layout`: Radial layout grouping by categories
 - `time_ring_layout`: Time-series radial layout (accepts ISO timestamp bounds)
+- `group_in_a_box_layout`: Group-in-a-box community layout
+- `circle_layout`: Circular node layout
+- `tree_layout`: Sugiyama-style tree layout
+- `mercator_layout`: Mercator projection for latitude/longitude node coordinates
+- `modularity_weighted_layout`: Community-weighted edge layout preparation
 
 ```{note}
 `time_ring_layout` accepts ISO-8601 strings for `time_start` / `time_end` when

--- a/docs/source/gfql/spec/llm_guide.md
+++ b/docs/source/gfql/spec/llm_guide.md
@@ -545,7 +545,7 @@ See [Quick Example](#quick-example-fraud-detection) for full JSON example.
 
 **Filters:** `filter_nodes_by_dict`, `filter_edges_by_dict`, `hop`, `drop_nodes`, `keep_nodes`
 
-**Layouts:** `layout_cugraph`, `layout_igraph`, `fa2_layout`, `group_in_a_box_layout`
+**Layouts:** `layout_cugraph`, `layout_igraph`, `layout_graphviz`, `fa2_layout`, `ring_continuous_layout`, `ring_categorical_layout`, `time_ring_layout`, `group_in_a_box_layout`, `circle_layout`, `tree_layout`, `mercator_layout`, `modularity_weighted_layout`
 
 **Encodings:** `encode_point_color`, `encode_edge_color`, `encode_point_size`, `encode_point_icon`
 

--- a/graphistry/compute/gfql/__init__.py
+++ b/graphistry/compute/gfql/__init__.py
@@ -28,6 +28,15 @@ from graphistry.compute.gfql.rollout import (
     strict_schema_env_default,
 )
 
+from graphistry.compute.gfql.layout import (
+    LAYOUT_FUNCTION_NAMES,
+    LAYOUT_KINDS,
+    RADIAL_LAYOUT_FUNCTION_NAMES,
+    RADIAL_LAYOUT_KINDS,
+    is_layout_chain,
+    is_layout_kind,
+)
+
 __all__ = [
     # Validation classes
     'ValidationIssue',
@@ -55,4 +64,12 @@ __all__ = [
     'env_bool',
     'resolve_strict_schema',
     'strict_schema_env_default',
+
+    # Layout chain helpers
+    'LAYOUT_FUNCTION_NAMES',
+    'LAYOUT_KINDS',
+    'RADIAL_LAYOUT_FUNCTION_NAMES',
+    'RADIAL_LAYOUT_KINDS',
+    'is_layout_chain',
+    'is_layout_kind',
 ]

--- a/graphistry/compute/gfql/call/validation.py
+++ b/graphistry/compute/gfql/call/validation.py
@@ -134,6 +134,29 @@ def _expr_required_cols(params: Dict[str, object], key: str = 'expr') -> List[st
     expr = params.get(key)
     return _where_rows_expr_required_cols(expr) if isinstance(expr, str) else []
 
+def _is_string_or_string_list_or_none(v: object) -> bool:
+    return v is None or is_string(v) or is_list_of_strings(v)
+
+
+def _is_bool_or_bool_list(v: object) -> bool:
+    return isinstance(v, bool) or (
+        isinstance(v, list)
+        and all(isinstance(item, bool) for item in v)
+    )
+
+
+def _is_numeric_quad(v: object) -> bool:
+    return (
+        isinstance(v, (list, tuple))
+        and len(v) == 4
+        and all(is_int_or_float(item) for item in v)
+    )
+
+
+def _is_json_scalar_or_none(v: object) -> bool:
+    return v is None or isinstance(v, (str, int, float, bool))
+
+
 def is_order_keys(v: object) -> bool:
     def _is_static_order_expr_supported(expr: str) -> bool:
         txt = expr.strip()
@@ -799,6 +822,82 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
         'schema_effects': XY_NODE_SCHEMA_EFFECTS
     },
 
+    'circle_layout': {
+        'allowed_params': {
+            'bounding_box', 'ring_spacing', 'point_spacing', 'partition_by',
+            'sort_by', 'ascending', 'na_position', 'ignore_index', 'engine'
+        },
+        'required_params': set(),
+        'param_validators': {
+            'bounding_box': lambda v: v is None or _is_numeric_quad(v),
+            'ring_spacing': lambda v: v is None or is_int_or_float(v),
+            'point_spacing': lambda v: v is None or is_int_or_float(v),
+            'partition_by': _is_string_or_string_list_or_none,
+            'sort_by': _is_string_or_string_list_or_none,
+            'ascending': _is_bool_or_bool_list,
+            'na_position': lambda v: v in ('first', 'last'),
+            'ignore_index': is_bool,
+            'engine': lambda v: v in ('auto', 'pandas', 'cudf', 'dask', 'dask_cudf')
+        },
+        'description': 'Circular node layout',
+        'schema_effects': XY_NODE_SCHEMA_EFFECTS
+    },
+
+    'tree_layout': {
+        'allowed_params': {
+            'level_col', 'level_sort_values_by', 'level_sort_values_by_ascending',
+            'width', 'height', 'rotate', 'allow_cycles', 'root'
+        },
+        'required_params': set(),
+        'param_validators': {
+            'level_col': is_string_or_none,
+            'level_sort_values_by': _is_string_or_string_list_or_none,
+            'level_sort_values_by_ascending': is_bool,
+            'width': lambda v: v is None or is_int_or_float(v),
+            'height': lambda v: v is None or is_int_or_float(v),
+            'rotate': lambda v: v is None or is_int_or_float(v),
+            'allow_cycles': is_bool,
+            'root': _is_json_scalar_or_none
+        },
+        'description': 'Sugiyama-style tree layout',
+        'schema_effects': XY_NODE_SCHEMA_EFFECTS
+    },
+
+    'mercator_layout': {
+        'allowed_params': {'scale_for_graphistry'},
+        'required_params': set(),
+        'param_validators': {
+            'scale_for_graphistry': is_bool
+        },
+        'description': 'Mercator projection layout for latitude/longitude node coordinates',
+        'schema_effects': XY_NODE_SCHEMA_EFFECTS
+    },
+
+    'modularity_weighted_layout': {
+        'allowed_params': {
+            'community_col', 'community_alg', 'community_params',
+            'same_community_weight', 'cross_community_weight', 'edge_influence',
+            'engine'
+        },
+        'required_params': set(),
+        'param_validators': {
+            'community_col': is_string_or_none,
+            'community_alg': is_string_or_none,
+            'community_params': lambda v: v is None or is_dict(v),
+            'same_community_weight': is_int_or_float,
+            'cross_community_weight': is_int_or_float,
+            'edge_influence': is_int_or_float,
+            'engine': lambda v: v in ('auto', 'pandas', 'cudf')
+        },
+        'description': 'Community-weighted edge layout preparation',
+        'schema_effects': {
+            'adds_node_cols': lambda p: [] if isinstance(p.get('community_col'), str) else [p.get('community_alg') or 'community_multilevel'],
+            'adds_edge_cols': ['weight', 'same_community'],
+            'requires_node_cols': lambda p: [p['community_col']] if isinstance(p.get('community_col'), str) else [],
+            'requires_edge_cols': []
+        }
+    },
+
     # Self-edge pruning
     'prune_self_edges': {
         'allowed_params': set(),
@@ -1069,6 +1168,22 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
             'requires_edge_cols': _umap_edge_required_cols
         }
     }
+}
+
+
+_LAYOUT_CALL_KINDS: Dict[str, str] = {
+    'layout_cugraph': 'cugraph',
+    'layout_igraph': 'igraph',
+    'layout_graphviz': 'graphviz',
+    'ring_continuous_layout': 'ring_continuous',
+    'ring_categorical_layout': 'ring_categorical',
+    'time_ring_layout': 'time_ring',
+    'fa2_layout': 'force_directed',
+    'group_in_a_box_layout': 'group_in_a_box',
+    'circle_layout': 'circle',
+    'tree_layout': 'tree',
+    'mercator_layout': 'mercator',
+    'modularity_weighted_layout': 'modularity_weighted',
 }
 
 

--- a/graphistry/compute/gfql/layout.py
+++ b/graphistry/compute/gfql/layout.py
@@ -1,0 +1,80 @@
+"""Helpers for detecting GFQL layout call chains."""
+
+from typing import FrozenSet, Iterable, Mapping, Optional, Tuple
+
+from graphistry.compute.gfql.call.validation import _LAYOUT_CALL_KINDS
+
+
+LAYOUT_FUNCTION_NAMES: FrozenSet[str] = frozenset(_LAYOUT_CALL_KINDS)
+LAYOUT_KINDS: FrozenSet[str] = frozenset(_LAYOUT_CALL_KINDS.values())
+RADIAL_LAYOUT_KINDS: FrozenSet[str] = frozenset({
+    'ring_continuous',
+    'ring_categorical',
+    'time_ring',
+})
+RADIAL_LAYOUT_FUNCTION_NAMES: FrozenSet[str] = frozenset(
+    function
+    for function, kind in _LAYOUT_CALL_KINDS.items()
+    if kind in RADIAL_LAYOUT_KINDS
+)
+
+
+def _iter_chain_steps(chain: object) -> Iterable[object]:
+    if isinstance(chain, str):
+        return ()
+
+    if isinstance(chain, Mapping):
+        steps = chain.get('chain')
+        if isinstance(steps, list):
+            return steps
+        return (chain,)
+
+    if isinstance(chain, (list, tuple)):
+        return chain
+
+    steps = getattr(chain, 'chain', None)
+    if isinstance(steps, list):
+        return steps
+
+    return (chain,)
+
+
+def _step_function(step: object) -> Optional[str]:
+    if isinstance(step, Mapping):
+        function = step.get('function')
+    else:
+        function = getattr(step, 'function', None)
+    return function if isinstance(function, str) else None
+
+
+def _layout_call_kind(function: object) -> Optional[str]:
+    """Return the layout kind for a GFQL ``call()`` function name, if any."""
+    return _LAYOUT_CALL_KINDS.get(function) if isinstance(function, str) else None
+
+
+def is_layout_kind(chain: object) -> Optional[str]:
+    """Return the first layout kind in a GFQL chain, or ``None``.
+
+    Accepts a ``Chain`` object, a list/tuple of GFQL steps, a Chain wire dict,
+    or a direct ``Call`` object/dict. Opaque strings are not parsed.
+    """
+    pending: Tuple[object, ...] = tuple(_iter_chain_steps(chain))
+
+    while pending:
+        step, pending = pending[0], pending[1:]
+        kind = _layout_call_kind(_step_function(step))
+        if kind is not None:
+            return kind
+
+        if not isinstance(step, str) and (
+            isinstance(step, Mapping) and isinstance(step.get('chain'), list)
+            or isinstance(getattr(step, 'chain', None), list)
+        ):
+            pending = tuple(_iter_chain_steps(step)) + pending
+
+    return None
+
+
+def is_layout_chain(chain: object) -> bool:
+    """Return whether any operation in a GFQL chain is a layout helper."""
+    return is_layout_kind(chain) is not None

--- a/graphistry/models/gfql/types/call.py
+++ b/graphistry/models/gfql/types/call.py
@@ -35,6 +35,7 @@ CallMethodName = Literal[
     'collapse',
     'compute_cugraph',
     'compute_igraph',
+    'circle_layout',
     'description',
     'drop_nodes',
     'encode_axis',
@@ -57,9 +58,12 @@ CallMethodName = Literal[
     'layout_cugraph',
     'layout_graphviz',
     'layout_igraph',
+    'mercator_layout',
+    'modularity_weighted_layout',
     'ring_continuous_layout',
     'ring_categorical_layout',
     'time_ring_layout',
+    'tree_layout',
     'materialize_nodes',
     'name',
     'prune_self_edges',
@@ -364,6 +368,47 @@ class GroupInABoxLayoutParams(TypedDict, total=False):
     engine: Literal['auto', 'cpu', 'gpu', 'pandas', 'cudf']
 
 
+class CircleLayoutParams(TypedDict, total=False):  # pragma: no cover
+    """Parameters for circle_layout operation."""
+    bounding_box: Optional[Union[Tuple[float, float, float, float], List[float]]]
+    ring_spacing: Optional[float]
+    point_spacing: Optional[float]
+    partition_by: Optional[Union[str, List[str]]]
+    sort_by: Optional[Union[str, List[str]]]
+    ascending: Union[bool, List[bool]]
+    na_position: Literal['first', 'last']
+    ignore_index: bool
+    engine: GFQLEngineLiteral
+
+
+class TreeLayoutParams(TypedDict, total=False):  # pragma: no cover
+    """Parameters for tree_layout operation."""
+    level_col: Optional[str]
+    level_sort_values_by: Optional[Union[str, List[str]]]
+    level_sort_values_by_ascending: bool
+    width: Optional[float]
+    height: Optional[float]
+    rotate: Optional[float]
+    allow_cycles: bool
+    root: Optional[Union[str, int, float, bool]]
+
+
+class MercatorLayoutParams(TypedDict, total=False):  # pragma: no cover
+    """Parameters for mercator_layout operation."""
+    scale_for_graphistry: bool
+
+
+class ModularityWeightedLayoutParams(TypedDict, total=False):  # pragma: no cover
+    """Parameters for modularity_weighted_layout operation."""
+    community_col: Optional[str]
+    community_alg: Optional[str]
+    community_params: Optional[Dict[str, Any]]
+    same_community_weight: float
+    cross_community_weight: float
+    edge_influence: float
+    engine: Literal['auto', 'pandas', 'cudf']
+
+
 class GetIndegreesParams(TypedDict, total=False):
     """Parameters for get_indegrees operation."""
     col: str
@@ -612,6 +657,22 @@ def call(function: Literal['fa2_layout'], params: Fa2LayoutParams = ...) -> 'AST
 
 @overload
 def call(function: Literal['group_in_a_box_layout'], params: GroupInABoxLayoutParams = ...) -> 'ASTCall':
+    ...
+
+@overload
+def call(function: Literal['circle_layout'], params: CircleLayoutParams = ...) -> 'ASTCall':
+    ...
+
+@overload
+def call(function: Literal['tree_layout'], params: TreeLayoutParams = ...) -> 'ASTCall':
+    ...
+
+@overload
+def call(function: Literal['mercator_layout'], params: MercatorLayoutParams = ...) -> 'ASTCall':
+    ...
+
+@overload
+def call(function: Literal['modularity_weighted_layout'], params: ModularityWeightedLayoutParams = ...) -> 'ASTCall':
     ...
 
 @overload

--- a/graphistry/tests/compute/gfql/test_layout_chain_predicate.py
+++ b/graphistry/tests/compute/gfql/test_layout_chain_predicate.py
@@ -1,0 +1,193 @@
+from graphistry.compute import Chain, call, n
+from graphistry.compute.gfql import (
+    LAYOUT_FUNCTION_NAMES,
+    LAYOUT_KINDS,
+    RADIAL_LAYOUT_FUNCTION_NAMES,
+    RADIAL_LAYOUT_KINDS,
+    is_layout_chain,
+    is_layout_kind,
+)
+from graphistry.compute.gfql.call.validation import SAFELIST_V1, _LAYOUT_CALL_KINDS
+
+
+def test_layout_chain_public_exports() -> None:
+    from graphistry.compute.gfql import (
+        LAYOUT_FUNCTION_NAMES as gfql_layout_function_names,
+        LAYOUT_KINDS as gfql_layout_kinds,
+        RADIAL_LAYOUT_FUNCTION_NAMES as gfql_radial_layout_function_names,
+        RADIAL_LAYOUT_KINDS as gfql_radial_layout_kinds,
+        is_layout_chain as gfql_is_layout_chain,
+    )
+
+    assert gfql_is_layout_chain is is_layout_chain
+    assert gfql_layout_function_names is LAYOUT_FUNCTION_NAMES
+    assert gfql_layout_kinds is LAYOUT_KINDS
+    assert gfql_radial_layout_function_names is RADIAL_LAYOUT_FUNCTION_NAMES
+    assert gfql_radial_layout_kinds is RADIAL_LAYOUT_KINDS
+
+
+def test_layout_chain_detects_chain_object() -> None:
+    chain = Chain([
+        n(),
+        call('ring_categorical_layout', {'ring_col': 'kind'}),
+    ])
+
+    assert is_layout_chain(chain)
+    assert is_layout_kind(chain) == 'ring_categorical'
+
+
+def test_layout_chain_detects_wire_dict() -> None:
+    chain = {
+        'type': 'Chain',
+        'chain': [
+            {'type': 'Node', 'filter_dict': {}},
+            {
+                'type': 'Call',
+                'function': 'time_ring_layout',
+                'params': {'time_col': 'ts'},
+            },
+        ],
+    }
+
+    assert is_layout_chain(chain)
+    assert is_layout_kind(chain) == 'time_ring'
+
+
+def test_layout_chain_detects_direct_call_object() -> None:
+    op = call('fa2_layout')
+
+    assert is_layout_chain(op)
+    assert is_layout_kind(op) == 'force_directed'
+    assert is_layout_kind(op) not in RADIAL_LAYOUT_KINDS
+
+
+def test_layout_chain_detects_direct_call_wire_dict() -> None:
+    op = {'type': 'Call', 'function': 'circle_layout', 'params': {}}
+
+    assert is_layout_chain(op)
+    assert is_layout_kind(op) == 'circle'
+
+
+def test_layout_chain_detects_nested_chain_wire_dict() -> None:
+    chain = [
+        {
+            'type': 'Chain',
+            'chain': [
+                {'type': 'Call', 'function': 'mercator_layout', 'params': {}},
+            ],
+        },
+    ]
+
+    assert is_layout_chain(chain)
+    assert is_layout_kind(chain) == 'mercator'
+
+
+def test_layout_registry_covers_all_safelisted_gfql_layouts() -> None:
+    assert LAYOUT_FUNCTION_NAMES == frozenset({
+        'layout_cugraph',
+        'layout_igraph',
+        'layout_graphviz',
+        'ring_continuous_layout',
+        'ring_categorical_layout',
+        'time_ring_layout',
+        'fa2_layout',
+        'group_in_a_box_layout',
+        'circle_layout',
+        'tree_layout',
+        'mercator_layout',
+        'modularity_weighted_layout',
+    })
+    assert LAYOUT_KINDS == frozenset({
+        'cugraph',
+        'igraph',
+        'graphviz',
+        'ring_continuous',
+        'ring_categorical',
+        'time_ring',
+        'force_directed',
+        'group_in_a_box',
+        'circle',
+        'tree',
+        'mercator',
+        'modularity_weighted',
+    })
+    assert is_layout_kind(call('group_in_a_box_layout')) == 'group_in_a_box'
+    assert is_layout_kind(call('tree_layout')) == 'tree'
+
+
+def test_radial_layout_registry_covers_canonical_radial_layouts() -> None:
+    assert RADIAL_LAYOUT_KINDS == frozenset({
+        'ring_continuous',
+        'ring_categorical',
+        'time_ring',
+    })
+    assert RADIAL_LAYOUT_FUNCTION_NAMES == frozenset({
+        'ring_continuous_layout',
+        'ring_categorical_layout',
+        'time_ring_layout',
+    })
+    assert RADIAL_LAYOUT_FUNCTION_NAMES.issubset(LAYOUT_FUNCTION_NAMES)
+    assert is_layout_kind(call('ring_continuous_layout')) in RADIAL_LAYOUT_KINDS
+
+
+def test_layout_chain_false_for_non_layout_chain() -> None:
+    chain = Chain([
+        n(),
+        call('get_degrees', {'col': 'degree'}),
+    ])
+
+    assert not is_layout_chain(chain)
+    assert is_layout_kind(chain) is None
+
+
+def test_layout_chain_false_for_empty_chain() -> None:
+    assert not is_layout_chain([])
+    assert is_layout_kind({'type': 'Chain', 'chain': []}) is None
+
+
+def test_layout_chain_tolerates_mixed_type_chain() -> None:
+    chain = [
+        object(),
+        {'type': 'Call', 'function': 'layout_graphviz', 'params': {}},
+    ]
+
+    assert is_layout_chain(chain)
+    assert is_layout_kind(chain) == 'graphviz'
+
+
+def test_layout_chain_ignores_unsupported_mixed_items() -> None:
+    chain = [
+        object(),
+        {'type': 'Call', 'function': 'not_a_safelisted_call', 'params': {}},
+    ]
+
+    assert not is_layout_chain(chain)
+    assert is_layout_kind(chain) is None
+
+
+def test_layout_chain_does_not_substring_match_opaque_strings() -> None:
+    assert not is_layout_chain("call('time_ring_layout', {'time_col': 'ts'})")
+    assert is_layout_kind("time_ring_layout") is None
+
+
+def test_layout_chain_metadata_tracks_safelist() -> None:
+    assert LAYOUT_FUNCTION_NAMES == frozenset(_LAYOUT_CALL_KINDS)
+    assert set(_LAYOUT_CALL_KINDS).issubset(SAFELIST_V1)
+
+
+def test_layout_registry_does_not_export_unsupported_radial_aliases() -> None:
+    assert frozenset({
+        'radial_layout',
+        'radial_categorical_layout',
+        'radial_continuous_layout',
+        'radial_time_layout',
+    }).isdisjoint(LAYOUT_FUNCTION_NAMES)
+
+
+def test_layout_registry_exports_python_layout_methods_as_gfql_calls() -> None:
+    assert frozenset({
+        'tree_layout',
+        'circle_layout',
+        'mercator_layout',
+        'modularity_weighted_layout',
+    }).issubset(LAYOUT_FUNCTION_NAMES)

--- a/graphistry/tests/compute/test_call_operations.py
+++ b/graphistry/tests/compute/test_call_operations.py
@@ -135,6 +135,71 @@ class TestCallExecution:
         assert result._nodes is not None
         assert len(result._nodes) == 3
 
+    def test_execute_circle_layout(self, sample_graph):
+        result = execute_call(
+            sample_graph,
+            'circle_layout',
+            {'bounding_box': [0, 0, 100, 100], 'engine': 'pandas'},
+            Engine.PANDAS
+        )
+
+        assert 'x' in result._nodes.columns
+        assert 'y' in result._nodes.columns
+
+    def test_execute_tree_layout(self):
+        edges_df = pd.DataFrame({
+            'source': ['a', 'b'],
+            'target': ['b', 'c'],
+        })
+        nodes_df = pd.DataFrame({
+            'node': ['a', 'b', 'c'],
+            'rank': [1, 2, 3],
+        })
+        g = CGFull().edges(edges_df).nodes(nodes_df).bind(source='source', destination='target', node='node')
+
+        result = execute_call(
+            g,
+            'tree_layout',
+            {'level_sort_values_by': 'rank'},
+            Engine.PANDAS
+        )
+
+        assert 'x' in result._nodes.columns
+        assert 'y' in result._nodes.columns
+        assert 'level' in result._nodes.columns
+
+    def test_execute_mercator_layout(self):
+        nodes_df = pd.DataFrame({
+            'node': ['nyc', 'sf'],
+            'latitude': [40.7128, 37.7749],
+            'longitude': [-74.0060, -122.4194],
+        })
+        g = CGFull().nodes(nodes_df).bind(node='node')
+
+        result = execute_call(
+            g,
+            'mercator_layout',
+            {},
+            Engine.PANDAS
+        )
+
+        assert 'x' in result._nodes.columns
+        assert 'y' in result._nodes.columns
+        assert result._point_x == 'x'
+        assert result._point_y == 'y'
+
+    def test_execute_modularity_weighted_layout_with_existing_community(self, sample_graph):
+        result = execute_call(
+            sample_graph,
+            'modularity_weighted_layout',
+            {'community_col': 'type', 'engine': 'pandas'},
+            Engine.PANDAS
+        )
+
+        assert 'weight' in result._edges.columns
+        assert 'same_community' in result._edges.columns
+        assert result._edge_weight == 'weight'
+
     def test_execute_encode_edge_icon(self, sample_graph):
         result = execute_call(
             sample_graph,

--- a/graphistry/tests/compute/test_gfql_call_validation.py
+++ b/graphistry/tests/compute/test_gfql_call_validation.py
@@ -699,6 +699,58 @@ class TestCallObjectCreation:
             call_obj.validate()
 
 
+class TestLayoutCallValidation:
+    """Validation for GFQL layout calls backed by Python layout methods."""
+
+    def test_circle_layout_params_valid(self):
+        params = validate_call_params('circle_layout', {
+            'bounding_box': [0, 0, 100, 100],
+            'partition_by': ['type', 'cluster'],
+            'sort_by': 'degree',
+            'ascending': [True, False],
+            'na_position': 'first',
+            'engine': 'pandas',
+        })
+        assert params['bounding_box'] == [0, 0, 100, 100]
+
+    def test_circle_layout_rejects_non_json_dataframe_boundary(self):
+        with pytest.raises(GFQLTypeError):
+            validate_call_params('circle_layout', {
+                'bounding_box': {'x': 0, 'y': 0, 'w': 100, 'h': 100},
+            })
+
+    def test_tree_layout_params_valid(self):
+        params = validate_call_params('tree_layout', {
+            'level_col': 'level',
+            'level_sort_values_by': ['type', 'rank'],
+            'level_sort_values_by_ascending': False,
+            'width': 100,
+            'height': 50,
+            'rotate': 90,
+            'allow_cycles': True,
+            'root': 'a',
+        })
+        assert params['root'] == 'a'
+
+    def test_mercator_layout_params_valid(self):
+        params = validate_call_params('mercator_layout', {
+            'scale_for_graphistry': False,
+        })
+        assert params['scale_for_graphistry'] is False
+
+    def test_modularity_weighted_layout_params_valid(self):
+        params = validate_call_params('modularity_weighted_layout', {
+            'community_col': 'community',
+            'community_alg': None,
+            'community_params': None,
+            'same_community_weight': 2.0,
+            'cross_community_weight': 0.3,
+            'edge_influence': 2.0,
+            'engine': 'pandas',
+        })
+        assert params['community_col'] == 'community'
+
+
 class TestRingAxisValidation:
     """Deep axis payload validation for ring layout calls."""
 


### PR DESCRIPTION
## Summary

Closes #1254.
Refs #1058.

Adds public GFQL layout-chain detection helpers and immutable layout registries so downstream tooling can stop maintaining brittle lists of layout helper names:

```python
from graphistry.compute import call
from graphistry.compute.gfql import (
    LAYOUT_FUNCTION_NAMES,
    LAYOUT_KINDS,
    RADIAL_LAYOUT_FUNCTION_NAMES,
    RADIAL_LAYOUT_KINDS,
    is_layout_chain,
    is_layout_kind,
)

chain = [call("time_ring_layout", {"time_col": "ts"})]
kind = is_layout_kind(chain)

assert is_layout_chain(chain)
assert kind == "time_ring"
assert kind in LAYOUT_KINDS
assert kind in RADIAL_LAYOUT_KINDS
assert "time_ring_layout" in RADIAL_LAYOUT_FUNCTION_NAMES
assert "group_in_a_box_layout" in LAYOUT_FUNCTION_NAMES
assert "tree_layout" in LAYOUT_FUNCTION_NAMES
```

Public surface:

- `is_layout_chain(chain) -> bool`
- `is_layout_kind(chain) -> Optional[str]`
- `LAYOUT_FUNCTION_NAMES: FrozenSet[str]`
- `LAYOUT_KINDS: FrozenSet[str]`
- `RADIAL_LAYOUT_FUNCTION_NAMES: FrozenSet[str]`
- `RADIAL_LAYOUT_KINDS: FrozenSet[str]`
- GFQL `call()` support for `circle_layout`, `tree_layout`, `mercator_layout`, and `modularity_weighted_layout`

Accepted inputs: `Chain` objects, list/tuple chains, Chain wire dictionaries, and direct `Call` objects/dicts. Opaque strings are intentionally not parsed; callers should pass native GFQL structures instead of substring-matching query text.

For graphistrygpt/Louie PR #2791: structured chains can use `is_layout_kind(chain) in RADIAL_LAYOUT_KINDS` for radial URL defaults, while legitimate pre-parse string gates can use `RADIAL_LAYOUT_FUNCTION_NAMES` / `LAYOUT_FUNCTION_NAMES` instead of local pygraphistry layout-name copies. Recent master validator work (#1592) may also let graphistrygpt delete `_raise_if_malformed_structured_radial_string` outright; this PR provides the registry for any remaining legitimate string-detection cases.

Registry audit: `group_in_a_box_layout`, `tree_layout`, `circle_layout`, `mercator_layout`, and `modularity_weighted_layout` are included as safelisted GFQL layout calls. `radial_layout`, `radial_categorical_layout`, `radial_continuous_layout`, and `radial_time_layout` are graphistrygpt-side/intuitive aliases, not current pygraphistry safelisted GFQL function names.

## Behavior

| Case | Result |
| --- | --- |
| `Chain([n(), call("ring_categorical_layout", {"ring_col": "kind"})])` | `is_layout_chain(...) == True`, kind `ring_categorical` |
| `{"type": "Chain", "chain": [{"type": "Call", "function": "time_ring_layout"}]}` | `True`, kind `time_ring` |
| `call("ring_continuous_layout")` | `True`, kind `ring_continuous`, radial kind |
| `call("group_in_a_box_layout")` | `True`, kind `group_in_a_box`, non-radial layout |
| `call("fa2_layout")` | `True`, kind `force_directed` |
| `call("circle_layout", {"bounding_box": [0, 0, 100, 100]})` | validated and executed as a GFQL call, kind `circle` |
| `call("tree_layout")` | validated and executed as a GFQL call, kind `tree` |
| `call("mercator_layout")` | validated and executed as a GFQL call, kind `mercator` |
| `call("modularity_weighted_layout", {"community_col": "type"})` | validated and executed as a GFQL call, kind `modularity_weighted` |
| `Chain([n(), call("get_degrees", {"col": "degree"})])` | `False`, kind `None` |
| `[]` / empty Chain wire dict | `False`, kind `None` |
| mixed list with unsupported objects plus a layout Call dict | `True` |
| opaque string containing `time_ring_layout` | `False` |
| `LAYOUT_FUNCTION_NAMES` | includes all current safelisted GFQL layouts, including `group_in_a_box_layout`, `circle_layout`, `tree_layout`, `mercator_layout`, and `modularity_weighted_layout` |
| `RADIAL_LAYOUT_FUNCTION_NAMES` | `{"ring_continuous_layout", "ring_categorical_layout", "time_ring_layout"}` |

## LOC Buckets

- Production: +273 / -0, net +273 LOC
- Tests: +310 / -0, net +310 LOC
- Comments / docs / changelog: +254 / -1, net +253 LOC
- Compiler-plan surface touched: no. This adds safelist-adjacent layout metadata, public predicates/registries, GFQL call validation/type metadata for existing layout methods, exports, tests, docs, and changelog.

## Validation

- [x] `python3 -m pytest -q graphistry/tests/compute/gfql/test_layout_chain_predicate.py` (`14 passed`)
- [x] `python3 -m pytest -q graphistry/tests/compute/test_gfql_call_validation.py graphistry/tests/compute/test_astcall_chains.py --maxfail=3`
- [x] `python3 -m pytest -q graphistry/tests/compute/gfql/test_layout_chain_predicate.py graphistry/tests/compute/test_gfql_call_validation.py graphistry/tests/compute/test_call_operations.py -k "layout or mercator or tree or circle or modularity" --maxfail=3` (`24 passed, 70 deselected`)
- [x] `python3 -m pytest -q graphistry/tests/compute/gfql/test_layout_chain_predicate.py graphistry/tests/compute/test_gfql_call_validation.py graphistry/tests/compute/test_call_operations.py --maxfail=3` (`94 passed, 2 skipped`)
- [x] `python3 -m pytest -q graphistry/tests/compute/test_call_schema_validation.py graphistry/tests/compute/gfql/test_schema_changers.py --maxfail=3` (`11 passed, 8 skipped`)
- [x] `python3 -m pytest -q docs/test_doc_examples.py -k builtin_calls --maxfail=1` (`1 passed, 28 deselected`)
- [x] `./bin/ruff.sh graphistry/compute/gfql/layout.py graphistry/compute/gfql/__init__.py graphistry/tests/compute/gfql/test_layout_chain_predicate.py`
- [x] `./bin/ruff.sh graphistry/compute/gfql/call/validation.py graphistry/compute/gfql/layout.py graphistry/compute/gfql/__init__.py graphistry/models/gfql/types/call.py graphistry/tests/compute/gfql/test_layout_chain_predicate.py graphistry/tests/compute/test_call_operations.py graphistry/tests/compute/test_gfql_call_validation.py`
- [x] `./bin/typecheck.sh graphistry/compute/gfql/layout.py graphistry/compute/gfql/__init__.py`
- [x] `./bin/typecheck.sh graphistry/compute/gfql/call/validation.py graphistry/compute/gfql/layout.py graphistry/compute/gfql/__init__.py graphistry/models/gfql/types/call.py`
- [x] `git diff --check`
- [x] Review skill converged before registry extension
- [x] Review skill converged after full layout registry clarification
- [x] Review skill converged after exposing Python layout methods as GFQL calls
- [x] Review skill reconverged after CI docs-example fix
- [x] Review skill reconverged after changed-line coverage fix
- [x] Full PR CI green after exposing Python layout methods as GFQL calls

DGX/RAPIDS: not run for this expansion. This PR exposes existing layout methods through GFQL call validation/dispatch but does not modify the underlying DataFrame/cuDF/GPU layout implementations.
