### PR TITLE
chore(gfql): shrink predicate ast helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL policy / Cypher compiler hooks (#1454)**: Added experimental exact-key `precompile` and `postcompile` policy hooks for local Cypher string-query compilation. `postcompile` reports success or failure using the existing policy `success`, `error`, and `error_type` fields plus a stable `CompileSummary` with scalar compiler metadata.
 
 ### Changed
+- **GFQL predicate/AST implementation shrink (#1058)**: DRYed repeated predicate comparison dispatch, regex string predicate scaffolding, and AST filter-dict serialization while preserving public predicate APIs, wire JSON, and compiler-plan behavior.
 - **CI Spark/Neo4j dependency hardening (#1322)**: Pinned the Spark smoke-test installer to a committed hashed lockfile with a CI drift check, and moved the Neo4j connector test image from EOL Neo4j 4.1 to pinned Neo4j 5.26 LTS.
 - **GFQL axis/ring diagnostics (#1245)**: Strengthened `encode_axis` and ring-layout axis validators with anchored row-indexed diagnostics for documented radial/linear axis payload mistakes, while preserving extension-subtype compatibility.
 - **GFQL chain tag warning cleanup (#877)**: Avoided pandas object-dtype `fillna()` downcast warnings when merging named chain tag columns without warning filters or behavior changes.

--- a/graphistry/compute/ast.py
+++ b/graphistry/compute/ast.py
@@ -116,6 +116,14 @@ def maybe_filter_dict_from_json(d: Dict, key: str) -> Optional[Dict]:
         return None
 
 
+def _filter_dict_to_json(filter_dict: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        k: v.to_json() if isinstance(v, ASTPredicate) else v
+        for k, v in filter_dict.items()
+        if v is not None
+    }
+
+
 def _edge_from_json_kwargs(d: Dict[str, Any]) -> Dict[str, Any]:
     return {
         'edge_match': maybe_filter_dict_from_json(d, 'edge_match'),
@@ -223,11 +231,7 @@ class ASTNode(ASTObject):
             self.validate()
         return {
             'type': 'Node',
-            'filter_dict': {
-                k: v.to_json() if isinstance(v, ASTPredicate) else v
-                for k, v in self.filter_dict.items()
-                if v is not None
-            } if self.filter_dict is not None else {},
+            'filter_dict': _filter_dict_to_json(self.filter_dict) if self.filter_dict is not None else {},
             **({'name': self._name} if self._name is not None else {}),
             **({'query': self.query } if self.query is not None else {})
         }
@@ -567,21 +571,9 @@ class ASTEdge(ASTObject):
             **({'label_seeds': self.label_seeds} if self.label_seeds else {}),
             'to_fixed_point': self.to_fixed_point,
             'direction': self.direction,
-            **({'source_node_match': {
-                k: v.to_json() if isinstance(v, ASTPredicate) else v
-                for k, v in self.source_node_match.items()
-                if v is not None
-            }} if self.source_node_match is not None else {}),
-            **({'edge_match': {
-                k: v.to_json() if isinstance(v, ASTPredicate) else v
-                for k, v in self.edge_match.items()
-                if v is not None
-            }} if self.edge_match is not None else {}),
-            **({'destination_node_match': {
-                k: v.to_json() if isinstance(v, ASTPredicate) else v
-                for k, v in self.destination_node_match.items()
-                if v is not None
-            }} if self.destination_node_match is not None else {}),
+            **({'source_node_match': _filter_dict_to_json(self.source_node_match)} if self.source_node_match is not None else {}),
+            **({'edge_match': _filter_dict_to_json(self.edge_match)} if self.edge_match is not None else {}),
+            **({'destination_node_match': _filter_dict_to_json(self.destination_node_match)} if self.destination_node_match is not None else {}),
             **({'name': self._name} if self._name is not None else {}),
             **({'source_node_query': self.source_node_query} if self.source_node_query is not None else {}),
             **({'destination_node_query': self.destination_node_query} if self.destination_node_query is not None else {}),

--- a/graphistry/compute/predicates/comparison.py
+++ b/graphistry/compute/predicates/comparison.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, TYPE_CHECKING, Union, cast
+from typing import Any, Callable, ClassVar, Dict, TYPE_CHECKING, Union, cast
 from datetime import date, time
 import operator
 import numpy as np
@@ -208,16 +208,26 @@ class _StringAllowingComparisonMixin:
             )
 
 
-class GT(_StringAllowingComparisonMixin, ComparisonPredicate):
+class _ScalarTemporalComparison(_StringAllowingComparisonMixin, ComparisonPredicate):
+    op: ClassVar[Any]
+    safe_scalar_compare: ClassVar[bool] = True
+
     def __call__(self, s: SeriesT) -> SeriesT:
-        """Greater than comparison"""
         if isinstance(self.val, (int, float, str)):
-            return self._safe_scalar_compare(s, operator.gt)
+            return (
+                self._safe_scalar_compare(s, type(self).op)
+                if self.safe_scalar_compare
+                else type(self).op(s, self.val)
+            )
         elif isinstance(self.val, TemporalValue):
             prepared_s, comparison_val = self._prepare_temporal_comparison(s, self.val)
-            return prepared_s > comparison_val
+            return type(self).op(prepared_s, comparison_val)
         else:
             raise TypeError(f"Unexpected value type: {type(self.val)}")
+
+
+class GT(_ScalarTemporalComparison):
+    op = staticmethod(operator.gt)
 
 def gt(val: ComparisonInput) -> GT:
     """
@@ -225,16 +235,8 @@ def gt(val: ComparisonInput) -> GT:
     """
     return GT(val)
 
-class LT(_StringAllowingComparisonMixin, ComparisonPredicate):
-    def __call__(self, s: SeriesT) -> SeriesT:
-        """Less than comparison"""
-        if isinstance(self.val, (int, float, str)):
-            return self._safe_scalar_compare(s, operator.lt)
-        elif isinstance(self.val, TemporalValue):
-            prepared_s, comparison_val = self._prepare_temporal_comparison(s, self.val)
-            return prepared_s < comparison_val
-        else:
-            raise TypeError(f"Unexpected value type: {type(self.val)}")
+class LT(_ScalarTemporalComparison):
+    op = staticmethod(operator.lt)
 
 def lt(val: ComparisonInput) -> LT:
     """
@@ -242,16 +244,8 @@ def lt(val: ComparisonInput) -> LT:
     """
     return LT(val)
 
-class GE(_StringAllowingComparisonMixin, ComparisonPredicate):
-    def __call__(self, s: SeriesT) -> SeriesT:
-        """Greater than or equal comparison"""
-        if isinstance(self.val, (int, float, str)):
-            return self._safe_scalar_compare(s, operator.ge)
-        elif isinstance(self.val, TemporalValue):
-            prepared_s, comparison_val = self._prepare_temporal_comparison(s, self.val)
-            return prepared_s >= comparison_val
-        else:
-            raise TypeError(f"Unexpected value type: {type(self.val)}")
+class GE(_ScalarTemporalComparison):
+    op = staticmethod(operator.ge)
 
 def ge(val: ComparisonInput) -> GE:
     """
@@ -259,16 +253,8 @@ def ge(val: ComparisonInput) -> GE:
     """
     return GE(val)
 
-class LE(_StringAllowingComparisonMixin, ComparisonPredicate):
-    def __call__(self, s: SeriesT) -> SeriesT:
-        """Less than or equal comparison"""
-        if isinstance(self.val, (int, float, str)):
-            return self._safe_scalar_compare(s, operator.le)
-        elif isinstance(self.val, TemporalValue):
-            prepared_s, comparison_val = self._prepare_temporal_comparison(s, self.val)
-            return prepared_s <= comparison_val
-        else:
-            raise TypeError(f"Unexpected value type: {type(self.val)}")
+class LE(_ScalarTemporalComparison):
+    op = staticmethod(operator.le)
 
 def le(val: ComparisonInput) -> LE:
     """
@@ -276,16 +262,9 @@ def le(val: ComparisonInput) -> LE:
     """
     return LE(val)
 
-class EQ(_StringAllowingComparisonMixin, ComparisonPredicate):
-    def __call__(self, s: SeriesT) -> SeriesT:
-        """Equal comparison"""
-        if isinstance(self.val, (int, float, str)):
-            return s == self.val
-        elif isinstance(self.val, TemporalValue):
-            prepared_s, comparison_val = self._prepare_temporal_comparison(s, self.val)
-            return prepared_s == comparison_val
-        else:
-            raise TypeError(f"Unexpected value type: {type(self.val)}")
+class EQ(_ScalarTemporalComparison):
+    op = staticmethod(operator.eq)
+    safe_scalar_compare = False
 
 def eq(val: ComparisonInput) -> EQ:
     """
@@ -300,16 +279,9 @@ def eq(val: ComparisonInput) -> EQ:
     """
     return EQ(val)
 
-class NE(_StringAllowingComparisonMixin, ComparisonPredicate):
-    def __call__(self, s: SeriesT) -> SeriesT:
-        """Not equal comparison"""
-        if isinstance(self.val, (int, float, str)):
-            return s != self.val
-        elif isinstance(self.val, TemporalValue):
-            prepared_s, comparison_val = self._prepare_temporal_comparison(s, self.val)
-            return prepared_s != comparison_val
-        else:
-            raise TypeError(f"Unexpected value type: {type(self.val)}")
+class NE(_ScalarTemporalComparison):
+    op = staticmethod(operator.ne)
+    safe_scalar_compare = False
 
 def ne(val: ComparisonInput) -> NE:
     """
@@ -328,24 +300,9 @@ class Between(ASTPredicate):
         self.lower = self._normalize_value(lower)
         self.upper = self._normalize_value(upper)
         self.inclusive = inclusive
-    
+
     def _normalize_value(self, val: BetweenBoundInput) -> Union[int, float, np.number, TemporalValue]:
-        """Convert various input types to internal representation"""
-        # Same normalization as ComparisonPredicate
-        if is_native_numeric(val):
-            return val
-        elif is_any_temporal(val):
-            # to_ast always returns TemporalValue for valid temporal inputs
-            temporal_val = to_ast(val)
-            return temporal_val
-        elif is_string(val):
-            raise ValueError(
-                f"Raw string '{val}' is ambiguous. Use:\n"
-                f"  - pd.Timestamp('{val}') for datetime\n"
-                f"  - {{'type': 'datetime', 'value': '{val}'}} for explicit type"
-            )
-        else:
-            raise TypeError(f"Unsupported type for {self.__class__.__name__}: {type(val)}")
+        return ComparisonPredicate._normalize_value(self, val)  # type: ignore[arg-type]
 
     def __call__(self, s: SeriesT) -> SeriesT:
         # Check if both bounds are same type

--- a/graphistry/compute/predicates/str.py
+++ b/graphistry/compute/predicates/str.py
@@ -364,7 +364,7 @@ def endswith(
     return Endswith(pat, case, na)
 
 
-class Match(ASTPredicate):
+class _RegexStringPredicate(ASTPredicate):
     def __init__(
         self,
         pat: str,
@@ -378,26 +378,7 @@ class Match(ASTPredicate):
         self.na = na
 
     def _compute_result(self, s: SeriesT, is_cudf: bool) -> SeriesT:
-        # workaround cuDF not supporting 'case' and 'na' parameters
-        # https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/
-        # cudf.core.accessors.string.stringmethods.match/
-        if is_cudf:
-            if not self.case:
-                s_modified = s.str.lower()
-                pat_modified = (
-                    self.pat.lower()
-                    if isinstance(self.pat, str)
-                    else self.pat
-                )
-                return s_modified.str.match(pat_modified, flags=self.flags)
-            return s.str.match(self.pat, flags=self.flags)
-
-        effective_flags = self.flags
-        if not self.case:
-            effective_flags |= re.IGNORECASE
-        if effective_flags:
-            return s.str.match(self.pat, flags=effective_flags)
-        return s.str.match(self.pat)
+        raise NotImplementedError
 
     def __call__(self, s: SeriesT) -> SeriesT:
         is_cudf = hasattr(s, '__module__') and 'cudf' in s.__module__
@@ -443,6 +424,30 @@ class Match(ASTPredicate):
             )
 
 
+class Match(_RegexStringPredicate):
+    def _compute_result(self, s: SeriesT, is_cudf: bool) -> SeriesT:
+        # workaround cuDF not supporting 'case' and 'na' parameters
+        # https://docs.rapids.ai/api/cudf/stable/user_guide/api_docs/api/
+        # cudf.core.accessors.string.stringmethods.match/
+        if is_cudf:
+            if not self.case:
+                s_modified = s.str.lower()
+                pat_modified = (
+                    self.pat.lower()
+                    if isinstance(self.pat, str)
+                    else self.pat
+                )
+                return s_modified.str.match(pat_modified, flags=self.flags)
+            return s.str.match(self.pat, flags=self.flags)
+
+        effective_flags = self.flags
+        if not self.case:
+            effective_flags |= re.IGNORECASE
+        if effective_flags:
+            return s.str.match(self.pat, flags=effective_flags)
+        return s.str.match(self.pat)
+
+
 def match(
     pat: str,
     case: bool = True,
@@ -455,19 +460,7 @@ def match(
     return Match(pat, case, flags, na)
 
 
-class Fullmatch(ASTPredicate):
-    def __init__(
-        self,
-        pat: str,
-        case: bool = True,
-        flags: int = 0,
-        na: Optional[bool] = None
-    ) -> None:
-        self.pat = pat
-        self.case = case
-        self.flags = flags
-        self.na = na
-
+class Fullmatch(_RegexStringPredicate):
     def _compute_result(self, s: SeriesT, is_cudf: bool) -> SeriesT:
         if is_cudf:
             # cuDF doesn't have fullmatch, use match() with anchors as
@@ -491,49 +484,6 @@ class Fullmatch(ASTPredicate):
         if effective_flags:
             return s.str.fullmatch(self.pat, flags=effective_flags)
         return s.str.fullmatch(self.pat)
-
-    def __call__(self, s: SeriesT) -> SeriesT:
-        is_cudf = hasattr(s, '__module__') and 'cudf' in s.__module__
-        result = self._compute_result(s, is_cudf)
-        if is_cudf:
-            return _cudf_handle_na(result, s, self.na)
-        return _pandas_handle_na(result, s, self.na)
-
-    def _validate_fields(self) -> None:
-        """Validate predicate fields."""
-        from graphistry.compute.exceptions import ErrorCode, GFQLTypeError
-
-        if not isinstance(self.pat, str):
-            raise GFQLTypeError(
-                ErrorCode.E201,
-                "pat must be string",
-                field="pat",
-                value=type(self.pat).__name__
-            )
-
-        if not isinstance(self.case, bool):
-            raise GFQLTypeError(
-                ErrorCode.E201,
-                "case must be boolean",
-                field="case",
-                value=type(self.case).__name__
-            )
-
-        if not isinstance(self.flags, int):
-            raise GFQLTypeError(
-                ErrorCode.E201,
-                "flags must be integer",
-                field="flags",
-                value=type(self.flags).__name__
-            )
-
-        if not isinstance(self.na, (bool, type(None))):
-            raise GFQLTypeError(
-                ErrorCode.E201,
-                "na must be boolean or None",
-                field="na",
-                value=type(self.na).__name__
-            )
 
 
 def fullmatch(


### PR DESCRIPTION
## Summary

Closes part of #1058.

GFQL implementation shrink in the requested paired audit surface:

- DRY repeated scalar/temporal comparison predicate dispatch in `graphistry/compute/predicates/comparison.py`
- DRY regex string predicate constructor/call/validation scaffolding shared by `match()` and `fullmatch()`
- DRY AST predicate-aware filter-dict serialization shared by node and edge wire output

No public predicate helper names, predicate JSON wire shapes, route names, compiler-plan dispatch, structured errors, schema hooks, remote hooks, or `validate='autofix'` semantics changed.

## Audit Notes

- `graphistry/compute/ast.py` and `graphistry/compute/predicates/` do not contain Arrow conversion or `validate='autofix'` paths; #1591/#1598 did not create dead Arrow code in these files.
- No `is_not_in` implementation exists in the target files, so there is no `is_in` / `is_not_in` duplicate body to collapse here.
- `numeric.py` and `comparison.py` overlap by predicate name, but both are reachable/public with different ownership: `numeric.py` remains used by direct AST/filter validation paths, while `comparison.py` remains used by Cypher lowering and temporal/string comparison support. This PR does not collapse those public modules.

## LOC Buckets

- Production: `+68 / -169`, net `-101`
  - `graphistry/compute/ast.py`: `+12 / -20`, net `-8`
  - `graphistry/compute/predicates/comparison.py`: `+29 / -72`, net `-43`
  - `graphistry/compute/predicates/str.py`: `+27 / -77`, net `-50`
- Tests / fixtures / baselines: `+0 / -0`, net `0`
- Comments / docs / changelog: `+1 / -0`, net `+1`

Compiler-plan surface touched: no. The AST edit is a private serialization helper extraction that preserves existing node/edge wire JSON.

## Validation

- `python3 -m pytest -q graphistry/tests/compute/predicates/test_comparison_strings.py graphistry/tests/compute/predicates/test_comparison_conformance.py graphistry/tests/compute/predicates/test_str.py graphistry/tests/compute/predicates/test_numeric.py graphistry/tests/test_compute_chain.py`
  - `161 passed, 96 skipped`
- `./bin/ruff.sh graphistry/compute/ast.py graphistry/compute/predicates/comparison.py graphistry/compute/predicates/str.py`
  - passed
- `./bin/typecheck.sh graphistry/compute/ast.py graphistry/compute/predicates/comparison.py graphistry/compute/predicates/str.py`
  - passed
- `python3 -m pytest -q graphistry/tests/test_schema_artifacts.py graphistry/tests/test_viz_settings.py`
  - `11 passed`
- `python3 -m graphistry.devschemas.export --check`
  - passed, no schema drift
- `git diff --check`
  - passed
- Local broader predicate/GFQL run:
  - `305 passed, 96 skipped`
  - one cuDF-only failure at `cudf.Series(...)` with `cudaErrorNoDevice` because this host has cuDF installed without a CUDA device
- DGX RAPIDS 26.02:
  - `RAPIDS_VERSION=26.02 PROFILE=gfql TEST_FILES="graphistry/tests/compute/predicates/test_str.py graphistry/tests/compute/predicates/test_comparison_conformance.py graphistry/tests/compute/predicates/test_temporal_values.py" docker/test-rapids-official-local.sh`
  - `181 passed, 4 skipped`
- DGX RAPIDS 25.02:
  - same focused predicate target set
  - `181 passed, 4 skipped`, with the known 25.02 driver-version warning from the RAPIDS image

## Coordination

- Stayed within `graphistry/compute/predicates/` and `graphistry/compute/ast.py`, plus `CHANGELOG.md`.
- #1590 JSON Schema exporter/checker still passes with no drift.
- #1587 settings-contract tests still pass.
- No auto-merge requested or performed.
