### PR TITLE
test(ai): harden model namespace embedding flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL call validation safelist + encode parity (#1058, #1253)**: DRYed repeated private safelist entry definitions for call validators while adding `encode_edge_size`, `encode_edge_weight`, and point/edge opacity, label, and title encode helpers with GFQL `call()` validation, apply-encodings/schema key contracts, and anchored validator coverage.
 - **GFQL CALL procedure implementation shrink (#1058)**: DRYed local Cypher CALL output-column derivation, computed-output renaming, and NetworkX backend error/dependency plumbing while preserving the no-SciPy `graphistry.nx.pagerank` path. Public CALL procedure behavior and diagnostics are preserved.
 
+### Fixed
+- **CI / feature_utils (#1085)**: Hardened the sentence-transformer model-namespace equivalence test against tiny parallel-run floating-point jitter while preserving explicit elementwise embedding comparison.
+
 ## [0.56.0 - 2026-05-23]
 
 ### Migration / Compatibility Notes

--- a/graphistry/tests/test_feature_utils.py
+++ b/graphistry/tests/test_feature_utils.py
@@ -1,4 +1,5 @@
 import graphistry
+import graphistry.feature_utils as feature_utils
 import logging
 import numpy as np
 import pandas as pd
@@ -6,6 +7,7 @@ from typing import Any
 
 import pytest
 import unittest
+from unittest.mock import patch
 
 from graphistry.feature_utils import (
     process_dirty_dataframes,
@@ -30,6 +32,38 @@ has_min_dependancy_text, _, _ = lazy_sentence_transformers_import()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logging.getLogger("graphistry.feature_utils").setLevel(logging.DEBUG)
+
+
+def _assert_embedding_frames_allclose(
+    testcase: unittest.TestCase,
+    left: pd.DataFrame,
+    right: pd.DataFrame,
+    message: str,
+) -> None:
+    testcase.assertEqual(left.shape, right.shape, f"{message}: shape mismatch")
+    left_values = np.asarray(left.values, dtype=np.float64)
+    right_values = np.asarray(right.values, dtype=np.float64)
+    testcase.assertGreater(
+        float(np.linalg.norm(left_values.reshape(-1))),
+        0.0,
+        f"{message}: left embeddings should be non-zero",
+    )
+    testcase.assertGreater(
+        float(np.linalg.norm(right_values.reshape(-1))),
+        0.0,
+        f"{message}: right embeddings should be non-zero",
+    )
+    try:
+        np.testing.assert_allclose(
+            left_values,
+            right_values,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg=message,
+        )
+    except AssertionError as exc:
+        testcase.fail(str(exc))
+
 
 model_avg_name = (
     "/models/average_word_embeddings_komninos"  # 250mb, fastest vectorizer in transformer models
@@ -404,6 +438,55 @@ class TestFeatureMethods(unittest.TestCase):
 
 class TestModelNameHandling(unittest.TestCase):
     """Test that both legacy and new model name formats work correctly"""
+
+    def test_legacy_model_name_resolves_to_canonical_sentence_transformers_id(self):
+        """Legacy and qualified names should load the same model identifier."""
+        seen_model_names = []
+
+        class FakeSentenceTransformer:
+            def __init__(self, model_name):
+                self.model_name = model_name
+                seen_model_names.append(model_name)
+
+            def encode(self, values, **kwargs):
+                return np.full((len(values), 3), 1.0)
+
+        test_df = pd.DataFrame({
+            'text': ['test sentence for encoding'],
+            'id': [1]
+        })
+        small_model = "paraphrase-albert-small-v2"
+
+        with patch.object(
+            feature_utils,
+            "lazy_sentence_transformers_import",
+            return_value=(True, None, FakeSentenceTransformer),
+        ):
+            legacy_result, legacy_text_cols, legacy_model = encode_textual(
+                test_df,
+                min_words=0,
+                model_name=small_model,
+                use_ngrams=False
+            )
+            qualified_result, qualified_text_cols, qualified_model = encode_textual(
+                test_df,
+                min_words=0,
+                model_name=f"sentence-transformers/{small_model}",
+                use_ngrams=False
+            )
+
+        expected_model_name = f"sentence-transformers/{small_model}"
+        self.assertEqual(seen_model_names, [expected_model_name, expected_model_name])
+        self.assertEqual(legacy_model.model_name, expected_model_name)
+        self.assertEqual(qualified_model.model_name, expected_model_name)
+        self.assertEqual(legacy_text_cols, ['text'])
+        self.assertEqual(qualified_text_cols, ['text'])
+        _assert_embedding_frames_allclose(
+            self,
+            legacy_result,
+            qualified_result,
+            "Canonicalized model names should produce identical embeddings",
+        )
     
     @pytest.mark.skipif(not has_min_dependancy or not has_min_dependancy_text, reason="requires ai feature dependencies")
     def test_model_name_formats(self):
@@ -536,19 +619,12 @@ class TestModelNameHandling(unittest.TestCase):
             use_ngrams=False
         )
         
-        # Both should produce semantically equivalent embeddings.
         # Different load paths can introduce tiny floating-point variation in CI.
-        self.assertEqual(result1.shape, result2.shape, 
-                        "Different formats should produce same shape embeddings")
-        v1 = np.asarray(result1.values, dtype=np.float64).reshape(-1)
-        v2 = np.asarray(result2.values, dtype=np.float64).reshape(-1)
-        denom = np.linalg.norm(v1) * np.linalg.norm(v2)
-        self.assertGreater(denom, 0.0, "Embeddings should be non-zero vectors")
-        cosine = float(np.dot(v1, v2) / denom)
-        self.assertGreater(
-            cosine,
-            0.9999,
-            f"Different formats should produce near-identical embeddings, got cosine={cosine}",
+        _assert_embedding_frames_allclose(
+            self,
+            result1,
+            result2,
+            "Different formats should produce near-identical embeddings",
         )
 
 


### PR DESCRIPTION
## Summary

Closes #1085.

Stabilizes `TestModelNameHandling::test_alternative_namespace_models` without skipping, serializing, or retrying it:

- replaces the prior cosine-only hardening with a shared helper that checks shape, non-zero embeddings, and explicit elementwise closeness
- uses `np.testing.assert_allclose(..., rtol=1e-5, atol=1e-5)` so tiny near-zero CI float jitter is tolerated while magnitude/value drift is still caught
- adds a no-model regression guard that verifies the legacy and fully-qualified aliases instantiate the same canonical SentenceTransformers model id
- adds a Development changelog entry for the developer-visible CI flake stabilization

## Root Cause

Historical failing run: https://github.com/graphistry/pygraphistry/actions/runs/24058325615

Failed job: `test-full-ai (3.11)` at `graphistry/tests/test_feature_utils.py:587`:

```text
AssertionError: False is not true : Different formats should produce identical embeddings
```

The old assertion used default `np.allclose(result1.values, result2.values)`. Equivalent SentenceTransformer load/encode paths can produce tiny absolute float jitter around near-zero embedding coordinates under the parallel `test-full-ai` lane. Default `np.allclose(..., atol=1e-08)` is too strict there.

Current `origin/master` had already moved that assertion to cosine similarity in `4ea93364`, but cosine-only comparison can hide magnitude drift. This PR keeps the flake fix while restoring explicit elementwise value comparison.

## Before / After Flake Evidence

| Scenario | Evidence | Result |
|---|---:|---|
| Historical CI before hardening | `test-full-ai (3.11)` in run `24058325615` | 1 failure at default `np.allclose` |
| Local no-model regression guard | `python3 -m pytest -q graphistry/tests/test_feature_utils.py::TestModelNameHandling::test_legacy_model_name_resolves_to_canonical_sentence_transformers_id` | 1 passed |
| Local focused class | `python3 -m pytest -q graphistry/tests/test_feature_utils.py::TestModelNameHandling` | 1 passed, 3 skipped due local missing AI deps |
| PR full AI matrix | PR #1625 CI run `26380012993` | all five `test-full-ai` lanes passed under `-n auto` |

Full AI PR CI evidence:

- `test-full-ai (3.9)`: passed in 4m44s
- `test-full-ai (3.10)`: passed in 4m36s
- `test-full-ai (3.11)`: passed in 3m41s (historical failing lane)
- `test-full-ai (3.12)`: passed in 3m56s
- `test-full-ai (3.13)`: passed in 4m08s

Local full AI reproduction note: this shell lacks `pytest_xdist`, `pytest_repeat`, `sentence_transformers`, and `torch`. A throwaway CI-style lock generation succeeded, but naive local install pulled the full CUDA torch dependency chain instead of CI's explicit CPU torch follow-up, so it was stopped and cleaned. PR CI is the authoritative full-matrix validation.

## Validation

- `python3 -m pytest -q graphistry/tests/test_feature_utils.py::TestModelNameHandling::test_legacy_model_name_resolves_to_canonical_sentence_transformers_id`
- `python3 -m pytest -q graphistry/tests/test_feature_utils.py::TestModelNameHandling`
- `./bin/ruff.sh graphistry/tests/test_feature_utils.py`
- `git diff --check`
- PR CI run `26380012993`: green, including changed-line coverage, RTD preview, `test-gfql-core`, `test-core-python`, and all `test-full-ai` matrix lanes

Local typecheck note: `./bin/typecheck.sh graphistry/tests/test_feature_utils.py` fails in this shell because the local mypy environment cannot import `pytest`; PR CI dependency setup should validate the typed lane.

## Review

Review skill converged locally:

- Wave 1: no findings
- Wave 2: no findings, no significant advance
- Wave 3: no findings after replacing the synthetic jitter-only regression with the behavior-focused canonicalization test
- Wave 4: no findings after fixing the CI-only mock target failure
- Artifacts: `plans/feature-utils-alt-namespace-flake-1085/review/` local only

## Scope

- Compiler-plan surface touched: no
- Production code touched: no
- DGX/RAPIDS required: no, no GPU/cuDF/runtime algorithm path changed
- Branch protection / CodeQL / changed-line coverage / guards weakened: no
- HF cache + offline-mode workflow changed: no
