### PR TITLE
feat(gfql): add internal schema effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
 ### Added
+- **GFQL schema effects (#1485)**: Added an internal typed schema-effect model for graph-growing GFQL calls so bound experimental `GraphSchema` snapshots are updated after successful degree, PageRank-style node-property writes, and edge-property write calls. Later local validation can see properties added by those calls without exposing a public `SchemaEffect` API or changing remote GFQL transport.
 - **GFQL NetworkX CALL parity (#1058)**: Expanded the local Cypher `graphistry.nx.*` CALL surface with explicit NetworkX dispatch for `degree_centrality`, `closeness_centrality`, `eigenvector_centrality`, `katz_centrality`, `connected_components`, `strongly_connected_components`, `core_number`, and multi-output `hits`, including row and `.write()` coverage.
 - **NetworkX/SciPy optional dependency policy (#1618)**: Declared supported `networkx>=2.5,<4` and optional `scipy>=1.5,<2` ranges for NetworkX-backed GFQL CALL procedures, with runtime version guards and a focused lower/current-upper CI matrix.
 - **GFQL schema Arrow boundary APIs (#1339)**: Added experimental public schema↔Arrow import/export helpers, graph-level Arrow declaration payloads, and opt-in `schema_validate='strict'|'autofix'` enforcement for `plot()`, `upload()`, `to_arrow()`, and `validate_arrow_schema()` when a `GraphSchema` is bound.

--- a/docs/source/gfql/schema.rst
+++ b/docs/source/gfql/schema.rst
@@ -131,6 +131,25 @@ validate user-authored or generated Cypher before running it. The same typed
 contract is also the foundation for later inference, coercion, remote transport,
 and planner/performance work, but this page covers the declared local contract.
 
+Schema Effects
+--------------
+
+Some graph-growing GFQL calls add properties to an existing graph. For example,
+``CALL graphistry.degree.write()`` adds degree columns to nodes, and
+PageRank-style ``.write()`` procedures add score columns. When a graph has a
+bound ``GraphSchema``, PyGraphistry now tracks those successful local effects
+internally and attaches the updated schema snapshot to the returned graph:
+
+.. code-block:: python
+
+   enriched = g.gfql("CALL graphistry.degree.write()")
+   enriched.gfql_validate("MATCH (n:Person) RETURN n.degree")
+
+This is not a new public API surface. The effect model is internal while schema
+inference, remote transport, and planner use continue to evolve. It is scoped to
+local graph results with an explicitly bound schema; remote GFQL requests still
+do not serialize schema snapshots or effect history.
+
 Arrow Boundary Validation
 -------------------------
 
@@ -214,6 +233,6 @@ Top-level imports are also available:
    from graphistry import NodeType, EdgeType, GraphSchema
 
 This lane exposes declaration, Arrow row-schema import/export, binder/preflight
-integration, and opt-in Arrow boundary validation/coercion. Inference from
-existing plottables, schema effects for graph-growing calls, and remote schema
-transport remain separate follow-on surfaces.
+integration, opt-in Arrow boundary validation/coercion, and internal local
+schema-effect propagation for graph-growing calls. Inference from existing
+plottables and remote schema transport remain separate follow-on surfaces.

--- a/graphistry/compute/gfql/call/executor.py
+++ b/graphistry/compute/gfql/call/executor.py
@@ -18,6 +18,7 @@ from graphistry.compute.exceptions import ErrorCode, GFQLTypeError
 from graphistry.compute.engine_coercion import ensure_engine_match
 from graphistry.compute.gfql.policy import PolicyContext, PolicyException
 from graphistry.compute.gfql.policy.stats import extract_graph_stats
+from graphistry.compute.gfql.schema_effects import apply_call_schema_effect
 
 if TYPE_CHECKING:
     from graphistry.compute.execution_context import ExecutionContext
@@ -147,6 +148,7 @@ def execute_call(g: Plottable, function: str, params: Dict[str, Any], engine: En
         # Schema-changing operations (UMAP, hypergraph) may alter DataFrame types
         if _is_plottable_like(result):
             result = ensure_engine_match(cast(Plottable, result), engine)
+            result = apply_call_schema_effect(g, cast(Plottable, result), function, validated_params)
 
         success = True
 

--- a/graphistry/compute/gfql/cypher/call_procedures.py
+++ b/graphistry/compute/gfql/cypher/call_procedures.py
@@ -28,6 +28,10 @@ from graphistry.compute.gfql.cypher.procedures.networkx import (
     networkx_node_rows as _networkx_node_rows,
     networkx_source_value_columns,
 )
+from graphistry.compute.gfql.schema_effects import (
+    apply_graph_schema_effect,
+    schema_effect_for_procedure_output,
+)
 from graphistry.compute.typing import DataFrameT
 from graphistry.plugins.cugraph import (
     compute_algs as _CUGRAPH_COMPUTE_ALGS,
@@ -747,7 +751,15 @@ def _write_only_igraph_row_error(compiled_call: CompiledCypherProcedureCall) -> 
 
 def execute_cypher_call(base_graph: Plottable, compiled_call: CompiledCypherProcedureCall) -> Plottable:
     if compiled_call.result_kind == "graph":
-        return _execute_backend_call(base_graph, compiled_call)
+        result_graph = _execute_backend_call(base_graph, compiled_call)
+        definition = _definition_from_compiled_call(compiled_call)
+        effect = schema_effect_for_procedure_output(
+            backend=compiled_call.backend,
+            algorithm=compiled_call.algorithm,
+            row_kind=compiled_call.row_kind,
+            value_columns=_normalized_value_columns(definition, compiled_call.call_params),
+        )
+        return apply_graph_schema_effect(base_graph, result_graph, effect)
 
     if compiled_call.backend == "degree":
         default_rows = _degree_rows(base_graph)

--- a/graphistry/compute/gfql/schema_effects.py
+++ b/graphistry/compute/gfql/schema_effects.py
@@ -1,0 +1,335 @@
+"""Internal schema-effect propagation for graph-growing GFQL calls.
+
+This module is deliberately private while typed-schema inference, Arrow
+boundaries, remote transport, and graph-value planning settle. It updates a
+bound public ``GraphSchema`` after graph-growing calls succeed, so later local
+validation sees properties written by earlier operations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Iterable, Mapping, Optional, Sequence, Tuple, cast
+
+from typing_extensions import Literal
+
+from graphistry.Plottable import Plottable
+from graphistry.compute.gfql.ir.types import LogicalType, ScalarType
+from graphistry.schema import EdgeType, GraphSchema, NodeType
+
+
+SchemaEffectConfidence = Literal["declared", "inferred", "observed", "user_refined"]
+SchemaEffectUpdateMap = Mapping[str, Mapping[str, LogicalType]]
+
+_CONFIDENCE_VALUES: FrozenSet[str] = frozenset(
+    ("declared", "inferred", "observed", "user_refined")
+)
+
+
+@dataclass(frozen=True)
+class SchemaEffect:
+    """Private graph-schema delta for graph-growing transforms.
+
+    The shape mirrors the typed-schema research model but remains internal.
+    Initial call integrations only use property additions; ``updates`` and
+    ``drops`` are included now so effect records have stable internal semantics
+    before public exposure is considered.
+    """
+
+    requires: Optional[GraphSchema] = None
+    adds_node_properties: Mapping[str, LogicalType] = field(default_factory=dict)
+    adds_edge_properties: Mapping[str, LogicalType] = field(default_factory=dict)
+    updates: SchemaEffectUpdateMap = field(default_factory=dict)
+    drops: Tuple[str, ...] = ()
+    confidence: SchemaEffectConfidence = "declared"
+
+    def __post_init__(self) -> None:
+        if self.confidence not in _CONFIDENCE_VALUES:
+            raise ValueError(
+                "SchemaEffect.confidence must be one of "
+                f"{tuple(sorted(_CONFIDENCE_VALUES))}; got {self.confidence!r}"
+            )
+
+
+_INT32 = ScalarType("int32")
+_INT64 = ScalarType("int64")
+_FLOAT64 = ScalarType("float64")
+_STRING = ScalarType("string")
+
+_NODE_FLOAT_ALGS: FrozenSet[str] = frozenset(
+    (
+        "authority_score",
+        "betweenness",
+        "betweenness_centrality",
+        "closeness",
+        "closeness_centrality",
+        "constraint",
+        "degree_centrality",
+        "eigenvector_centrality",
+        "harmonic_centrality",
+        "hub_score",
+        "hits",
+        "katz_centrality",
+        "pagerank",
+        "personalized_pagerank",
+    )
+)
+_NODE_INT_ALGS: FrozenSet[str] = frozenset(
+    (
+        "articulation_points",
+        "clusters",
+        "community_edge_betweenness",
+        "community_fastgreedy",
+        "community_infomap",
+        "community_label_propagation",
+        "community_leading_eigenvector",
+        "community_leiden",
+        "community_multilevel",
+        "community_optimal_modularity",
+        "community_spinglass",
+        "community_walktrap",
+        "connected_components",
+        "core_number",
+        "coreness",
+        "ecg",
+        "leiden",
+        "louvain",
+        "spectralBalancedCutClustering",
+        "spectralModularityMaximizationClustering",
+        "strongly_connected_components",
+    )
+)
+_NODE_STRING_ALGS: FrozenSet[str] = frozenset(("bfs", "bfs_edges", "shortest_path", "sssp"))
+_EDGE_FLOAT_ALGS: FrozenSet[str] = frozenset(
+    (
+        "edge_betweenness_centrality",
+        "jaccard",
+        "jaccard_w",
+        "overlap",
+        "overlap_coefficient",
+        "overlap_w",
+        "sorensen",
+        "sorensen_coefficient",
+        "sorensen_w",
+    )
+)
+_CUGRAPH_EDGE_DEFAULT_COLUMNS: Mapping[str, str] = {
+    "batched_ego_graphs": "unknown",
+    "edge_betweenness_centrality": "betweenness_centrality",
+    "jaccard": "jaccard_coeff",
+    "jaccard_w": "jaccard_coeff",
+    "overlap": "overlap_coeff",
+    "overlap_coefficient": "overlap_coefficient",
+    "overlap_w": "overlap_coeff",
+    "sorensen": "sorensen_coeff",
+    "sorensen_coefficient": "sorensen_coeff",
+    "sorensen_w": "sorensen_coeff",
+}
+
+
+def _typed_properties(columns: Iterable[str], logical_type: LogicalType) -> Dict[str, LogicalType]:
+    return {str(column): logical_type for column in columns if str(column)}
+
+
+def _property_type_for_algorithm(algorithm: Optional[str], *, table: Literal["nodes", "edges"]) -> LogicalType:
+    if algorithm is None:
+        return _STRING
+    if table == "edges":
+        return _FLOAT64 if algorithm in _EDGE_FLOAT_ALGS else _STRING
+    if algorithm in _NODE_FLOAT_ALGS:
+        return _FLOAT64
+    if algorithm in _NODE_INT_ALGS:
+        return _INT64
+    if algorithm in _NODE_STRING_ALGS:
+        return _STRING
+    return _STRING
+
+
+def schema_effect_for_call(function: str, params: Mapping[str, Any]) -> Optional[SchemaEffect]:
+    """Return an internal effect for a successful safelisted ``call(...)``."""
+    if function == "get_degrees":
+        return SchemaEffect(
+            adds_node_properties={
+                str(params.get("col", "degree")): _INT32,
+                str(params.get("degree_in", "degree_in")): _INT32,
+                str(params.get("degree_out", "degree_out")): _INT32,
+            },
+            confidence="declared",
+        )
+    if function == "get_indegrees":
+        return SchemaEffect(
+            adds_node_properties={str(params.get("col", "degree_in")): _INT32},
+            confidence="declared",
+        )
+    if function == "get_outdegrees":
+        return SchemaEffect(
+            adds_node_properties={str(params.get("col", "degree_out")): _INT32},
+            confidence="declared",
+        )
+    if function == "compute_cugraph":
+        algorithm = params.get("alg")
+        if not isinstance(algorithm, str):
+            return None
+        if algorithm in _CUGRAPH_EDGE_DEFAULT_COLUMNS:
+            out_col = cast(Optional[str], params.get("out_col")) or _CUGRAPH_EDGE_DEFAULT_COLUMNS[algorithm]
+            return SchemaEffect(
+                adds_edge_properties={
+                    str(out_col): _property_type_for_algorithm(algorithm, table="edges")
+                },
+                confidence="declared",
+            )
+        out_col = cast(Optional[str], params.get("out_col")) or algorithm
+        if out_col is None:
+            return None
+        properties = {str(out_col): _property_type_for_algorithm(algorithm, table="nodes")}
+        if algorithm == "hits":
+            properties["authorities"] = _FLOAT64
+        return SchemaEffect(adds_node_properties=properties, confidence="declared")
+    if function == "compute_igraph":
+        algorithm = params.get("alg")
+        if not isinstance(algorithm, str):
+            return None
+        out_col = cast(Optional[str], params.get("out_col")) or algorithm
+        return SchemaEffect(
+            adds_node_properties={
+                str(out_col): _property_type_for_algorithm(algorithm, table="nodes")
+            },
+            confidence="declared",
+        )
+    return None
+
+
+def schema_effect_for_procedure_output(
+    *,
+    backend: str,
+    algorithm: Optional[str],
+    row_kind: str,
+    value_columns: Sequence[str],
+) -> Optional[SchemaEffect]:
+    """Return an internal effect for a successful Cypher graph-write procedure."""
+    if backend == "degree":
+        return SchemaEffect(
+            adds_node_properties={
+                "degree": _INT32,
+                "degree_in": _INT32,
+                "degree_out": _INT32,
+            },
+            confidence="declared",
+        )
+    if not value_columns:
+        return None
+    if row_kind == "edge":
+        return SchemaEffect(
+            adds_edge_properties=_typed_properties(
+                value_columns,
+                _property_type_for_algorithm(algorithm, table="edges"),
+            ),
+            confidence="declared",
+        )
+    if row_kind in {"node", "node_or_graph"}:
+        return SchemaEffect(
+            adds_node_properties=_typed_properties(
+                value_columns,
+                _property_type_for_algorithm(algorithm, table="nodes"),
+            ),
+            confidence="declared",
+        )
+    return None
+
+
+def apply_schema_effect(schema: GraphSchema, effect: SchemaEffect) -> GraphSchema:
+    """Apply an internal effect to a public ``GraphSchema`` snapshot."""
+    node_types = tuple(
+        _apply_node_properties(node_type, effect.adds_node_properties)
+        for node_type in schema.node_types
+    )
+    edge_types = tuple(
+        _apply_edge_properties(edge_type, effect.adds_edge_properties)
+        for edge_type in schema.edge_types
+    )
+    return GraphSchema(
+        node_types=node_types,
+        edge_types=edge_types,
+        strict=schema.strict,
+        node_id_column=schema.node_id_column,
+        edge_source_column=schema.edge_source_column,
+        edge_destination_column=schema.edge_destination_column,
+    )
+
+
+def apply_call_schema_effect(
+    input_graph: Plottable,
+    result_graph: Plottable,
+    function: str,
+    params: Mapping[str, Any],
+) -> Plottable:
+    return apply_graph_schema_effect(
+        input_graph,
+        result_graph,
+        schema_effect_for_call(function, params),
+    )
+
+
+def apply_graph_schema_effect(
+    input_graph: Plottable,
+    result_graph: Plottable,
+    effect: Optional[SchemaEffect],
+) -> Plottable:
+    if effect is None:
+        return result_graph
+    bound_schema = getattr(input_graph, "_gfql_schema", None)
+    if not isinstance(bound_schema, GraphSchema):
+        return result_graph
+
+    filtered_effect = _filter_effect_to_result_columns(result_graph, effect)
+    if not filtered_effect.adds_node_properties and not filtered_effect.adds_edge_properties:
+        return result_graph
+
+    return result_graph.bind(schema=apply_schema_effect(bound_schema, filtered_effect))
+
+
+def _apply_node_properties(
+    node_type: NodeType,
+    additions: Mapping[str, LogicalType],
+) -> NodeType:
+    if not additions:
+        return node_type
+    properties = dict(node_type.properties)
+    for name, logical_type in additions.items():
+        properties.setdefault(str(name), logical_type)
+    return NodeType(node_type.name, properties=properties, labels=node_type.labels)
+
+
+def _apply_edge_properties(
+    edge_type: EdgeType,
+    additions: Mapping[str, LogicalType],
+) -> EdgeType:
+    if not additions:
+        return edge_type
+    properties = dict(edge_type.properties)
+    for name, logical_type in additions.items():
+        properties.setdefault(str(name), logical_type)
+    return EdgeType(edge_type.name, edge_type.source, edge_type.destination, properties=properties)
+
+
+def _filter_effect_to_result_columns(result_graph: Plottable, effect: SchemaEffect) -> SchemaEffect:
+    nodes_df = getattr(result_graph, "_nodes", None)
+    edges_df = getattr(result_graph, "_edges", None)
+    node_columns = set(nodes_df.columns) if nodes_df is not None else set()
+    edge_columns = set(edges_df.columns) if edges_df is not None else set()
+    return SchemaEffect(
+        requires=effect.requires,
+        adds_node_properties={
+            name: logical_type
+            for name, logical_type in effect.adds_node_properties.items()
+            if name in node_columns
+        },
+        adds_edge_properties={
+            name: logical_type
+            for name, logical_type in effect.adds_edge_properties.items()
+            if name in edge_columns
+        },
+        updates=effect.updates,
+        drops=effect.drops,
+        confidence=effect.confidence,
+    )

--- a/graphistry/tests/compute/gfql/test_schema_effects.py
+++ b/graphistry/tests/compute/gfql/test_schema_effects.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pandas as pd
+import pytest  # type: ignore[import-not-found]
+
+import graphistry
+from graphistry.Engine import Engine
+from graphistry.compute.exceptions import GFQLValidationError
+from graphistry.compute.gfql.call.executor import execute_call
+from graphistry.compute.gfql.ir.types import ScalarType
+from graphistry.compute.gfql.schema_effects import SchemaEffect
+from graphistry.schema import EdgeType, GraphSchema, NodeType
+
+
+def _bound_graph() -> Any:
+    nodes = pd.DataFrame(
+        [
+            {"id": "a", "label__Node": True},
+            {"id": "b", "label__Node": True},
+            {"id": "c", "label__Node": True},
+        ]
+    )
+    edges = pd.DataFrame(
+        [
+            {"src": "a", "dst": "b", "label__REL": True},
+            {"src": "b", "dst": "c", "label__REL": True},
+        ]
+    )
+    schema = GraphSchema(
+        node_types=[NodeType("Node", {"id": str})],
+        edge_types=[EdgeType("REL", "Node", "Node", {})],
+        node_id_column="id",
+        edge_source_column="src",
+        edge_destination_column="dst",
+    )
+    return graphistry.bind(source="src", destination="dst", node="id", schema=schema).edges(edges).nodes(nodes)
+
+
+def _assert_node_property_validates(g: Any, prop: str) -> None:
+    report = g.gfql_validate(f"MATCH (n:Node) RETURN n.{prop} AS value")
+    assert report["ok"] is True
+
+
+def _assert_edge_property_validates(g: Any, prop: str) -> None:
+    report = g.gfql_validate(f"MATCH (:Node)-[e:REL]->(:Node) RETURN e.{prop} AS value")
+    assert report["ok"] is True
+
+
+def test_schema_effect_model_is_internal_and_confidence_checked() -> None:
+    assert not hasattr(graphistry, "SchemaEffect")
+
+    effect = SchemaEffect(confidence="declared")
+    assert effect.confidence == "declared"
+
+    with pytest.raises(ValueError, match="SchemaEffect.confidence"):
+        SchemaEffect(confidence="guessed")  # type: ignore[arg-type]
+
+
+def test_execute_call_degree_updates_bound_schema_for_chain_continuation() -> None:
+    g = _bound_graph()
+    with pytest.raises(GFQLValidationError):
+        _assert_node_property_validates(g, "degree")
+
+    out = cast(Any, execute_call(g, "get_degrees", {}, Engine.PANDAS))
+
+    _assert_node_property_validates(out, "degree")
+    _assert_node_property_validates(out, "degree_in")
+    assert out._gfql_schema.node_types[0].properties["degree"] == ScalarType("int32")
+    assert "degree" not in g._gfql_schema.node_types[0].properties
+
+
+def test_execute_call_cugraph_edge_write_updates_bound_schema_for_chain_continuation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    g = _bound_graph()
+
+    def fake_compute_cugraph(self: Any, alg: str, out_col: str | None = None, **kwargs: object) -> Any:
+        assert alg == "edge_betweenness_centrality"
+        assert self._edges is not None
+        return self.edges(
+            self._edges.assign(**{out_col or "betweenness_centrality": [1.0, 2.0]}),
+            self._source,
+            self._destination,
+        )
+
+    monkeypatch.setattr(type(g), "compute_cugraph", fake_compute_cugraph)
+
+    out = cast(
+        Any,
+        execute_call(
+            g,
+            "compute_cugraph",
+            {"alg": "edge_betweenness_centrality", "out_col": "ebc"},
+            Engine.PANDAS,
+        ),
+    )
+
+    _assert_edge_property_validates(out, "ebc")
+    assert out._gfql_schema.edge_types[0].properties["ebc"] == ScalarType("float64")
+
+
+def test_execute_call_cugraph_hits_updates_all_bound_schema_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    g = _bound_graph()
+
+    def fake_compute_cugraph(self: Any, alg: str, out_col: str | None = None, **kwargs: object) -> Any:
+        assert alg == "hits"
+        assert self._nodes is not None
+        return self.nodes(
+            self._nodes.assign(**{out_col or alg: [0.1, 0.2, 0.3], "authorities": [0.4, 0.5, 0.6]}),
+            self._node,
+        )
+
+    monkeypatch.setattr(type(g), "compute_cugraph", fake_compute_cugraph)
+
+    out = cast(Any, execute_call(g, "compute_cugraph", {"alg": "hits"}, Engine.PANDAS))
+
+    _assert_node_property_validates(out, "hits")
+    _assert_node_property_validates(out, "authorities")
+    assert out._gfql_schema.node_types[0].properties["hits"] == ScalarType("float64")
+    assert out._gfql_schema.node_types[0].properties["authorities"] == ScalarType("float64")
+
+
+def test_cypher_degree_write_updates_bound_schema_for_next_validation() -> None:
+    enriched = _bound_graph().gfql("CALL graphistry.degree.write()")
+
+    _assert_node_property_validates(enriched, "degree")
+    assert enriched._gfql_schema.node_types[0].properties["degree_in"] == ScalarType("int32")
+
+
+def test_cypher_igraph_pagerank_write_updates_bound_schema_for_next_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    g = _bound_graph()
+
+    def fake_compute_igraph(self: Any, alg: str, out_col: str | None = None, **kwargs: object) -> Any:
+        assert alg == "pagerank"
+        assert self._nodes is not None
+        return self.nodes(
+            self._nodes.assign(**{out_col or alg: [0.2, 0.3, 0.5]}),
+            self._node,
+        )
+
+    monkeypatch.setattr(type(g), "compute_igraph", fake_compute_igraph)
+
+    enriched = g.gfql("CALL graphistry.igraph.pagerank.write()")
+
+    _assert_node_property_validates(enriched, "pagerank")
+    assert enriched._gfql_schema.node_types[0].properties["pagerank"] == ScalarType("float64")
+
+
+def test_cypher_cugraph_edge_write_updates_bound_schema_for_next_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    g = _bound_graph()
+
+    def fake_compute_cugraph(self: Any, alg: str, out_col: str | None = None, **kwargs: object) -> Any:
+        assert alg == "edge_betweenness_centrality"
+        assert self._edges is not None
+        return self.edges(
+            self._edges.assign(**{out_col or alg: [1.0, 2.0]}),
+            self._source,
+            self._destination,
+        )
+
+    monkeypatch.setattr(type(g), "compute_cugraph", fake_compute_cugraph)
+
+    enriched = g.gfql("CALL graphistry.cugraph.edge_betweenness_centrality.write({out_col: 'ebc'})")
+
+    _assert_edge_property_validates(enriched, "ebc")
+    assert enriched._gfql_schema.edge_types[0].properties["ebc"] == ScalarType("float64")


### PR DESCRIPTION
Refs #1485
Refs #1058
Refs #1465

## Summary

Implements the first internal schema-effects slice for graph-growing GFQL calls:

- adds private `graphistry.compute.gfql.schema_effects.SchemaEffect`
- applies typed node/edge property effects after successful local graph-growing calls
- updates returned graphs' bound experimental `GraphSchema` snapshots, so later local validation can see properties written by earlier operations
- covers `get_degrees` / `degree.write`, PageRank-style node writes, and edge-property writes
- keeps `SchemaEffect` internal: no top-level `graphistry` or `graphistry.schema` re-export

This does not add remote schema transport and does not change algorithm/runtime semantics.

## Behavior

| Flow | Before | After |
|---|---|---|
| `g.bind(schema=s).gfql("CALL graphistry.degree.write()")` then validate `n.degree` | bound schema still lacked `degree`; strict local validation rejected the follow-on property | returned graph has updated bound schema with `degree`, `degree_in`, `degree_out` as `int32` |
| `CALL graphistry.igraph.pagerank.write()` | returned nodes had `pagerank`, but bound schema did not | returned graph schema admits `pagerank: float64` |
| edge write such as `cugraph.edge_betweenness_centrality.write({out_col: "ebc"})` | returned edges had `ebc`, but bound schema did not | returned graph schema admits `ebc: float64` |
| direct `call("compute_cugraph", {"alg": "hits"})` | returned nodes had `hits` and `authorities`, but bound schema did not | returned graph schema admits both score columns as `float64` |

## Scope / Guardrails

- Compiler-plan surface touched: no
- IR metadata seam touched: no
- Public API exposure: no new public `SchemaEffect` export
- Remote GFQL transport: unchanged
- #1338 inference: not included
- #1339 Arrow boundary semantics: preserved

## LOC Buckets

- Production: +352 / -3, net +349 LOC
- Tests: +174 / -0, net +174 LOC
- Docs/changelog: +23 / -3, net +20 LOC

## Validation

- `python3 -m pytest -q graphistry/tests/compute/gfql/test_schema_effects.py` — pass
- `python3 -m pytest -q graphistry/tests/compute/gfql/test_schema_effects.py graphistry/tests/compute/gfql/test_public_schema.py` — pass
- `python3 -m pytest -q graphistry/tests/compute/gfql/cypher/test_lowering.py -k 'graph_preserving or graph_write_call or pagerank_write or edge_write_call or graphistry_call'` — pass
- `python3 -m pytest -q docs/test_doc_examples.py -k schema` — pass
- `./bin/ruff.sh graphistry/compute/gfql/schema_effects.py graphistry/compute/gfql/call/executor.py graphistry/compute/gfql/cypher/call_procedures.py graphistry/tests/compute/gfql/test_schema_effects.py` — pass
- `./bin/typecheck.sh graphistry/compute/gfql/schema_effects.py graphistry/compute/gfql/call/executor.py graphistry/compute/gfql/cypher/call_procedures.py graphistry/tests/compute/gfql/test_schema_effects.py` — pass
- `git diff --check` — pass
- Review-skill convergence: wave 1 found and fixed direct `compute_cugraph` edge/multi-column effect coverage; waves 2 and 3 had no findings / no significant advance
- DGX RAPIDS 26.02, `PROFILE=gfql WITH_GPU=1 WITH_IMAGE_BUILD=0 TEST_FILES="graphistry/tests/compute/gfql/test_schema_effects.py graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_executes_real_cugraph_edge_write_call_on_cudf graphistry/tests/compute/gfql/cypher/test_lowering.py::test_string_cypher_executes_real_cugraph_node_multi_column_write_call_on_cudf" docker/test-rapids-official-local.sh` — 9 passed
- DGX RAPIDS 25.02, same command/targets — 9 passed

CI: pending latest GitHub checks.
