### PR TITLE
refactor(gfql): shrink validate entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Changed
+- **GFQL validate entrypoint implementation shrink (#1058)**: DRYed legacy `graphistry.compute.gfql.validate` issue construction, filter-key checks, schema-filter diagnostics, and report formatting while preserving deprecated public validation helpers and anchored error diagnostics.
 - **GFQL call validation safelist + encode parity (#1058, #1253)**: DRYed repeated private safelist entry definitions for call validators while adding `encode_edge_size`, `encode_edge_weight`, and point/edge opacity, label, and title encode helpers with GFQL `call()` validation, apply-encodings/schema key contracts, and anchored validator coverage.
 - **GFQL CALL procedure implementation shrink (#1058)**: DRYed local Cypher CALL output-column derivation, computed-output renaming, and NetworkX backend error/dependency plumbing while preserving the no-SciPy `graphistry.nx.pagerank` path. Public CALL procedure behavior and diagnostics are preserved.
 

--- a/graphistry/compute/gfql/validate.py
+++ b/graphistry/compute/gfql/validate.py
@@ -18,8 +18,8 @@
            print(f"[{e.code}] {e.message}")
 """
 
+from dataclasses import dataclass
 from typing import List, Optional, Dict, Union, Any, Tuple, TYPE_CHECKING
-import warnings
 import pandas as pd
 
 if TYPE_CHECKING:
@@ -38,31 +38,21 @@ from graphistry.compute.predicates.temporal import (
     IsMonthStart, IsMonthEnd, IsQuarterStart, IsQuarterEnd,
     IsYearStart, IsYearEnd, IsLeapYear
 )
-from graphistry.util import setup_logger
 
 # NOTE: This module is deprecated but still used internally for backwards compatibility.
 # We don't emit warnings on import since that would spam users who aren't directly
 # importing this module. Warnings are only shown in the docstring.
 
-logger = setup_logger(__name__)
-
-
+@dataclass(eq=False)
 class ValidationIssue:
     """Represents a validation issue (error or warning)."""
 
-    def __init__(self,
-                 level: str,  # 'error' or 'warning'
-                 message: str,
-                 operation_index: Optional[int] = None,
-                 field: Optional[str] = None,
-                 suggestion: Optional[str] = None,
-                 error_type: Optional[str] = None):
-        self.level = level
-        self.message = message
-        self.operation_index = operation_index
-        self.field = field
-        self.suggestion = suggestion
-        self.error_type = error_type
+    level: str  # 'error' or 'warning'
+    message: str
+    operation_index: Optional[int] = None
+    field: Optional[str] = None
+    suggestion: Optional[str] = None
+    error_type: Optional[str] = None
 
     def __repr__(self) -> str:
         parts = [f"{self.level.upper()}: {self.message}"]
@@ -102,74 +92,89 @@ class Schema:
 
 # Error message templates
 ERROR_MESSAGES = {
-    # Syntax errors
-    'INVALID_CHAIN_TYPE': {
-        'message': 'Chain must be a list of operations',
-        'suggestion': 'Wrap your operations in a list: [n(), e(), n()]'
-    },
-    'INVALID_OPERATION': {
-        'message': 'Operation at index {index} is not a valid GFQL operation',
-        'suggestion': ('Use n() for nodes, '
-                       'e()/e_forward()/e_reverse() for edges')
-    },
-    'INVALID_FILTER_KEY': {
-        'message': 'Invalid filter key format: {key}',
-        'suggestion': 'Filter keys must be strings'
-    },
-    'INVALID_HOPS': {
-        'message': 'Hops must be a positive integer or None',
-        'suggestion': ('Use hops=2 for specific count, '
-                       'or to_fixed_point=True for unbounded')
-    },
-
-    # Schema errors
-    'COLUMN_NOT_FOUND': {
-        'message': 'Column "{column}" not found in {table} data',
-        'suggestion': 'Available columns: {available}'
-    },
-    'TYPE_MISMATCH': {
-        'message': ('Column "{column}" is {actual_type} but '
-                    'predicate expects {expected_type}'),
-        'suggestion': 'Use appropriate predicate for {actual_type} columns'
-    },
-    'INVALID_PREDICATE': {
-        'message': ('Predicate {predicate} cannot be used with '
-                    '{column_type} columns'),
-        'suggestion': 'Use {suggested_predicates} for {column_type} columns'
-    },
-
-    # Semantic errors
-    'ORPHANED_EDGE': {
-        'message': 'Edge operation at index {index} not connected to nodes',
-        'suggestion': ('Add node operations before/after edge: '
-                       'n() -> e() -> n()')
-    },
-    'UNBOUNDED_HOPS_WARNING': {
-        'message': ('Unbounded hops (to_fixed_point=True) may be slow '
-                    'on large graphs'),
-        'suggestion': ('Consider using specific hop count for better '
-                       'performance')
-    },
-    'EMPTY_CHAIN': {
-        'message': 'Chain is empty',
-        'suggestion': 'Add at least one operation: [n()]'
-    },
-    'INVALID_EDGE_DIRECTION': {
-        'message': 'Invalid edge direction: {direction}',
-        'suggestion': 'Use "forward", "reverse", or "undirected"'
-    }
+    'INVALID_CHAIN_TYPE': (
+        'Chain must be a list of operations',
+        'Wrap your operations in a list: [n(), e(), n()]'),
+    'INVALID_OPERATION': (
+        'Operation at index {index} is not a valid GFQL operation',
+        'Use n() for nodes, e()/e_forward()/e_reverse() for edges'),
+    'INVALID_FILTER_KEY': (
+        'Invalid filter key format: {key}',
+        'Filter keys must be strings'),
+    'INVALID_HOPS': (
+        'Hops must be a positive integer or None',
+        'Use hops=2 for specific count, or to_fixed_point=True for unbounded'),
+    'COLUMN_NOT_FOUND': (
+        'Column "{column}" not found in {table} data',
+        'Available columns: {available}'),
+    'TYPE_MISMATCH': (
+        'Column "{column}" is {actual_type} but predicate expects {expected_type}',
+        'Use appropriate predicate for {actual_type} columns'),
+    'INVALID_PREDICATE': (
+        'Predicate {predicate} cannot be used with {column_type} columns',
+        'Use {suggested_predicates} for {column_type} columns'),
+    'ORPHANED_EDGE': (
+        'Edge operation at index {index} not connected to nodes',
+        'Add node operations before/after edge: n() -> e() -> n()'),
+    'UNBOUNDED_HOPS_WARNING': (
+        'Unbounded hops (to_fixed_point=True) may be slow on large graphs',
+        'Consider using specific hop count for better performance'),
+    'EMPTY_CHAIN': (
+        'Chain is empty',
+        'Add at least one operation: [n()]'),
+    'INVALID_EDGE_DIRECTION': (
+        'Invalid edge direction: {direction}',
+        'Use "forward", "reverse", or "undirected"'),
 }
 
 
 def _format_error(error_key: str, **kwargs) -> Tuple[str, str]:
     """Format error message with context."""
-    template = ERROR_MESSAGES.get(error_key, {
-        'message': f'Unknown error: {error_key}',
-        'suggestion': 'Check documentation for valid syntax'
-    })
-    message = template['message'].format(**kwargs)
-    suggestion = template['suggestion'].format(**kwargs)
+    message_template, suggestion_template = ERROR_MESSAGES.get(
+        error_key,
+        (f'Unknown error: {error_key}', 'Check documentation for valid syntax'))
+    message = message_template.format(**kwargs)
+    suggestion = suggestion_template.format(**kwargs)
     return message, suggestion
+
+
+def _append_issue(
+    issues: List[ValidationIssue],
+    level: str,
+    error_key: str,
+    *,
+    operation_index: Optional[int] = None,
+    field: Optional[str] = None,
+    **kwargs: Any
+) -> None:
+    message, suggestion = _format_error(error_key, **kwargs)
+    issues.append(ValidationIssue(
+        level, message, operation_index=operation_index, field=field,
+        suggestion=suggestion, error_type=error_key))
+
+
+def _validate_filter_keys(
+    issues: List[ValidationIssue],
+    filter_dict: Optional[Dict[Any, Any]],
+    op_index: int,
+    field_prefix: str = "",
+) -> None:
+    if not filter_dict:
+        return
+    for key in filter_dict:
+        if not isinstance(key, str):
+            _append_issue(
+                issues, 'error', 'INVALID_FILTER_KEY',
+                operation_index=op_index,
+                field=f"{field_prefix}{key}" if field_prefix else str(key),
+                key=key)
+
+
+def _available_columns(schema_columns: Dict[str, str]) -> str:
+    available = list(schema_columns.keys())[:5]
+    if len(schema_columns) > 5:
+        available.append('...')
+    return ', '.join(available)
 
 
 def validate_syntax(chain: Union["Chain", List]) -> List[ValidationIssue]:
@@ -182,7 +187,7 @@ def validate_syntax(chain: Union["Chain", List]) -> List[ValidationIssue]:
     Returns:
         List of validation issues (errors and warnings)
     """
-    issues = []
+    issues: List[ValidationIssue] = []
 
     # Import here to avoid circular import with ast.py
     from graphistry.compute.chain import Chain
@@ -194,60 +199,41 @@ def validate_syntax(chain: Union["Chain", List]) -> List[ValidationIssue]:
     elif isinstance(chain, list):
         operations = chain
     else:
-        message, suggestion = _format_error('INVALID_CHAIN_TYPE')
-        issues.append(ValidationIssue(
-            'error', message, suggestion=suggestion,
-            error_type='INVALID_CHAIN_TYPE'))
+        _append_issue(issues, 'error', 'INVALID_CHAIN_TYPE')
         return issues
 
     # Check empty chain
     if not operations:
-        message, suggestion = _format_error('EMPTY_CHAIN')
-        issues.append(ValidationIssue(
-            'error', message, suggestion=suggestion,
-            error_type='EMPTY_CHAIN'))
+        _append_issue(issues, 'error', 'EMPTY_CHAIN')
         return issues
 
     # Validate each operation
     for i, op in enumerate(operations):
         # Check if valid operation type
         if not isinstance(op, ASTObject):
-            message, suggestion = _format_error('INVALID_OPERATION', index=i)
-            issues.append(ValidationIssue(
-                'error', message, operation_index=i,
-                suggestion=suggestion, error_type='INVALID_OPERATION'))
+            _append_issue(
+                issues, 'error', 'INVALID_OPERATION',
+                operation_index=i, index=i)
             continue
 
         # Validate nodes
         if isinstance(op, ASTNode):
-            if op.filter_dict:
-                for key, value in op.filter_dict.items():
-                    if not isinstance(key, str):
-                        message, suggestion = _format_error(
-                            'INVALID_FILTER_KEY', key=key)
-                        issues.append(ValidationIssue(
-                            'error', message, operation_index=i,
-                            field=str(key), suggestion=suggestion,
-                            error_type='INVALID_FILTER_KEY'))
+            _validate_filter_keys(issues, op.filter_dict, i)
 
         # Validate edges
         elif isinstance(op, ASTEdge):
             # Check hops
             if (op.hops is not None
                     and (not isinstance(op.hops, int) or op.hops < 1)):
-                message, suggestion = _format_error('INVALID_HOPS')
-                issues.append(ValidationIssue(
-                    'error', message, operation_index=i,
-                    field='hops', suggestion=suggestion,
-                    error_type='INVALID_HOPS'))
+                _append_issue(
+                    issues, 'error', 'INVALID_HOPS',
+                    operation_index=i, field='hops')
 
             # Check unbounded hops warning
             if op.to_fixed_point:
-                message, suggestion = _format_error('UNBOUNDED_HOPS_WARNING')
-                issues.append(ValidationIssue(
-                    'warning', message, operation_index=i,
-                    suggestion=suggestion,
-                    error_type='UNBOUNDED_HOPS_WARNING'))
+                _append_issue(
+                    issues, 'warning', 'UNBOUNDED_HOPS_WARNING',
+                    operation_index=i)
 
             # Check edge filters
             for filter_name, filter_dict in [
@@ -255,16 +241,8 @@ def validate_syntax(chain: Union["Chain", List]) -> List[ValidationIssue]:
                 ('source_node_match', op.source_node_match),
                 ('destination_node_match', op.destination_node_match)
             ]:
-                if filter_dict:
-                    for key, value in filter_dict.items():
-                        if not isinstance(key, str):
-                            message, suggestion = _format_error(
-                                'INVALID_FILTER_KEY', key=key)
-                            issues.append(ValidationIssue(
-                                'error', message, operation_index=i,
-                                field=f"{filter_name}.{key}",
-                                suggestion=suggestion,
-                                error_type='INVALID_FILTER_KEY'))
+                _validate_filter_keys(
+                    issues, filter_dict, i, field_prefix=f"{filter_name}.")
 
     # Check semantic issues
     issues.extend(_validate_semantics(operations))
@@ -274,7 +252,7 @@ def validate_syntax(chain: Union["Chain", List]) -> List[ValidationIssue]:
 
 def _validate_semantics(operations: List["ASTObject"]) -> List[ValidationIssue]:
     """Validate semantic correctness of operation sequence."""
-    issues = []
+    issues: List[ValidationIssue] = []
 
     # Import here to avoid circular import with ast.py
     from graphistry.compute.ast import ASTEdge
@@ -285,20 +263,16 @@ def _validate_semantics(operations: List["ASTObject"]) -> List[ValidationIssue]:
             # Check if first or last operation
             if i == 0 or i == len(operations) - 1:
                 # Edge at boundary - likely orphaned
-                message, suggestion = _format_error('ORPHANED_EDGE', index=i)
-                issues.append(ValidationIssue(
-                    'warning', message, operation_index=i,
-                    suggestion=suggestion,
-                    error_type='ORPHANED_EDGE'))
+                _append_issue(
+                    issues, 'warning', 'ORPHANED_EDGE',
+                    operation_index=i, index=i)
             # Check if between two edges
             elif (i > 0 and isinstance(operations[i - 1], ASTEdge)
                   and i < len(operations) - 1
                   and isinstance(operations[i + 1], ASTEdge)):
-                message, suggestion = _format_error('ORPHANED_EDGE', index=i)
-                issues.append(ValidationIssue(
-                    'warning', message, operation_index=i,
-                    suggestion=suggestion,
-                    error_type='ORPHANED_EDGE'))
+                _append_issue(
+                    issues, 'warning', 'ORPHANED_EDGE',
+                    operation_index=i, index=i)
 
     return issues
 
@@ -345,33 +319,8 @@ def validate_schema(chain: Union["Chain", List],
 def _validate_node_schema(node: "ASTNode", schema: Schema,
                           op_index: int) -> List[ValidationIssue]:
     """Validate node operation against schema."""
-    issues = []
-
-    if node.filter_dict and schema.node_columns:
-        for col, predicate in node.filter_dict.items():
-            # Check column exists
-            if col not in schema.node_columns:
-                available = list(schema.node_columns.keys())[:5]
-                if len(schema.node_columns) > 5:
-                    available.append('...')
-                message, suggestion = _format_error(
-                    'COLUMN_NOT_FOUND',
-                    column=col,
-                    table='node',
-                    available=', '.join(available))
-                issues.append(ValidationIssue(
-                    'error', message, operation_index=op_index,
-                    field=col, suggestion=suggestion,
-                    error_type='COLUMN_NOT_FOUND'))
-                continue
-
-            # Check predicate type compatibility
-            if isinstance(predicate, ASTPredicate):
-                col_type = schema.node_columns[col]
-                issues.extend(_validate_predicate_type(
-                    predicate, col, col_type, op_index))
-
-    return issues
+    return _validate_filter_schema(
+        node.filter_dict, schema.node_columns, 'node', op_index)
 
 
 def _validate_edge_schema(edge: "ASTEdge", schema: Schema,
@@ -379,57 +328,48 @@ def _validate_edge_schema(edge: "ASTEdge", schema: Schema,
     """Validate edge operation against schema."""
     issues = []
 
-    # Validate edge filters
-    if edge.edge_match and schema.edge_columns:
-        for col, predicate in edge.edge_match.items():
-            if col not in schema.edge_columns:
-                available = list(schema.edge_columns.keys())[:5]
-                if len(schema.edge_columns) > 5:
-                    available.append('...')
-                message, suggestion = _format_error(
-                    'COLUMN_NOT_FOUND',
-                    column=col,
-                    table='edge',
-                    available=', '.join(available))
-                issues.append(ValidationIssue(
-                    'error', message, operation_index=op_index,
-                    field=f"edge_match.{col}", suggestion=suggestion,
-                    error_type='COLUMN_NOT_FOUND'))
-                continue
-
-            if isinstance(predicate, ASTPredicate):
-                col_type = schema.edge_columns[col]
-                issues.extend(_validate_predicate_type(
-                    predicate, col, col_type, op_index,
-                    field_prefix="edge_match."))
+    issues.extend(_validate_filter_schema(
+        edge.edge_match, schema.edge_columns, 'edge', op_index,
+        field_prefix="edge_match."))
 
     # Validate source/dest node filters against node schema
     for filter_name, filter_dict in [
         ('source_node_match', edge.source_node_match),
         ('destination_node_match', edge.destination_node_match)
     ]:
-        if filter_dict and schema.node_columns:
-            for col, predicate in filter_dict.items():
-                if col not in schema.node_columns:
-                    available = list(schema.node_columns.keys())[:5]
-                    if len(schema.node_columns) > 5:
-                        available.append('...')
-                    message, suggestion = _format_error(
-                        'COLUMN_NOT_FOUND',
-                        column=col,
-                        table='node',
-                        available=', '.join(available))
-                    issues.append(ValidationIssue(
-                        'error', message, operation_index=op_index,
-                        field=f"{filter_name}.{col}", suggestion=suggestion,
-                        error_type='COLUMN_NOT_FOUND'))
-                    continue
+        issues.extend(_validate_filter_schema(
+            filter_dict, schema.node_columns, 'node', op_index,
+            field_prefix=f"{filter_name}."))
 
-                if isinstance(predicate, ASTPredicate):
-                    col_type = schema.node_columns[col]
-                    issues.extend(_validate_predicate_type(
-                        predicate, col, col_type, op_index,
-                        field_prefix=f"{filter_name}."))
+    return issues
+
+
+def _validate_filter_schema(
+    filter_dict: Optional[Dict[str, Any]],
+    schema_columns: Dict[str, str],
+    table: str,
+    op_index: int,
+    field_prefix: str = "",
+) -> List[ValidationIssue]:
+    issues: List[ValidationIssue] = []
+    if not filter_dict or not schema_columns:
+        return issues
+
+    for col, predicate in filter_dict.items():
+        if col not in schema_columns:
+            _append_issue(
+                issues, 'error', 'COLUMN_NOT_FOUND',
+                operation_index=op_index,
+                field=f"{field_prefix}{col}",
+                column=col,
+                table=table,
+                available=_available_columns(schema_columns))
+            continue
+
+        if isinstance(predicate, ASTPredicate):
+            issues.extend(_validate_predicate_type(
+                predicate, col, schema_columns[col], op_index,
+                field_prefix=field_prefix))
 
     return issues
 
@@ -502,20 +442,15 @@ def _validate_predicate_type(predicate: ASTPredicate, column: str,
 def _get_type_category(dtype_str: str) -> str:
     """Categorize dtype string into broad categories."""
     dtype_lower = str(dtype_str).lower()
-
-    if any(t in dtype_lower for t in
-           ['int', 'float', 'double', 'numeric', 'decimal']):
-        return 'numeric'
-    elif any(t in dtype_lower for t in
-             ['str', 'object', 'char', 'text', 'varchar']):
-        return 'string'
-    elif any(t in dtype_lower for t in
-             ['date', 'time', 'timestamp', 'datetime']):
-        return 'temporal'
-    elif 'bool' in dtype_lower:
-        return 'boolean'
-    else:
-        return 'unknown'
+    for category, markers in [
+        ('numeric', ('int', 'float', 'double', 'numeric', 'decimal')),
+        ('string', ('str', 'object', 'char', 'text', 'varchar')),
+        ('temporal', ('date', 'time', 'timestamp', 'datetime')),
+        ('boolean', ('bool',)),
+    ]:
+        if any(marker in dtype_lower for marker in markers):
+            return category
+    return 'unknown'
 
 
 def validate_query(chain: Union["Chain", List],
@@ -614,26 +549,21 @@ def format_validation_errors(issues: List[ValidationIssue]) -> str:
     errors = [i for i in issues if i.level == 'error']
     warning_issues = [i for i in issues if i.level == 'warning']
 
-    if errors:
-        lines.append(f"\nERRORS ({len(errors)}):")
-        for i, error in enumerate(errors, 1):
-            lines.append(f"\n{i}. {error.message}")
-            if error.operation_index is not None:
-                lines.append(f"   Location: Operation {error.operation_index}")
-            if error.field:
-                lines.append(f"   Field: {error.field}")
-            if error.suggestion:
-                lines.append(f"   💡 {error.suggestion}")
-
-    if warning_issues:
-        lines.append(f"\nWARNINGS ({len(warning_issues)}):")
-        for i, warning in enumerate(warning_issues, 1):
-            lines.append(f"\n{i}. {warning.message}")
-            if warning.operation_index is not None:
-                lines.append(
-                    f"   Location: Operation {warning.operation_index}")
-            if warning.suggestion:
-                lines.append(f"   💡 {warning.suggestion}")
+    for title, group, include_field in [
+        ("ERRORS", errors, True),
+        ("WARNINGS", warning_issues, False),
+    ]:
+        if not group:
+            continue
+        lines.append(f"\n{title} ({len(group)}):")
+        for i, issue in enumerate(group, 1):
+            lines.append(f"\n{i}. {issue.message}")
+            if issue.operation_index is not None:
+                lines.append(f"   Location: Operation {issue.operation_index}")
+            if include_field and issue.field:
+                lines.append(f"   Field: {issue.field}")
+            if issue.suggestion:
+                lines.append(f"   💡 {issue.suggestion}")
 
     return "\n".join(lines)
 

--- a/graphistry/tests/compute/test_gfql_validation.py
+++ b/graphistry/tests/compute/test_gfql_validation.py
@@ -194,6 +194,104 @@ def test_edge_validation():
     print(format_validation_errors(issues))
 
 
+def test_syntax_filter_key_diagnostics_are_stable():
+    issues = validate_syntax([
+        n({1: "person"}),
+        e_forward(
+            edge_match={2: "knows"},
+            source_node_match={3: "a"},
+            destination_node_match={4: "b"},
+        ),
+        n(),
+    ])
+
+    errors = [issue for issue in issues if issue.error_type == "INVALID_FILTER_KEY"]
+    assert [(issue.operation_index, issue.field, issue.message, issue.suggestion) for issue in errors] == [
+        (0, "1", "Invalid filter key format: 1", "Filter keys must be strings"),
+        (1, "edge_match.2", "Invalid filter key format: 2", "Filter keys must be strings"),
+        (1, "source_node_match.3", "Invalid filter key format: 3", "Filter keys must be strings"),
+        (1, "destination_node_match.4", "Invalid filter key format: 4", "Filter keys must be strings"),
+    ]
+
+
+def test_schema_filter_diagnostics_are_stable_across_node_edge_shapes():
+    schema = Schema(
+        node_columns={"id": "object", "age": "int64", "name": "object"},
+        edge_columns={"relationship": "object", "weight": "float64"},
+    )
+    chain = [
+        n({"missing_node": "value", "age": contains("25")}),
+        e_forward(
+            edge_match={"missing_edge": "value", "weight": contains("1")},
+            source_node_match={"missing_source": "a"},
+            destination_node_match={"missing_dest": "b"},
+        ),
+        n(),
+    ]
+
+    issues = validate_schema(chain, schema)
+
+    assert [
+        (issue.error_type, issue.operation_index, issue.field, issue.message)
+        for issue in issues
+    ] == [
+        ("COLUMN_NOT_FOUND", 0, "missing_node", 'Column "missing_node" not found in node data'),
+        ("TYPE_MISMATCH", 0, "age", 'Column "age" is int64 but predicate expects string'),
+        ("COLUMN_NOT_FOUND", 1, "edge_match.missing_edge", 'Column "missing_edge" not found in edge data'),
+        ("TYPE_MISMATCH", 1, "edge_match.weight", 'Column "weight" is float64 but predicate expects string'),
+        ("COLUMN_NOT_FOUND", 1, "source_node_match.missing_source", 'Column "missing_source" not found in node data'),
+        ("COLUMN_NOT_FOUND", 1, "destination_node_match.missing_dest", 'Column "missing_dest" not found in node data'),
+    ]
+
+
+def test_validation_issue_and_report_formatting_are_stable():
+    error = ValidationIssue(
+        "error",
+        "Column problem",
+        operation_index=2,
+        field="age",
+        suggestion="Fix age",
+        error_type="TYPE_MISMATCH",
+    )
+    warning = ValidationIssue(
+        "warning",
+        "Slow hop",
+        operation_index=3,
+        field="hops",
+        suggestion="Use fixed hops",
+        error_type="UNBOUNDED_HOPS_WARNING",
+    )
+
+    assert repr(error) == (
+        "ERROR: Column problem | at operation 2 | field: age | "
+        "Suggestion: Fix age"
+    )
+    assert ValidationIssue("error", "Column problem") != ValidationIssue(
+        "error", "Column problem"
+    )
+    assert error.to_dict() == {
+        "level": "error",
+        "message": "Column problem",
+        "operation_index": 2,
+        "field": "age",
+        "suggestion": "Fix age",
+        "error_type": "TYPE_MISMATCH",
+    }
+    assert format_validation_errors([error, warning]) == (
+        "GFQL Validation Report:\n"
+        "--------------------------------------------------\n"
+        "\nERRORS (1):\n"
+        "\n1. Column problem\n"
+        "   Location: Operation 2\n"
+        "   Field: age\n"
+        "   💡 Fix age\n"
+        "\nWARNINGS (1):\n"
+        "\n1. Slow hop\n"
+        "   Location: Operation 3\n"
+        "   💡 Use fixed hops"
+    )
+
+
 if __name__ == "__main__":
     test_syntax_validation()
     test_schema_validation()


### PR DESCRIPTION
## Summary
- DRY legacy graphistry.compute.gfql.validate issue construction, filter-key checks, schema-filter diagnostics, and report formatting.
- Keep deprecated public validation helpers and messages intact, including ValidationIssue identity equality semantics.
- Add anchored positive/negative coverage for syntax diagnostics, schema diagnostics, ValidationIssue formatting/equality, dict serialization, and report rendering.

## LOC accounting
- Production: graphistry/compute/gfql/validate.py 169 added / 239 deleted = net -70 LOC.
- Tests: graphistry/tests/compute/test_gfql_validation.py +98 LOC.
- Docs/changelog: CHANGELOG.md +1 LOC.

## Validation
- python3 -m pytest -q graphistry/tests/compute/test_gfql_validation.py graphistry/tests/compute/test_chain_schema_validation.py graphistry/tests/compute/test_chain_schema_prevalidation.py
- ./bin/ruff.sh graphistry/compute/gfql/validate.py graphistry/tests/compute/test_gfql_validation.py
- ./bin/typecheck.sh graphistry/compute/gfql/validate.py
- git diff --check
- Full PR CI green: changed-line coverage, RTD, TCK GFQL, GFQL core 3.12/3.14, docs, lint/type matrix, minimal/core/full matrix.

## Notes
- Compiler-plan surface touched: no. This only changes the deprecated legacy GFQL validation helper module.
- Source-span surface: none in this module. Diagnostic fidelity is preserved by exact assertions over error_type, operation_index, field, message, repr, equality, to_dict, and formatted report output.
- DGX RAPIDS 25.02/26.02: not run. This is validation control-plane cleanup with no DataFrame/cuDF runtime path changes.
- Review skill converged: wave 1 found missing formatter anchoring; fixed. Wave 2 found dataclass equality compatibility risk; fixed with eq=False and anchored. Wave 3 found no new findings.

Refs #1058