### PR TITLE
chore(gfql): shrink Cypher result postprocess helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **GFQL NetworkX CALL parity (#1058)**: Expanded the local Cypher `graphistry.nx.*` CALL surface with explicit NetworkX dispatch for `degree_centrality`, `closeness_centrality`, `eigenvector_centrality`, `katz_centrality`, `connected_components`, `strongly_connected_components`, `core_number`, and multi-output `hits`, including row and `.write()` coverage.
 
 ### Changed
+- **GFQL Cypher result postprocess shrink (#1058)**: Collapsed private result-projection alias/metadata helpers while preserving prefixed alias whole-row rendering, reentry entity metadata, and pandas/cuDF projection behavior.
 - **GFQL hop implementation shrink (#1058)**: Removed stale hop-local debug scaffolding while preserving public `hop()` traversal, hop-label, and pandas/cuDF behavior.
 - **GFQL call support implementation shrink (#1058)**: DRYed private call safelist schema-effect helpers and option-column collectors while preserving validated `call()` behavior, schema-effect keys, and diagnostics.
 - **GFQL temporal folding implementation shrink (#1058)**: Reused the shared expression AST rebuild helper for temporal constructor folding, preserving recursive folding behavior while covering property-access children such as `duration({days: 1}).days`.

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Any, Literal, Optional, TypedDict, cast
+from typing import Any, Dict, Literal, Optional, TypedDict, cast
 
 import pandas as pd
 
@@ -49,7 +49,7 @@ def entity_projection_meta_entry(
     from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 
     entity_meta = cast(
-        Optional[dict[str, WholeRowProjectionMeta]],
+        Optional[Dict[str, WholeRowProjectionMeta]],
         getattr(result, "_cypher_entity_projection_meta", None),
     )
     if not isinstance(entity_meta, dict) or output_name not in entity_meta:
@@ -185,8 +185,8 @@ def apply_result_projection(result: Plottable, projection: ResultProjectionPlan)
     alias_rows_df = _projection_alias_rows(rows_df, alias=projection.alias)
     if alias_rows_df is None or projection.alias not in alias_rows_df.columns:
         return result
-    projected_data: dict[str, SeriesT] = {}
-    projected_entity_meta: dict[str, WholeRowProjectionMeta] = {}
+    projected_data: Dict[str, SeriesT] = {}
+    projected_entity_meta: Dict[str, WholeRowProjectionMeta] = {}
     for column in projection.columns:
         if column.kind == "whole_row":
             source_alias = column.source_name or projection.alias

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional, TypedDict, cast
+from dataclasses import replace
+from typing import Any, Literal, Optional, TypedDict, cast
 
 import pandas as pd
 
@@ -48,7 +49,7 @@ def entity_projection_meta_entry(
     from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 
     entity_meta = cast(
-        Optional[Dict[str, WholeRowProjectionMeta]],
+        Optional[dict[str, WholeRowProjectionMeta]],
         getattr(result, "_cypher_entity_projection_meta", None),
     )
     if not isinstance(entity_meta, dict) or output_name not in entity_meta:
@@ -63,11 +64,6 @@ def entity_projection_meta_entry(
     return entity_meta[output_name]
 
 
-
-def _bool_mask(series: SeriesT) -> SeriesT:
-    return cast(SeriesT, series == True)  # noqa: E712
-
-
 def _node_label_text(df: DataFrameT, alias_col: str) -> SeriesT:
     label_cols = [
         col
@@ -78,7 +74,7 @@ def _node_label_text(df: DataFrameT, alias_col: str) -> SeriesT:
     if label_cols:
         labels = _empty_text(df, alias_col)
         for col in label_cols:
-            mask = _bool_mask(cast(SeriesT, df[col]))
+            mask = cast(SeriesT, cast(SeriesT, df[col]) == True)  # noqa: E712
             label = ":" + str(col).split("label__", 1)[1]
             labels = cast(SeriesT, labels + _const_text(df, alias_col, label).where(mask, ""))
         return labels
@@ -161,51 +157,25 @@ def _project_expr_column(
     return cast(SeriesT, value if hasattr(value, "astype") else _broadcast_projected_scalar(adapter, rows_df, value))
 
 
-def _whole_row_projection_meta(
-    result: Plottable,
-    rows_df: DataFrameT,
-    projection: ResultProjectionPlan,
-) -> WholeRowProjectionMeta | None:
-    id_column = getattr(result, "_node" if projection.table == "nodes" else "_edge", None)
-    if id_column is None or id_column not in rows_df.columns:
-        return None
-    return {
-        "table": projection.table,
-        "alias": projection.alias,
-        "id_column": id_column,
-        "ids": cast(SeriesT, rows_df[id_column]).copy(),
-    }
-
-
 def _projection_alias_rows(
-    rows_df: DataFrameT,
-    *,
-    alias: str,
-) -> Optional[DataFrameT]:
-    binding_rows = _binding_alias_projection_rows(rows_df, alias=alias)
-    if binding_rows is not None and alias in binding_rows.columns:
-        return binding_rows
-    if alias in rows_df.columns:
-        return rows_df
-    return None
-
-
-def _binding_alias_projection_rows(
     rows_df: DataFrameT,
     *,
     alias: str,
 ) -> Optional[DataFrameT]:
     prefix = f"{alias}."
     alias_columns = [column for column in rows_df.columns if str(column).startswith(prefix)]
-    if not alias_columns:
-        return None
-    alias_rows = cast(
-        DataFrameT,
-        rows_df[alias_columns].rename(columns={column: str(column)[len(prefix):] for column in alias_columns}),
-    )
-    if alias in rows_df.columns and alias not in alias_rows.columns:
-        alias_rows = cast(DataFrameT, alias_rows.assign(**{alias: rows_df[alias]}))
-    return alias_rows
+    if alias_columns:
+        alias_rows = cast(
+            DataFrameT,
+            rows_df[alias_columns].rename(columns={column: str(column)[len(prefix):] for column in alias_columns}),
+        )
+        if alias in rows_df.columns and alias not in alias_rows.columns:
+            alias_rows = cast(DataFrameT, alias_rows.assign(**{alias: rows_df[alias]}))
+        if alias in alias_rows.columns:
+            return alias_rows
+    if alias in rows_df.columns:
+        return rows_df
+    return None
 
 
 def apply_result_projection(result: Plottable, projection: ResultProjectionPlan) -> Plottable:
@@ -223,24 +193,19 @@ def apply_result_projection(result: Plottable, projection: ResultProjectionPlan)
             source_rows_df = _projection_alias_rows(rows_df, alias=source_alias)
             if source_rows_df is None or source_alias not in source_rows_df.columns:
                 raise ValueError(f"whole-row projection source alias not found: {source_alias!r}")
-            source_projection = projection if source_alias == projection.alias else ResultProjectionPlan(
-                alias=source_alias,
-                table=projection.table,
-                columns=projection.columns,
-                exclude_columns=projection.exclude_columns,
-            )
+            source_projection = projection if source_alias == projection.alias else replace(projection, alias=source_alias)
             projected_data[column.output_name] = (
                 _format_node_entities(source_rows_df, source_projection)
                 if projection.table == "nodes"
                 else _format_edge_entities(source_rows_df, source_projection)
             )
-            whole_row_meta = _whole_row_projection_meta(result, source_rows_df, source_projection)
-            if whole_row_meta is not None:
+            id_column = getattr(result, "_node" if source_projection.table == "nodes" else "_edge", None)
+            if id_column is not None and id_column in source_rows_df.columns:
                 projected_entity_meta[column.output_name] = {
-                    "table": whole_row_meta["table"],
-                    "alias": whole_row_meta["alias"],
-                    "id_column": whole_row_meta["id_column"],
-                    "ids": whole_row_meta["ids"],
+                    "table": source_projection.table,
+                    "alias": source_projection.alias,
+                    "id_column": id_column,
+                    "ids": cast(SeriesT, source_rows_df[id_column]).copy(),
                 }
         else:
             if column.kind == "property":

--- a/graphistry/tests/compute/gfql/cypher/test_result_postprocess.py
+++ b/graphistry/tests/compute/gfql/cypher/test_result_postprocess.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pandas as pd
+
+import graphistry
+from graphistry.compute.gfql.cypher.lowering import ResultProjectionColumn, ResultProjectionPlan
+from graphistry.compute.gfql.cypher.result_postprocess import apply_result_projection
+
+
+def test_apply_result_projection_preserves_prefixed_whole_row_metadata() -> None:
+    rows = pd.DataFrame(
+        {
+            "id": ["a"],
+            "n": ["a"],
+            "n.id": ["a"],
+            "n.name": ["Alice"],
+            "n.label__Person": [True],
+        }
+    )
+    result = graphistry.bind(node="id").nodes(rows)
+
+    out = apply_result_projection(
+        result,
+        ResultProjectionPlan(
+            alias="n",
+            table="nodes",
+            columns=(
+                ResultProjectionColumn("node", "whole_row"),
+                ResultProjectionColumn("name", "property", "name"),
+            ),
+        ),
+    )
+
+    assert out._nodes.to_dict(orient="records") == [{"node": "(:Person {name: 'Alice'})", "name": "Alice"}]
+    assert out._cypher_entity_projection_meta["node"]["table"] == "nodes"
+    assert out._cypher_entity_projection_meta["node"]["alias"] == "n"
+    assert out._cypher_entity_projection_meta["node"]["id_column"] == "id"
+    assert out._cypher_entity_projection_meta["node"]["ids"].tolist() == ["a"]


### PR DESCRIPTION
## Summary
- Collapse private Cypher result-projection alias/metadata helpers in `result_postprocess.py`.
- Preserve prefixed alias whole-row rendering and reentry entity metadata.
- Add a focused regression test for prefixed whole-row projection metadata.

Refs #1058

#1058 receipt: https://github.com/graphistry/pygraphistry/issues/1058#issuecomment-4531215588

## LOC Report
- Production / implementation: +22 / -57, net -35 LOC
- Tests / fixtures / baselines: +38 / -0, net +38 LOC
- Comments / docs / changelog: +1 / -0, net +1 LOC

## Compiler-Plan Surface
Compiler-plan surface touched: no.

This stays inside private result postprocess helpers; route names, planning semantics, dispatch contracts, typed-schema/IR metadata seams, structured diagnostics, and source-span handling are unchanged.

Source-span/diagnostic evidence: no diagnostic/source-span construction changed; existing structured `entity_projection_meta_entry()` error path is untouched, and focused projection/reentry suites pass.

## Validation
- `python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_result_postprocess.py` -> 1 passed
- `python3 -m pytest -q graphistry/tests/compute/gfql/test_runtime_physical_cutover.py graphistry/tests/compute/gfql/cypher/test_result_postprocess.py -k 'not cudf'` -> 31 passed, 1 deselected
- `python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k '(projection or reentry) and not cudf'` -> 206 passed, 926 deselected
- `./bin/ruff.sh graphistry/compute/gfql/cypher/result_postprocess.py graphistry/tests/compute/gfql/cypher/test_result_postprocess.py` -> pass
- `./bin/typecheck.sh` -> pass
- `git diff --check` -> pass
- Local cuDF tests: unavailable on this host (`cudaErrorNoDevice`); validated on DGX instead
- DGX RAPIDS 25.02 + 26.02 targeted cuDF matrix -> pass
- PR CI -> green after one loop; first run caught a Python 3.8 runtime typing issue from evaluated `dict[...]` in `cast(...)`, fixed with `typing.Dict[...]`
