### PR TITLE
perf(gfql): dtype-gate temporal-text detection to avoid spurious stringification (#1650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Performance
+- **GFQL temporal-detection dtype gate (#1650)**: `order_detect_temporal_mode` now short-circuits for numeric/bool/complex columns, which can never hold temporal *text*, instead of running an `astype(str)` + multi-regex `fullmatch` scan on every comparison. Eliminates spurious row-wise stringification in `where_rows`/comparison paths whose output never contains entity-text. Byte-identical results; measured `where_rows` speedups ~3.1× (pandas) and ~4.4–13.3× (cuDF, scaling with row count). Does not address whole-entity `RETURN a` text rendering, which is tracked separately.
+
 ## [0.56.1 - 2026-05-27]
 
 ### Added

--- a/graphistry/compute/gfql/row/ordering.py
+++ b/graphistry/compute/gfql/row/ordering.py
@@ -214,6 +214,13 @@ def parse_stringified_list_series(series: Any) -> Optional[SeriesT]:
 def order_detect_temporal_mode(series: Any) -> Optional[str]:
     if not hasattr(series, "dropna"):
         return None
+    # Temporal values are encoded as *text* (Cypher date/datetime/time literals or
+    # constructor calls). Numeric/bool/complex columns can never match those regexes,
+    # so skip the astype(str) + multi-regex fullmatch scan for them. This avoids
+    # spuriously stringifying numeric columns on every comparison (issue #1650).
+    dtype_kind = getattr(getattr(series, "dtype", None), "kind", None)
+    if dtype_kind in ("i", "u", "f", "b", "c"):
+        return None
     non_null = series.dropna()
     if len(non_null) == 0 or not hasattr(non_null, "astype"):
         return None

--- a/graphistry/tests/compute/gfql/row/test_ordering.py
+++ b/graphistry/tests/compute/gfql/row/test_ordering.py
@@ -5,6 +5,7 @@ import pytest
 
 from graphistry.compute.ast import limit, order_by, rows, select
 from graphistry.compute.exceptions import GFQLTypeError
+from graphistry.compute.gfql.row.ordering import order_detect_temporal_mode
 from graphistry.tests.test_compute import CGFull
 
 
@@ -193,3 +194,36 @@ def test_row_pipeline_order_by_multi_key_stringified_list_with_scalar() -> None:
     assert result["num"].tolist() == [20, 10, 15, 5]
     leaked = [c for c in result.columns if "__gfql_sort_listparsed" in str(c)]
     assert leaked == [], f"aux columns leaked: {leaked}"
+
+
+@pytest.mark.parametrize(
+    "series",
+    [
+        pd.Series([1, 2, 3], dtype="int64"),
+        pd.Series([1, 2, 3], dtype="uint32"),
+        pd.Series([1.5, 2.5], dtype="float64"),
+        pd.Series([True, False], dtype="bool"),
+    ],
+    ids=["int64", "uint32", "float64", "bool"],
+)
+def test_order_detect_temporal_mode_skips_non_text_dtypes(series: pd.Series) -> None:
+    # Numeric/bool columns can never hold temporal *text*; the detector must
+    # short-circuit without the astype(str) + multi-regex scan (issue #1650).
+    assert order_detect_temporal_mode(series) is None
+
+
+def test_order_detect_temporal_mode_still_detects_text_temporals() -> None:
+    # Gate must not regress detection on object/string columns.
+    assert order_detect_temporal_mode(pd.Series(["2020-01-01", "2020-02-02"], dtype="object")) == "date"
+    assert order_detect_temporal_mode(pd.Series(["abc", "def"], dtype="object")) is None
+
+
+def test_where_rows_numeric_filter_returns_correct_rows() -> None:
+    # End-to-end: a numeric where_rows comparison still filters correctly with the
+    # temporal-detection gate in place.
+    nodes_df = pd.DataFrame({"id": [0, 1, 2, 3], "val": [10, 60, 51, 99]})
+    edges_df = pd.DataFrame({"s": [0, 1], "d": [2, 3]})
+    from graphistry.compute.ast import where_rows
+
+    out = _mk_graph(nodes_df, edges_df).gfql([rows(), where_rows(expr="val > 50")])._nodes
+    assert sorted(out["val"].tolist()) == [51, 60, 99]


### PR DESCRIPTION
## Summary

Fixes the **spurious-stringification half of #1650**. GFQL ran row-wise entity/temporal stringification in comparison paths whose output never contains entity-text (e.g. `where_rows`). Root cause: `order_detect_temporal_mode` (`ordering.py`) runs `astype(str)` + up to **6 regex `fullmatch` passes** on **both operands of every comparison** — including `int64`/`bool` columns that can never hold temporal *text*. A 10k-row `where_rows(val > 50)`, which returns a plain 3-column table, fired **~160,006 spurious `re.fullmatch`** calls, all discarded.

> Note: the where_rows cost is `order_detect_temporal_mode`, **not** `entity_text.py`/`entity_props.py` as the issue body speculated (cProfile-confirmed), and the issue's ~10× over-render does **not** reproduce — entity-text already renders on the deduped node table. This PR targets the confirmed spurious path; whole-entity `RETURN a` structured/Arrow returns are tracked separately.

## Fix

`order_detect_temporal_mode` early-returns `None` when `series.dtype.kind in {i, u, f, b, c}` (numeric/bool/complex). Object/string/datetime columns are unaffected, so temporal-text detection is preserved.

## Results (byte-identical output, gated == ungated)

| `where_rows(val>50)` | before | after | speedup |
|---|--:|--:|--:|
| pandas @10k | 48.9 ms | 15.6 ms | **3.1×** |
| cuDF @10k | 37.4 ms | 8.5 ms | **4.4×** |
| cuDF @100k (1M edges) | 191.0 ms | 14.4 ms | **13.3×** |

Speedup scales with row count (spurious scan is O(rows)). cuDF measured on a GB10 box with `graphistry/test-gpu:latest` (cudf 25.12).

## Tests

- pandas: temporal + ordering + row suites — **91 pass**
- cuDF (`TEST_CUDF=1` container): temporal + ordering + row suites — **83 pass**
- Added: `order_detect_temporal_mode` unit coverage (numeric/bool skip; object temporal still detected) + end-to-end numeric `where_rows` filter assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)