### PR TITLE
chore(gfql): shrink temporal folding traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - **GFQL call support implementation shrink (#1058)**: DRYed private call safelist schema-effect helpers and option-column collectors while preserving validated `call()` behavior, schema-effect keys, and diagnostics.
+- **GFQL temporal folding implementation shrink (#1058)**: Reused the shared expression AST rebuild helper for temporal constructor folding, preserving recursive folding behavior while covering property-access children such as `duration({days: 1}).days`.
 - **GFQL validate entrypoint implementation shrink (#1058)**: DRYed legacy `graphistry.compute.gfql.validate` issue construction, filter-key checks, schema-filter diagnostics, and report formatting while preserving deprecated public validation helpers and anchored error diagnostics.
 - **GFQL Cypher reentry execution shrink (#1058)**: DRYed private reentry execution graph-state construction and removed stale internal scalar/free-form helper parameters while preserving whole-row/scalar/free-form reentry behavior, optional null-fill shape, and diagnostics.
 - **GFQL call validation safelist + encode parity (#1058, #1253)**: DRYed repeated private safelist entry definitions for call validators while adding `encode_edge_size`, `encode_edge_weight`, and point/edge opacity, label, and title encode helpers with GFQL `call()` validation, apply-encodings/schema key contracts, and anchored validator coverage.

--- a/graphistry/compute/gfql/temporal/folding.py
+++ b/graphistry/compute/gfql/temporal/folding.py
@@ -3,65 +3,19 @@ from __future__ import annotations
 from datetime import datetime as py_datetime
 from datetime import timedelta
 import re
-from typing import Callable, Optional, cast
+from typing import Optional, cast
 
 from graphistry.compute.gfql.temporal import constructors as _tt
 from graphistry.compute.gfql.expr_parser import (
-    BinaryOp,
-    CaseWhen,
     ExprNode,
     FunctionCall,
-    Identifier,
-    IsNullOp,
-    ListComprehension,
-    ListLiteral,
     Literal,
-    MapLiteral,
-    QuantifierExpr,
-    SliceExpr,
-    SubscriptExpr,
-    UnaryOp,
-    Wildcard,
+    _rebuild_expr_node,
 )
 from graphistry.compute.gfql.temporal.durations import _fold_duration_function_call
 from graphistry.compute.gfql.temporal.rendering import _render_temporal_arg
 from graphistry.compute.gfql.temporal.truncation import _fold_temporal_truncate_call
 from graphistry.compute.gfql.temporal.values import _format_localdatetime_parts
-
-
-def _fold_expr_children(node: ExprNode, fold: Callable[[ExprNode], ExprNode]) -> ExprNode:
-    if isinstance(node, (Identifier, Literal, Wildcard)):
-        return node
-    if isinstance(node, UnaryOp):
-        return UnaryOp(node.op, fold(node.operand))
-    if isinstance(node, BinaryOp):
-        return BinaryOp(node.op, fold(node.left), fold(node.right))
-    if isinstance(node, IsNullOp):
-        return IsNullOp(fold(node.value), negated=node.negated)
-    if isinstance(node, CaseWhen):
-        return CaseWhen(fold(node.condition), fold(node.when_true), fold(node.when_false))
-    if isinstance(node, QuantifierExpr):
-        return QuantifierExpr(node.fn, node.var, fold(node.source), fold(node.predicate))
-    if isinstance(node, ListComprehension):
-        return ListComprehension(
-            node.var,
-            fold(node.source),
-            predicate=None if node.predicate is None else fold(node.predicate),
-            projection=None if node.projection is None else fold(node.projection),
-        )
-    if isinstance(node, ListLiteral):
-        return ListLiteral(tuple(fold(item) for item in node.items))
-    if isinstance(node, MapLiteral):
-        return MapLiteral(tuple((key, fold(value)) for key, value in node.items))
-    if isinstance(node, SubscriptExpr):
-        return SubscriptExpr(fold(node.value), fold(node.key))
-    if isinstance(node, SliceExpr):
-        return SliceExpr(
-            fold(node.value),
-            None if node.start is None else fold(node.start),
-            None if node.stop is None else fold(node.stop),
-        )
-    return node
 
 
 def _fold_datetime_epoch_function_call(
@@ -186,6 +140,6 @@ def fold_temporal_constructor_ast(node: ExprNode) -> ExprNode:
                 if folded is not None:
                     return folded
             return rewritten
-        return _fold_expr_children(inner, _fold)
+        return _rebuild_expr_node(inner, rewrite=_fold, error_context="temporal constructor folding")
 
     return _fold(node)

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -5180,6 +5180,10 @@ def test_string_cypher_executes_duration_between_with_alias_properties() -> None
     )
 
 
+def test_string_cypher_folds_temporal_constructor_before_property_access() -> None:
+    _assert_query_rows("RETURN duration({days: 1}).days AS days", [{"days": 1}])
+
+
 def test_string_cypher_executes_negative_duration_between_day_time_components() -> None:
     _assert_query_rows(
         "RETURN duration.between("

--- a/graphistry/tests/compute/gfql/cypher/test_temporal_text.py
+++ b/graphistry/tests/compute/gfql/cypher/test_temporal_text.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+
+from graphistry.compute.gfql.expr_parser import FunctionCall, Literal
 import graphistry.compute.gfql.temporal_text as temporal_text
 from graphistry.compute.gfql.temporal import constructors
 from graphistry.compute.gfql.temporal import durations
@@ -19,3 +22,22 @@ def test_temporal_text_reexports_domain_helpers_for_legacy_imports() -> None:
     assert temporal_text.parse_temporal_sort_duration_components is durations.parse_temporal_sort_duration_components
     assert temporal_text.resolve_duration_text_property is durations.resolve_duration_text_property
     assert temporal_text.fold_temporal_constructor_ast is folding.fold_temporal_constructor_ast
+
+
+def test_fold_temporal_constructor_ast_handles_current_date_literal() -> None:
+    folded = folding.fold_temporal_constructor_ast(FunctionCall("date", ()))
+
+    assert isinstance(folded, Literal)
+    assert isinstance(folded.value, str)
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", folded.value)
+
+
+def test_fold_temporal_constructor_ast_handles_null_epoch_literal() -> None:
+    assert folding.fold_temporal_constructor_ast(
+        FunctionCall("datetime.fromepoch", (Literal(None),))
+    ) == Literal(None)
+
+
+def test_fold_temporal_constructor_ast_handles_tostring_literals() -> None:
+    assert folding.fold_temporal_constructor_ast(FunctionCall("tostring", (Literal(None),))) == Literal(None)
+    assert folding.fold_temporal_constructor_ast(FunctionCall("tostring", (Literal(True),))) == Literal("true")


### PR DESCRIPTION
## Summary

Shrinks GFQL temporal constructor folding by deleting the local expression-child traversal copy in `temporal/folding.py` and reusing the shared `expr_parser._rebuild_expr_node()` helper.

This also preserves/extends recursive folding for property-access children, anchored by `duration({days: 1}).days`.

## Reporting

- Production: `+3 / -49`, net `-46` LOC
- Tests: `+26 / -0`, net `+26` LOC
- Docs/changelog: `+1 / -0`, net `+1` LOC
- Compiler-plan surface touched: no
- Scaffolding/typing additions offset deletion: no
- Source-span/diagnostic fidelity: no diagnostic wording or source-span path changed; existing temporal folding call sites are preserved
- DGX/RAPIDS: skipped; AST-only folding change, no dataframe/cuDF/GPU path changed

## Validation

- `python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_temporal_text.py graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_folds_temporal_constructor_before_property_access graphistry/tests/compute/gfql/cypher/test_lowering.py -k 'temporal_constructor or temporal_truncation or duration or fromepoch'`
  - `68 passed, 1060 deselected, 4 warnings`
- `python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_folds_temporal_constructor_before_property_access graphistry/tests/compute/gfql/cypher/test_temporal_text.py`
  - `6 passed, 4 warnings`
- `./bin/ruff.sh graphistry/compute/gfql/temporal/folding.py graphistry/tests/compute/gfql/cypher/test_lowering.py graphistry/tests/compute/gfql/cypher/test_temporal_text.py`
  - passed
- `./bin/typecheck.sh graphistry/compute/gfql/temporal/folding.py`
  - passed
- `git diff --check`
  - passed
- Clean CI-like py3.12 GFQL coverage reproduction in `/tmp/pyg-coverage-1622`
  - `3182 passed, 242 skipped, 15 xfailed, 105 warnings`
  - `bin/coverage_audit.py --profile gfql --skip-tests ... --baseline-file graphistry/tests/compute/gfql/coverage_baselines/ci-pandas-py3.12.json`
  - passed; `folding.py` coverage `94.32%` vs `90.00%` floor

Notes:
- Direct typecheck of `test_lowering.py` still hits pre-existing test-suite mypy debt/missing `pytest` stubs unrelated to this patch.
- A broad local `-k property_access` selector pulled in existing cuDF tests and failed with `cudaErrorNoDevice` on this CPU host; not a patch regression.

Refs #1058
