### PR TITLE
ci(dgx): proven GB10 unified-memory safety harness (RMM cap + watchdog + preflight)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **GFQL `ne()`/`<>` and `IN`/membership on NULL follow openCypher/SQL 3-valued logic (pandas + cuDF)**: a `ne()` / `<>` filter or a list-membership (`IN`) filter over a NULL cell now EXCLUDES the row — per 3VL, `null <> x` and `null IN [...]` evaluate to `null` (not a match) — consistent with `eq`/`gt`/`lt` (which already dropped nulls) and with the cuDF/polars engines. Previously the pandas `NE` predicate kept null rows (`NaN != x` → True) and cuDF matched a null cell against a `None`/`NaN` list element. Behavior change for `ne()` / `NOT IN` on nullable columns under the default pandas engine. (Broader openCypher null-semantics tracked in #1664.)
 
+### Infrastructure
+
+- **dgx GB10 benchmark safety harness**: `benchmarks/dgx/{safe_run.sh, preflight.py, sitecustomize.py, local_run.sh}` — an RMM device-allocation cap + host-memory watchdog + preflight refusal + hard timeout for running GPU / large-graph benchmarks on the unified-memory GB10 box without OOM-wedging it. Developer/benchmark tooling only; no runtime or library behavior change.
+
 ## [0.57.0 - 2026-06-28]
 
 ### Changed

--- a/benchmarks/dgx/README.md
+++ b/benchmarks/dgx/README.md
@@ -1,0 +1,22 @@
+# dgx GB10 safety harness
+
+Run **every** GPU / large-graph benchmark on the shared unified-memory dgx box through
+`safe_run.sh`. Background: on the GB10, **GPU memory *is* system RAM** (unified, 119 GB,
+16 GB swap). A 1.8B-edge cudf/cugraph load once OOM-thrashed the box for ~9.5 h.
+
+Proven (2026-07-01): `docker --memory` is **transparent** to cudf/unified allocs (does not
+contain them). The working caps are **RMM allocation limit** (cudf + cugraph decline cleanly)
++ a **host watchdog** (for the pandas/host path) + a **preflight estimate** refusal.
+
+- `sitecustomize.py` — auto-applies `GFQL_RMM_LIMIT_GB` to any Python in the container (no
+  workload edits). Put its dir on `PYTHONPATH` (safe_run.sh does this).
+- `preflight.py` — `peak_gb(edges)`/`is_safe(edges)`; refuses runs over budget.
+- `safe_run.sh` — wraps `docker run`: preflight refuse + RMM inject + host watchdog force-kill
+  + hard timeout. Example:
+
+```bash
+benchmarks/dgx/safe_run.sh --name idx --est-edges 80000000 --rmm-gb 80 --floor-gb 20 \
+  --timeout 3600 --pythonpath /opt/pygraphistry -- \
+  -v $PWD:/opt/pygraphistry -v ~/data:/data:ro --entrypoint python \
+  graphistry/test-rapids-official:26.02-cuda12-gfql /opt/pygraphistry/benchmarks/gfql/index_takeover_bench.py
+```

--- a/benchmarks/dgx/local_run.sh
+++ b/benchmarks/dgx/local_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# LOCAL desktop run guard. The local box is a ~31GB WORKSTATION (not dgx's 119GB) —
+# a runaway alloc OOM-kills the desktop SESSION (logout). Caps address space so a
+# runaway process dies with a clean MemoryError instead of taking the session down.
+# TESTED 2026-07-01: ulimit -v 2GB + 3GB alloc -> MemoryError, desktop survived.
+# Use for ANY local python; keep local data TINY (<~1M rows). Benchmarks -> dgx safe_run.sh.
+# Usage: benchmarks/dgx/local_run.sh python3 script.py   (LOCAL_CAP_GB=8 default)
+CAP_GB=${LOCAL_CAP_GB:-8}
+( ulimit -v $((CAP_GB*1024*1024)) 2>/dev/null; exec "$@" )

--- a/benchmarks/dgx/preflight.py
+++ b/benchmarks/dgx/preflight.py
@@ -1,0 +1,27 @@
+"""Memory preflight estimator for dgx GB10 (unified memory, ~119 GB, shared).
+
+peak_gb(edges) estimates the worst-case resident memory for a cudf+cugraph run:
+the edge frame (edges * 16 B: two int64 columns) plus ~2x for the cugraph CSR +
+pagerank vectors. safe_run refuses to launch if peak exceeds the budget, so we
+never repeat the 1.8B-edge crash (28.9 GB frame -> ~87 GB peak -> host OOM).
+"""
+HOST_GB = 119
+DEFAULT_FLOOR_GB = 39  # leave this much for the OS + non-RMM (pandas/pinned) allocs
+
+
+def peak_gb(edges: int, cugraph_factor: float = 3.0) -> float:
+    """Worst-case GB: edge frame (edges*16B) scaled for the cugraph CSR build."""
+    return edges * 16 * cugraph_factor / 1e9
+
+
+def is_safe(edges: int, host_gb: int = HOST_GB, floor_gb: int = DEFAULT_FLOOR_GB) -> bool:
+    return peak_gb(edges) <= (host_gb - floor_gb)
+
+
+if __name__ == "__main__":
+    import sys
+    e = int(sys.argv[1])
+    p = peak_gb(e)
+    ok = is_safe(e)
+    print(f"edges={e:,} peak~{p:.1f}GB budget={HOST_GB-DEFAULT_FLOOR_GB}GB -> {'SAFE' if ok else 'REFUSE'}")
+    sys.exit(0 if ok else 3)

--- a/benchmarks/dgx/safe_run.sh
+++ b/benchmarks/dgx/safe_run.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Enforced safety wrapper for dgx GB10 GPU/big runs. PROVEN (2026-07-01):
+#  - docker --memory is TRANSPARENT to cudf/unified allocs (A2) -> useless.
+#  - RMM LimitingResourceAdaptor caps cudf AND cugraph cleanly (A3/A3b) -> the real cap,
+#    injected non-invasively via sitecustomize + GFQL_RMM_LIMIT_GB.
+#  - preflight refuses obviously-oversized runs; host watchdog force-kills on low RAM;
+#    hard timeout + docker kill -s KILL so a hung container can't wedge the box.
+# Usage:
+#   safe_run.sh --name N --est-edges E [--rmm-gb 80] [--floor-gb 20] [--timeout 3600] \
+#     [--pythonpath /opt/pygraphistry] -- <extra docker args e.g. -v ...> IMAGE <cmd...>
+set -uo pipefail
+NAME="dgxsafe_$$"; EST_EDGES=0; RMM_GB=80; FLOOR_GB=20; TIMEOUT=3600; PYPATH="/opt/pygraphistry"
+GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [[ $# -gt 0 ]]; do case "$1" in
+  --name) NAME="$2"; shift 2;; --est-edges) EST_EDGES="$2"; shift 2;;
+  --rmm-gb) RMM_GB="$2"; shift 2;; --floor-gb) FLOOR_GB="$2"; shift 2;;
+  --timeout) TIMEOUT="$2"; shift 2;; --pythonpath) PYPATH="$2"; shift 2;;
+  --) shift; break;; *) echo "unknown arg $1"; exit 2;; esac; done
+
+if [[ "$EST_EDGES" -gt 0 ]]; then
+  if ! python3 "$GUARD_DIR/preflight.py" "$EST_EDGES"; then
+    echo "[safe_run] REFUSED: estimated peak > budget for $EST_EDGES edges."; exit 3; fi
+fi
+echo "[safe_run] name=$NAME rmm=${RMM_GB}GB floor=${FLOOR_GB}GB timeout=${TIMEOUT}s"
+
+( while true; do
+    avail=$(free -g | awk '/Mem:/{print $7}')
+    echo "[watchdog $(date +%H:%M:%S)] host avail=${avail}GB"
+    if [[ "${avail:-999}" -lt "$FLOOR_GB" ]]; then
+      echo "[watchdog] avail ${avail}GB < floor ${FLOOR_GB}GB -> KILL $NAME"
+      docker kill -s KILL "$NAME" >/dev/null 2>&1; break; fi
+    sleep 5
+  done ) & WD=$!
+
+timeout -s KILL "$TIMEOUT" docker run --rm --name "$NAME" --gpus all \
+  -e GFQL_RMM_LIMIT_GB="$RMM_GB" -e PYTHONPATH="/dgx-guard:${PYPATH}" \
+  -v "$GUARD_DIR:/dgx-guard:ro" "$@"
+rc=$?
+docker kill -s KILL "$NAME" >/dev/null 2>&1; kill "$WD" >/dev/null 2>&1
+echo "[safe_run] exit=$rc"
+exit $rc

--- a/benchmarks/dgx/sitecustomize.py
+++ b/benchmarks/dgx/sitecustomize.py
@@ -1,0 +1,42 @@
+"""Auto-applied RMM allocation-limit guard for dgx GB10 (unified memory).
+
+Python imports `sitecustomize` at startup if it's on sys.path. When
+GFQL_RMM_LIMIT_GB is set, this caps ALL RMM (cudf/cugraph/cupy) device
+allocations so an over-allocation raises a clean caught MemoryError instead of
+consuming the shared 119 GB unified host RAM and OOM-thrashing the box.
+
+Proven (2026-07-01): docker --memory is TRANSPARENT to cudf/unified allocs;
+RMM LimitingResourceAdaptor caps both cudf AND cugraph cleanly. This is the
+containment mechanism. No-op (silent) when GFQL_RMM_LIMIT_GB unset or rmm absent
+(CPU runs). Mount this dir + prepend to PYTHONPATH via benchmarks/dgx/safe_run.sh.
+"""
+import os as _os
+
+
+def _apply_rmm_limit() -> None:
+    gb = _os.environ.get("GFQL_RMM_LIMIT_GB")
+    if not gb:
+        return
+    try:
+        limit = int(float(gb) * 1024 ** 3)
+    except ValueError:
+        return
+    try:
+        import rmm
+        rmm.mr.set_current_device_resource(
+            rmm.mr.LimitingResourceAdaptor(rmm.mr.CudaMemoryResource(), allocation_limit=limit))
+        try:
+            import cupy
+            from rmm.allocators.cupy import rmm_cupy_allocator
+            cupy.cuda.set_allocator(rmm_cupy_allocator)
+        except Exception:
+            pass
+        import sys
+        print(f"[dgx-guard] RMM device allocation limit = {gb} GB (unified-memory safety)",
+              file=sys.stderr)
+    except Exception:
+        # rmm not present (CPU run) or set failed — do not block the workload.
+        pass
+
+
+_apply_rmm_limit()

--- a/benchmarks/dgx/test_preflight.py
+++ b/benchmarks/dgx/test_preflight.py
@@ -1,0 +1,25 @@
+"""Regression test for the dgx safety preflight estimator.
+
+Guards the exact failure that crashed dgx-spark (2026-07-01): a 1.8B-edge
+cudf/cugraph run whose ~87 GB peak exceeds the ~80 GB unified-memory budget must
+be REFUSED, while the #1658 handoff's 80M-edge run must be allowed.
+"""
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import preflight
+
+
+def test_friendster_1p8b_is_refused():
+    # 1.8B edges -> ~87 GB peak > budget -> must refuse (this is what crashed the box).
+    assert preflight.peak_gb(1_806_067_135) > (preflight.HOST_GB - preflight.DEFAULT_FLOOR_GB)
+    assert preflight.is_safe(1_806_067_135) is False
+
+
+def test_handoff_80m_is_allowed():
+    # 80M edges -> ~3.8 GB peak -> safely allowed (index_takeover_bench largest N).
+    assert preflight.is_safe(80_000_000) is True
+
+
+def test_peak_scales_with_edges_and_cugraph_factor():
+    assert preflight.peak_gb(1_000_000_000) > preflight.peak_gb(100_000_000)
+    assert preflight.peak_gb(100_000_000, cugraph_factor=3.0) > preflight.peak_gb(100_000_000, cugraph_factor=1.0)


### PR DESCRIPTION
## Why
We OOM-thrashed the shared **dgx-spark** box for ~9.5 h with a 1.8B-edge cudf/cugraph load. Root cause: the **GB10 is unified memory — GPU memory *is* the 119 GB system RAM** (16 GB swap). A cudf/cugraph over-allocation consumes host RAM and OOM-kills the OS's own services; the container then hangs and the box wedges.

## What (proven on dgx, small safe scale, host flat throughout)
- **`docker --memory` is TRANSPARENT** to cudf/unified allocations (reached 8 GB under a 4 GB cap) → useless as a guardrail.
- **RMM `LimitingResourceAdaptor` caps both cudf AND cugraph cleanly** — the exact crash call (`compute_cugraph('pagerank')`) hit the limit and raised a caught `MemoryError`, host untouched. **This is the real containment.**
- A **host watchdog** kills a runaway host (pandas/numpy) allocation at a RAM floor (exit 137, host recovers) — covers the path RMM doesn't.

## Files (`benchmarks/dgx/`)
- `sitecustomize.py` — auto-applies `GFQL_RMM_LIMIT_GB` to any Python in the container (non-invasive, no workload edits).
- `preflight.py` + `test_preflight.py` — `peak_gb()`/`is_safe()`; the test guards that **friendster-1.8B is REFUSED** and the 80M handoff run allowed.
- `safe_run.sh` — wraps `docker run` with preflight-refuse + RMM inject + watchdog force-kill + hard timeout. **All dgx GPU/big runs go through it.**
- `README.md` — usage + rationale.

Standalone infra off `master`; benefits every branch that runs dgx benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)