### PR TITLE
perf(ai): reuse sentence transformer models in full-AI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1601,6 +1601,7 @@ jobs:
       run: |
         source pygraphistry/bin/activate
         python -B -m pytest -vv -n auto \
+          --durations=50 \
           graphistry/tests/test_compute_cluster.py \
           graphistry/tests/test_feature_utils.py \
           graphistry/tests/test_text_utils.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - **GFQL call executor implementation shrink (#1058)**: DRYed private call execution, postcall graph-stat selection, and policy exception enrichment while preserving validated `call()` execution, postcall-on-error behavior, and policy-denial precedence.
+- **AI feature test/runtime performance (#1058)**: Reused normalized `SentenceTransformer` model instances within each Python process during `encode_textual()` calls, reducing repeated model construction in `test-full-ai` and user workflows that encode with the same model repeatedly. Added `test-full-ai` duration reporting for continued CI profiling.
 - **GFQL Cypher result postprocess shrink (#1058)**: Collapsed private result-projection alias/metadata helpers while preserving prefixed alias whole-row rendering, reentry entity metadata, and pandas/cuDF projection behavior.
 - **GFQL hop implementation shrink (#1058)**: Removed stale hop-local debug scaffolding while preserving public `hop()` traversal, hop-label, and pandas/cuDF behavior.
 - **GFQL call support implementation shrink (#1058)**: DRYed private call safelist schema-effect helpers and option-column collectors while preserving validated `call()` behavior, schema-effect keys, and diagnostics.

--- a/graphistry/feature_utils.py
+++ b/graphistry/feature_utils.py
@@ -5,7 +5,7 @@ import pandas as pd
 from time import time
 from inspect import getmodule
 import warnings
-from functools import partial
+from functools import lru_cache, partial
 from typing import cast
 
 from typing import (
@@ -720,6 +720,20 @@ def _get_sentence_transformer_headers(emb, text_cols):
     return [f"{'_'.join(text_cols)}_{k}" for k in range(emb.shape[1])]
 
 
+def _normalize_sentence_transformer_model_name(model_name: str) -> str:
+    if model_name.startswith('/') or model_name.startswith('./'):
+        return os.path.split(model_name)[-1]
+    if '/' not in model_name:
+        return f"sentence-transformers/{model_name}"
+    return model_name
+
+
+@lru_cache(maxsize=8)
+def _get_sentence_transformer_model(model_name: str) -> Any:
+    _, _, SentenceTransformer = lazy_sentence_transformers_import()
+    return SentenceTransformer(model_name)
+
+
 def encode_textual(
     df: pd.DataFrame,
     min_words: float = 2.5,
@@ -729,8 +743,6 @@ def encode_textual(
     max_df: float = 0.2,
     min_df: int = 3,
 ) -> Tuple[pd.DataFrame, List, Any]:
-    _, _, SentenceTransformer = lazy_sentence_transformers_import()
-
     t = time()
     text_cols = get_textual_columns(
         df, min_words=min_words
@@ -751,19 +763,9 @@ def encode_textual(
             embeddings = make_array(model.fit_transform(res))
             transformed_columns = list(model[0].vocabulary_.keys())
         else:
-            # Handle different model name formats:
-            # 1. Local path: "/models/xyz" -> extract just model name (preserves old behavior)
-            # 2. Org prefix: "org/model" -> use as-is
-            # 3. Legacy: "model" -> prepend "sentence-transformers/"
-            if model_name.startswith('/') or model_name.startswith('./'):
-                # Local path - extract just the model name (preserves old behavior)
-                model_name = os.path.split(model_name)[-1]
-            elif '/' not in model_name:
-                # Legacy format without org prefix, add sentence-transformers/
-                model_name = f"sentence-transformers/{model_name}"
-            # else: already has org/model format, use as-is
-            
-            model = SentenceTransformer(model_name)
+            model = _get_sentence_transformer_model(
+                _normalize_sentence_transformer_model_name(model_name)
+            )
             batch_size = use_global_session().encode_textual_batch_size
             embeddings = model.encode(res.values, **({'batch_size': batch_size} if batch_size is not None else {}))
             transformed_columns = _get_sentence_transformer_headers(

--- a/graphistry/tests/test_feature_utils.py
+++ b/graphistry/tests/test_feature_utils.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import unittest
 
+import graphistry.feature_utils as feature_utils_module
 from graphistry.feature_utils import (
     process_dirty_dataframes,
     process_nodes_dataframes,
@@ -550,6 +551,86 @@ class TestModelNameHandling(unittest.TestCase):
             0.9999,
             f"Different formats should produce near-identical embeddings, got cosine={cosine}",
         )
+
+
+def test_encode_textual_reuses_normalized_sentence_transformer_model(monkeypatch):
+    class FakeSentenceTransformer:
+        def __init__(self, model_name):
+            calls.append(model_name)
+            self.model_name = model_name
+
+        def encode(self, values, **kwargs):
+            return np.ones((len(values), 2))
+
+    calls = []
+    test_df = pd.DataFrame({"text": ["hello world"], "number": [1]})
+    model_name = "paraphrase-albert-small-v2"
+
+    feature_utils_module._get_sentence_transformer_model.cache_clear()
+    monkeypatch.setattr(
+        feature_utils_module,
+        "lazy_sentence_transformers_import",
+        lambda: (True, "ok", FakeSentenceTransformer),
+    )
+    try:
+        _, _, legacy_model = encode_textual(
+            test_df,
+            min_words=0,
+            model_name=model_name,
+            use_ngrams=False,
+        )
+        _, _, full_model = encode_textual(
+            test_df,
+            min_words=0,
+            model_name=f"sentence-transformers/{model_name}",
+            use_ngrams=False,
+        )
+    finally:
+        feature_utils_module._get_sentence_transformer_model.cache_clear()
+
+    assert legacy_model is full_model
+    assert calls == [f"sentence-transformers/{model_name}"]
+
+
+def test_encode_textual_keeps_distinct_sentence_transformer_names(monkeypatch):
+    class FakeSentenceTransformer:
+        def __init__(self, model_name):
+            calls.append(model_name)
+            self.model_name = model_name
+
+        def encode(self, values, **kwargs):
+            return np.ones((len(values), 2))
+
+    calls = []
+    test_df = pd.DataFrame({"text": ["hello world"], "number": [1]})
+
+    feature_utils_module._get_sentence_transformer_model.cache_clear()
+    monkeypatch.setattr(
+        feature_utils_module,
+        "lazy_sentence_transformers_import",
+        lambda: (True, "ok", FakeSentenceTransformer),
+    )
+    try:
+        _, _, sentence_transformers_model = encode_textual(
+            test_df,
+            min_words=0,
+            model_name="sentence-transformers/paraphrase-albert-small-v2",
+            use_ngrams=False,
+        )
+        _, _, provider_model = encode_textual(
+            test_df,
+            min_words=0,
+            model_name="other-org/paraphrase-albert-small-v2",
+            use_ngrams=False,
+        )
+    finally:
+        feature_utils_module._get_sentence_transformer_model.cache_clear()
+
+    assert sentence_transformers_model is not provider_model
+    assert calls == [
+        "sentence-transformers/paraphrase-albert-small-v2",
+        "other-org/paraphrase-albert-small-v2",
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refs #1058.

This is the profile-driven `test-full-ai` speed lane from the #1593 handoff. It targets repeated `SentenceTransformer(...)` construction in `encode_textual()`:

- normalizes sentence-transformer model names in one helper
- reuses normalized model instances within each Python process with a bounded private cache
- keeps legacy `model` and full `sentence-transformers/model` aliases equivalent
- keeps distinct provider namespaces separate
- adds `--durations=50` to `test-full-ai` so CI logs keep exposing the top slow tests

No tests are skipped or weakened.

## Profiling / Baseline

Representative successful master CI run: https://github.com/graphistry/pygraphistry/actions/runs/26383588817

| Lane | Job wall-clock | `Full AI tests` step |
|---|---:|---:|
| `test-full-ai (3.13)` | 4m20s | 2m32s |
| `test-full-ai (3.10)` | 4m55s | 3m26s |
| `test-full-ai (3.9)` | 4m43s | 3m17s |
| `test-full-ai (3.11)` | 3m57s | 2m34s |
| `test-full-ai (3.12)` | 4m16s | 2m48s |

Top suspected model/test work from code-path audit:

- repeated direct `encode_textual()` calls in `graphistry/tests/test_feature_utils.py::TestModelNameHandling`
- repeated `g.featurize(..., model_name=model_avg_name, ...)` loops in node/edge featurization tests
- downstream `process_nodes_dataframes()` / `process_edge_dataframes()` calls that reach `encode_textual()`
- UMAP/cluster tests remain separate work and are intentionally not changed here

Local full-AI profiling note: this shell lacks the CI AI stack (`pytest-xdist`, `sentence-transformers`, `transformers`, `torch`). Pulling the CI lockfile locally began downloading the large CUDA Torch dependency graph, so I stopped it and used the successful master CI timing baseline plus PR CI for after timings.

## After Evidence

PR CI run: https://github.com/graphistry/pygraphistry/actions/runs/26385195781

| Lane | Before job | After job | Before `Full AI tests` | After `Full AI tests` |
|---|---:|---:|---:|---:|
| `test-full-ai (3.13)` | 4m20s | [4m20s](https://github.com/graphistry/pygraphistry/actions/runs/26385195781/job/77662647037) | 2m32s | 2m12s |
| `test-full-ai (3.10)` | 4m55s | [4m27s](https://github.com/graphistry/pygraphistry/actions/runs/26385195781/job/77662647031) | 3m26s | 2m56s |
| `test-full-ai (3.9)` | 4m43s | [4m08s](https://github.com/graphistry/pygraphistry/actions/runs/26385195781/job/77662647041) | 3m17s | 2m42s |
| `test-full-ai (3.11)` | 3m57s | [3m56s](https://github.com/graphistry/pygraphistry/actions/runs/26385195781/job/77662647039) | 2m34s | 2m34s |
| `test-full-ai (3.12)` | 4m16s | [3m53s](https://github.com/graphistry/pygraphistry/actions/runs/26385195781/job/77662647050) | 2m48s | 2m28s |

Top durations from `test-full-ai (3.12)` after adding `--durations=50`:

| Test | Duration |
|---|---:|
| `TestFeatureMethods::test_node_featurizations` | 74.63s |
| `TestComputeCluster::test_dbscan_params` | 18.94s |
| `TestTextSearch::test_search_fuzzy_with_target_columns` | 16.94s |
| `TestFeatureMethods::test_node_scaling` | 14.10s |
| `TestFeaturizeGetMethods::test_get_col_matrix` | 10.96s |
| `TestFeatureProcessors::test_process_node_dataframes_min_words` | 7.82s |
| `TestFeatureMethods::test_edge_scaling` | 5.18s |
| `TestFeatureMethods::test_edge_featurization` | 1.46s |

The same run finished the rich-featurize pytest step with `32 passed, 1 skipped, 17 warnings, 14 subtests passed in 146.68s`.

## CI RCA

Initial PR CI was red only in `tck-gfql`, and the latest master run showed the same failure: `firstparty-networkx-degree-centrality-1` failed because the generated `tck` lock profile installed `test` but not the existing `networkx` optional extra. The required fix is `bin/generate-lockfiles.sh` changing from `tck:test` to `tck:test,networkx`.

Validation evidence: a clean temporary clone generated `/tmp/tck-lock-clean/tck-py3.12.lock` with `COOLDOWN_DAYS=0 PROFILES=tck VERSIONS=3.12`, and the generated lock contains `networkx==3.6.1`.

Rebase note: latest `origin/master` already contains that tck lock-profile fix, so the final PR diff no longer carries `bin/generate-lockfiles.sh`; the rebase picks up the green-base fix.

## Validation

Local:

- `python3 -m pytest -q graphistry/tests/test_feature_utils.py::test_encode_textual_reuses_normalized_sentence_transformer_model graphistry/tests/test_feature_utils.py::test_encode_textual_keeps_distinct_sentence_transformer_names` -> `2 passed`
- `python3 -m pytest -q graphistry/tests/test_feature_utils.py --durations=50` -> `3 passed, 13 skipped`
- `./bin/ruff.sh graphistry/feature_utils.py graphistry/tests/test_feature_utils.py` -> pass
- `./bin/typecheck.sh graphistry/feature_utils.py` -> pass
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml", encoding="utf-8")); print("yaml ok")'` -> pass
- `git diff --check` -> pass
- `COOLDOWN_DAYS=0 PROFILES=tck VERSIONS=3.12 OUTPUT_DIR=/tmp/tck-lock-clean /tmp/pyg-lock-check/bin/generate-lockfiles.sh` from a clean temporary clone -> generated lock successfully
- `rg -n "^networkx==" /tmp/tck-lock-clean/tck-py3.12.lock` -> `networkx==3.6.1`

Local caveats:

- `./bin/typecheck.sh graphistry/feature_utils.py graphistry/tests/test_feature_utils.py` fails in this shell because local mypy cannot find pytest stubs. Production file typecheck passes.
- Running `./bin/ruff.sh .github/workflows/ci.yml` is invalid for this repo wrapper because it parses YAML as Python; YAML parse check passed instead.
- Running `./bin/ruff.sh bin/generate-lockfiles.sh` is invalid for the same reason: the wrapper parses shell as Python.

## Scope

- Compiler-plan surface touched: no.
- DGX/RAPIDS required: no. This is CPU AI feature encoding/test work, not GPU dataframe or GFQL runtime behavior.
- Coverage/branch protection weakened: no.
- Slim `test-minimal-python` boundary touched: no.
