### PR TITLE
fix(gfql): ne()/<> and IN on NULL follow openCypher/SQL 3-valued logic (L0 generic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Fixed
+
+- **GFQL `ne()`/`<>` and `IN`/membership on NULL follow openCypher/SQL 3-valued logic (pandas + cuDF)**: a `ne()` / `<>` filter or a list-membership (`IN`) filter over a NULL cell now EXCLUDES the row — per 3VL, `null <> x` and `null IN [...]` evaluate to `null` (not a match) — consistent with `eq`/`gt`/`lt` (which already dropped nulls) and with the cuDF/polars engines. Previously the pandas `NE` predicate kept null rows (`NaN != x` → True) and cuDF matched a null cell against a `None`/`NaN` list element. Behavior change for `ne()` / `NOT IN` on nullable columns under the default pandas engine. (Broader openCypher null-semantics tracked in #1664.)
+
 ## [0.57.0 - 2026-06-28]
 
 ### Changed

--- a/graphistry/compute/filter_by_dict.py
+++ b/graphistry/compute/filter_by_dict.py
@@ -192,7 +192,11 @@ def filter_by_dict(df: DataFrameT, filter_dict: Optional[dict] = None, engine: U
             if original_col.startswith("label__") and resolved_col == "labels" and isinstance(resolved_val, str):
                 hits = hits & _label_series_contains(df[resolved_col], resolved_val)
             elif _is_membership_filter_value(resolved_val):
-                hits = hits & df[resolved_col].isin(list(resolved_val))
+                # openCypher/SQL 3VL: `null IN [...]` is null -> a NULL cell is NOT a member (and a
+                # NULL in the list cannot make a null cell match). `& notna()` excludes null cells —
+                # a no-op for pandas (its isin already excludes a NaN cell here) but fixes cuDF, which
+                # otherwise matches a null cell against a None/NaN list element.
+                hits = hits & df[resolved_col].isin(list(resolved_val)) & df[resolved_col].notna()
             else:
                 hits = hits & (df[resolved_col] == resolved_val)
     if predicates:

--- a/graphistry/compute/predicates/comparison.py
+++ b/graphistry/compute/predicates/comparison.py
@@ -283,9 +283,21 @@ class NE(_ScalarTemporalComparison):
     op = staticmethod(operator.ne)
     safe_scalar_compare = False
 
+    def __call__(self, s: SeriesT) -> SeriesT:
+        # openCypher/SQL three-valued logic: `null <> x` is NULL, so a NULL cell is NOT a match
+        # (an unknown value cannot be proven unequal to x). pandas `NaN != x` returns True, which
+        # would wrongly KEEP the null; AND with notna() so a null is excluded — matching cuDF and
+        # the polars engine. The other comparisons (eq/gt/lt/ge/le) already drop nulls (their
+        # operator returns False on a null cell).
+        mask = super().__call__(s)
+        return mask & s.notna()
+
 def ne(val: ComparisonInput) -> NE:
     """
-    Return whether a given value is not equal to a threshold
+    Return whether a given value is not equal to a threshold.
+
+    Follows openCypher/SQL three-valued logic: a NULL/NA cell is NOT a match (``null <> x`` is
+    unknown), so null rows are excluded — the same as ``eq`` and the other comparisons.
     """
     return NE(val)
 

--- a/graphistry/compute/predicates/numeric.py
+++ b/graphistry/compute/predicates/numeric.py
@@ -77,9 +77,19 @@ def eq(val: float) -> EQ:
 class NE(NumericASTPredicate):
     op = staticmethod(operator.ne)
 
+    def __call__(self, s: SeriesT) -> SeriesT:
+        # openCypher/SQL three-valued logic: `null <> x` is NULL, so a NULL/NaN cell is NOT a match
+        # (an unknown value cannot be proven unequal to x). pandas `NaN != x` returns True, which
+        # would wrongly KEEP the null; AND with notna() so it is excluded — matching cuDF + the
+        # polars engine. eq/gt/lt/ge/le already drop nulls (their operator returns False on a null).
+        return cast(SeriesT, super().__call__(s) & s.notna())
+
 def ne(val: float) -> NE:
     """
-    Return whether a given value is not equal to a threshold
+    Return whether a given value is not equal to a threshold.
+
+    Follows openCypher/SQL three-valued logic: a NULL/NA cell is NOT a match (``null <> x`` is
+    unknown), so null rows are excluded — the same as ``eq`` and the other comparisons.
     """
     return NE(val)
 

--- a/graphistry/tests/test_compute_filter_by_dict.py
+++ b/graphistry/tests/test_compute_filter_by_dict.py
@@ -151,3 +151,25 @@ class TestPredicateIsIn(object):
         assert g.filter_nodes_by_dict({'node': is_in(['a', 'b']), 'type': 'bad'})._nodes.equals(g._nodes[:0])
         assert g.filter_nodes_by_dict({'node': is_in(['a', 'bad']), 'type': 'n'})._nodes.equals(g._nodes[:1])
         assert g.filter_nodes_by_dict({'node': is_in(['a', 'bad']), 'type': 'bad'})._nodes.equals(g._nodes[:0])
+
+
+class TestThreeValuedLogicNull(object):
+    """openCypher/SQL 3-valued logic: a NULL cell is NEVER a match for ne()/<> or membership
+    (`null <> x` and `null IN [...]` are both NULL -> excluded). pandas `NaN != x` is True and
+    cuDF `isin` matches a null against a None list element, so both used to KEEP the null; these
+    assert the fix in filter_by_dict / the NE predicate. Generic (pandas oracle here; the polars
+    engine + 4-engine parity are asserted in the gfql polars suite)."""
+
+    def test_ne_excludes_null(self):
+        # numeric column so the comparison-on-string guard (a separate fix higher in the stack) is
+        # not in play — this isolates the NE 3VL null-masking. score=None -> NaN; `NaN != 20` is
+        # True on pandas (would KEEP), so the row must be excluded by the `& notna()` fix.
+        from graphistry.compute.ast import ne
+        df = pd.DataFrame({"id": ["n0", "n1", "n2", "n3"], "score": [10.0, 20.0, None, 40.0]})
+        out = filter_by_dict(df, {"score": ne(20)})
+        assert sorted(out["id"].tolist()) == ["n0", "n3"]   # n1 fails ne(20); n2 (null) excluded by 3VL
+
+    def test_membership_excludes_null(self):
+        df = pd.DataFrame({"id": ["n0", "n1", "n2", "n3"], "kind": ["x", "y", None, "z"]})
+        out = filter_by_dict(df, {"kind": ["x", "z", None]})
+        assert sorted(out["id"].tolist()) == ["n0", "n3"]   # x,z match; null excluded despite None in list


### PR DESCRIPTION
L0 of the GFQL engine stack: the generic 3-valued-logic null fix (benefits pandas + cuDF; polars already conformant). `ne()`/`<>` and membership/`IN` over a NULL cell now exclude the row per openCypher/SQL 3VL, fixed in the `NE` predicate + `filter_by_dict`. Peeled below the polars engine so all engines inherit it. Part of #1664 (openCypher conformance).

**Note for the merger:** the user-facing CHANGELOG entries for this fix ride the stacked followups PR #1667 (they were written there before this fix was peeled down to L0). Merging this PR alone ships the behavior change without its CHANGELOG line — fine if #1667 follows shortly; otherwise cherry-pick the two 3VL entries from #1667's CHANGELOG.
