### PR TITLE
chore(gfql): shrink hop debug scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL NetworkX CALL parity (#1058)**: Expanded the local Cypher `graphistry.nx.*` CALL surface with explicit NetworkX dispatch for `degree_centrality`, `closeness_centrality`, `eigenvector_centrality`, `katz_centrality`, `connected_components`, `strongly_connected_components`, `core_number`, and multi-output `hits`, including row and `.write()` coverage.
 
 ### Changed
+- **GFQL hop implementation shrink (#1058)**: Removed stale hop-local debug scaffolding while preserving public `hop()` traversal, hop-label, and pandas/cuDF behavior.
 - **GFQL call support implementation shrink (#1058)**: DRYed private call safelist schema-effect helpers and option-column collectors while preserving validated `call()` behavior, schema-effect keys, and diagnostics.
 - **GFQL temporal folding implementation shrink (#1058)**: Reused the shared expression AST rebuild helper for temporal constructor folding, preserving recursive folding behavior while covering property-access children such as `duration({days: 1}).days`.
 - **GFQL validate entrypoint implementation shrink (#1058)**: DRYed legacy `graphistry.compute.gfql.validate` issue construction, filter-key checks, schema-filter diagnostics, and report formatting while preserving deprecated public validation helpers and anchored error diagnostics.

--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -3,7 +3,6 @@ Graph hop/traversal operations for PyGraphistry.
 
 NOTE: Excluded from pyre (.pyre_configuration) - hop() complexity causes hang. Use mypy.
 """
-import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union, cast
 import pandas as pd
@@ -12,16 +11,12 @@ from graphistry.Engine import (
     EngineAbstract, align_shared_column_dtypes, df_concat, df_cons, df_to_engine, resolve_engine, safe_map_series, safe_row_concat, s_series, s_to_numeric, s_na, Engine
 )
 from graphistry.Plottable import Plottable
-from graphistry.util import setup_logger
 from graphistry.otel import otel_traced, otel_detail_enabled
 from .filter_by_dict import filter_by_dict
 from graphistry.Engine import safe_merge
 from .typing import DataFrameT, DomainT
-from .dataframe_utils import column_frame, column_values, dbg_df
+from .dataframe_utils import column_frame, column_values
 from .util import generate_safe_column_name
-
-
-logger = setup_logger(__name__)
 
 
 def _hop_otel_attrs(*args: Any, **kwargs: Any) -> Dict[str, Any]:
@@ -147,7 +142,6 @@ def hop(self: Plottable,
     
     nodes = df_to_engine(nodes, engine_concrete) if nodes is not None else None
     target_wave_front = df_to_engine(target_wave_front, engine_concrete) if target_wave_front is not None else None
-    debugging_hop = False
 
     if direction not in ['forward', 'reverse', 'undirected']:
         raise ValueError(f'Invalid direction: "{direction}", must be one of: "forward" (default), "reverse", "undirected"')
@@ -201,7 +195,6 @@ def hop(self: Plottable,
         destination_node_match = None
 
     g2 = self.materialize_nodes(engine=EngineAbstract(engine_concrete.value))
-    logger.debug('materialized node/edge types: %s, %s', type(g2._nodes), type(g2._edges))
 
     if g2._node is None:
         raise ValueError('Node binding cannot be None, please set g._node via bind() or nodes()')
@@ -215,22 +208,6 @@ def hop(self: Plottable,
     assert g2._destination is not None, "Destination binding checked above"
     source_col = g2._source
     destination_col = g2._destination
-
-    node_src_conflict = g2._node == g2._source
-    node_dst_conflict = g2._node == g2._destination
-
-    TEMP_SRC_COL = str(g2._source)
-    TEMP_DST_COL = str(g2._destination)
-
-    if node_src_conflict:
-        TEMP_SRC_COL = generate_safe_column_name(g2._source, g2._edges)
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('Node column conflicts with source column, using temp name: %s', TEMP_SRC_COL)
-
-    if node_dst_conflict:
-        TEMP_DST_COL = generate_safe_column_name(g2._destination, g2._edges)
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('Node column conflicts with destination column, using temp name: %s', TEMP_DST_COL)
 
     seeds_provided = nodes is not None
     starting_nodes = nodes if seeds_provided else g2._nodes
@@ -331,14 +308,6 @@ def hop(self: Plottable,
         seed_nodes = starting_nodes[[node_col]].drop_duplicates()
         node_hop_records = seed_nodes.assign(**{node_hop_col: 0})
         seen_node_ids = _domain_unique(seed_nodes[node_col])
-
-    if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-        logger.debug('~~~~~~~~~~ LOOP PRE ~~~~~~~~~~~')
-        logger.debug('starting_nodes: %s', dbg_df(starting_nodes))
-        logger.debug('g2._nodes: %s', dbg_df(g2._nodes))
-        logger.debug('g2._edges: %s', dbg_df(g2._edges))
-        logger.debug('edges_indexed: %s', dbg_df(edges_indexed))
-        logger.debug('=====================')
 
     # Fast path: no hop tracking, no predicates, no target_wave_front.
     fast_path_enabled = (
@@ -495,22 +464,6 @@ def hop(self: Plottable,
 
         current_hop += 1
 
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('~~~~~~~~~~ LOOP STEP BEGIN ~~~~~~~~~~~')
-            logger.debug('current_hop: %s', current_hop)
-            logger.debug('wave_front: %s', dbg_df(wave_front))
-            logger.debug('matches_nodes: %s', dbg_df(matches_nodes))
-            logger.debug('matches_edges: %s', dbg_df(matches_edges))
-            logger.debug('first_iter: %s', first_iter)
-            logger.debug('source_node_match: %s', source_node_match)
-            logger.debug('starting_nodes: %s', dbg_df(starting_nodes))
-            logger.debug('self._nodes: %s', dbg_df(self._nodes))
-            logger.debug('wave_front: %s', dbg_df(wave_front))
-            logger.debug(
-                'wave_front_base: %s',
-                dbg_df(starting_nodes[[node_col]] if first_iter else wave_front),
-            )
-
         assert len(wave_front.columns) == 1, "just indexes"
         wave_front_base = starting_nodes[[node_col]] if first_iter else wave_front
         if allowed_source_series is None:
@@ -519,32 +472,20 @@ def hop(self: Plottable,
             wave_front_iter = wave_front_base[wave_front_base[node_col].isin(allowed_source_series)]
         first_iter = False
 
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('~~~~~~~~~~ LOOP STEP CONTINUE ~~~~~~~~~~~')
-            logger.debug('wave_front_iter: %s', dbg_df(wave_front_iter))
-            
         wavefront_ids = wave_front_iter[node_col].unique()
         hop_edges = pairs[pairs[FROM_COL].isin(wavefront_ids)]
-
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('hop_edges basic: %s', dbg_df(hop_edges))
 
         if allowed_target_intermediate is not None:
             has_more_hops_planned = to_fixed_point or resolved_max_hops is None or current_hop < resolved_max_hops
             target_ids = allowed_target_intermediate if has_more_hops_planned else allowed_target_final
             if target_ids is not None:
                 hop_edges = hop_edges[hop_edges[TO_COL].isin(target_ids)]
-            if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-                logger.debug('hop_edges filtered by target_wave_front: %s', dbg_df(hop_edges))
 
         new_node_ids = hop_edges[[TO_COL]].rename(columns={TO_COL: node_col}).drop_duplicates()
 
         if allowed_dest_series is not None:
             new_node_ids = new_node_ids[new_node_ids[node_col].isin(allowed_dest_series)]
             hop_edges = hop_edges[hop_edges[TO_COL].isin(allowed_dest_series)]
-            if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-                logger.debug('new_node_ids after precomputed filtering: %s', dbg_df(new_node_ids))
-                logger.debug('hop_edges filtered by precomputed nodes: %s', dbg_df(hop_edges))
 
         matches_edges = concat(
             [matches_edges, hop_edges[[EDGE_ID]]],
@@ -605,13 +546,6 @@ def hop(self: Plottable,
                     new_node_ids_domain = _domain_unique(new_node_labels[node_col])
                     seen_node_ids = _domain_union(seen_node_ids, new_node_ids_domain)
 
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('~~~~~~~~~~ LOOP STEP MERGES 1 ~~~~~~~~~~~')
-            logger.debug('matches_edges: %s', dbg_df(matches_edges))
-            logger.debug('matches_nodes: %s', dbg_df(matches_nodes))
-            logger.debug('new_node_ids: %s', dbg_df(new_node_ids))
-            logger.debug('hop_edges: %s', dbg_df(hop_edges))
-
         if matches_nodes is None:  # first iteration
             if return_as_wave_front:
                 matches_nodes = new_node_ids[:0]
@@ -619,10 +553,6 @@ def hop(self: Plottable,
                 matches_nodes = hop_edges[[FROM_COL]].rename(
                     columns={FROM_COL: node_col}
                 ).drop_duplicates(subset=[node_col])
-
-            if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-                logger.debug('~~~~~~~~~~ LOOP STEP MERGES 2 ~~~~~~~~~~~')
-                logger.debug('matches_edges: %s', dbg_df(matches_edges))
 
         if len(matches_nodes) > 0:
             combined_node_ids = concat(
@@ -638,20 +568,6 @@ def hop(self: Plottable,
 
         wave_front = new_node_ids
         matches_nodes = combined_node_ids
-
-        if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-            logger.debug('~~~~~~~~~~ LOOP STEP POST ~~~~~~~~~~~')
-            logger.debug('matches_nodes: %s', dbg_df(matches_nodes))
-            logger.debug('wave_front: %s', dbg_df(wave_front))
-            logger.debug('matches_nodes: %s', dbg_df(matches_nodes))
-
-    if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-        logger.debug('~~~~~~~~~~ LOOP END POST ~~~~~~~~~~~')
-        logger.debug('matches_nodes: %s', dbg_df(matches_nodes))
-        logger.debug('matches_edges: %s', dbg_df(matches_edges))
-        logger.debug('nodes (self): %s', dbg_df(self._nodes))
-        logger.debug('nodes (init): %s', dbg_df(nodes))
-        logger.debug('target_wave_front: %s', dbg_df(target_wave_front))
 
     if resolved_min_hops is not None and max_reached_hop < resolved_min_hops:
         matches_nodes = starting_nodes[[node_col]][:0]
@@ -920,17 +836,9 @@ def hop(self: Plottable,
         return loop_nodes | {node_id for node_id in degrees if node_id not in removed}
 
     if self._nodes is not None:
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug('~~~~~~~~~~ NODES HYDRATION ~~~~~~~~~~~')
         rich_nodes = self._nodes
         if target_wave_front is not None:
             rich_nodes = concat([rich_nodes, target_wave_front], ignore_index=True, sort=False).drop_duplicates(subset=[node_col])
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug('rich_nodes available for inner merge: %s', dbg_df(rich_nodes))
-            logger.debug('target_wave_front: %s', dbg_df(target_wave_front))
-            logger.debug('matches_nodes: %s', dbg_df(matches_nodes))
-            logger.debug('wave_front: %s', dbg_df(wave_front))
-            logger.debug('self._nodes: %s', dbg_df(self._nodes))
 
         base_nodes = matches_nodes if matches_nodes is not None else wave_front[:0]
 
@@ -1168,13 +1076,6 @@ def hop(self: Plottable,
             g_out = g_out.nodes(g_out._nodes[mask].drop_duplicates(subset=[node_col]))
         except Exception:
             pass
-
-    if debugging_hop and logger.isEnabledFor(logging.DEBUG):
-        logger.debug('~~~~~~~~~~ HOP OUTPUT ~~~~~~~~~~~')
-        logger.debug('nodes: %s', dbg_df(g_out._nodes))
-        logger.debug('edges: %s', dbg_df(g_out._edges))
-        logger.debug('======== /HOP =============')
-        logger.debug('==========================')
 
     if (
         return_as_wave_front


### PR DESCRIPTION
## Summary

Refs #1058.

Removes stale hop-local debug scaffolding from `graphistry/compute/hop.py`. The removed code was guarded by `debugging_hop = False` or only emitted local `dbg_df()` debug traces; traversal, result construction, hop labels, min/max hop pruning, and pandas/cuDF conversion paths are unchanged.

## LOC

- Production: +1 / -100, net -99 (`graphistry/compute/hop.py`)
- Tests / fixtures / baselines: +0 / -0, net 0
- Comments / docs / changelog: +1 / -0, net +1 (`CHANGELOG.md`)

## Protected Surfaces

- Compiler-plan surface touched: no
- Public hop API touched: no signature or semantic changes
- Source-span / diagnostic surface touched: no
- pandas/cuDF parity: preserved; runtime smoke passed on DGX RAPIDS 25.02 + 26.02

## Validation

- `python3 -m compileall -q graphistry/compute/hop.py`
- `python3 -m pytest -q graphistry/tests/compute/test_hop.py graphistry/tests/test_compute_hops.py` -> 119 passed, 4 skipped
- `./bin/ruff.sh graphistry/compute/hop.py graphistry/tests/compute/test_hop.py graphistry/tests/test_compute_hops.py`
- `./bin/typecheck.sh graphistry/compute/hop.py`
- DGX RAPIDS 25.02: `graphistry/test-rapids-official:25.02-cuda12-gfql` + `_dgx_977_smoke.py` -> all checks passed
- DGX RAPIDS 26.02: `graphistry/test-rapids-official:26.02-cuda13-gfql` + `_dgx_977_smoke.py` -> all checks passed

## Notes

Local broader `test_engine_coercion.py -k 'hop or dbg_df'` was not used as the cuDF signal because this machine has cuDF importable but no CUDA device, causing no-device failures before code execution. The equivalent hop/cuDF smoke was run on DGX instead.
