### PR TITLE
fix(gfql): decline undirected varlen + node alias on polars chain (honest NIE, #1741)

### DIFF
--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -569,6 +569,21 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
             "include_zero_hop_seed, prune_to_endpoints) require engine='pandas'."
         )
 
+    # issue #1741: undirected multi-hop lacks pandas' backtrack avoidance — the node/edge SETS
+    # still agree (reachability), but the named-alias flag on nodes after the undirected varlen
+    # edge can tag a node whose only path bounces back over one edge (seed at *1..2), which
+    # pandas correctly leaves untagged (trail semantics). Cypher RETURN projects those flags, so
+    # this silently returned wrong rows. Decline the affected shape (undirected non-single-hop +
+    # any node alias) until the backtrack-avoidance port lands; unnamed chains keep running.
+    if any(isinstance(op, ASTEdge) and not op.is_simple_single_hop()
+           and op.direction == "undirected" for op in ops) and any(
+               isinstance(op, ASTNode) and op._name is not None for op in ops):
+        raise NotImplementedError(
+            "polars chain engine: undirected variable-length hops with node aliases are not "
+            "yet supported (missing backtrack avoidance would mis-tag aliases — issue #1741); "
+            "use engine='pandas' for this query"
+        )
+
     edge_ops = [op for op in ops if isinstance(op, ASTEdge)]
     # Undirected edges in multi-edge chains: NATIVE for single-hop (backward pass threads BOTH
     # endpoints — see override below) and fixed-length multi-hop (generic backward hop +

--- a/graphistry/tests/compute/gfql/test_engine_polars_chain.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_chain.py
@@ -704,3 +704,34 @@ def test_engine_polars_predicate_correctness_fixes():
     # temporal val -> _cmp_expr declines (None) so upstream raises honest NIE; numeric still lowers.
     assert _cmp_expr(None, operator.gt, datetime.date(2020, 1, 1)) is None
     assert _cmp_expr(pl.col("x"), operator.gt, 5) is not None
+
+
+class TestUndirectedVarlenAliasNIE:
+    """issue #1741: undirected varlen + node alias mis-tagged the alias on bounce-back-only
+    nodes (pandas trail semantics leaves them untagged; Cypher RETURN projects the flag ->
+    silent wrong rows). The shape must decline honestly; unnamed chains keep native parity."""
+
+    def _graphs(self):
+        nodes = pd.DataFrame({"id": [f"p{i}" for i in range(6)], "label__Person": [True] * 6})
+        edges = pd.DataFrame({"s": ["p0", "p1", "p2", "p0", "p3"],
+                              "d": ["p1", "p2", "p3", "p4", "p5"], "type": ["KNOWS"] * 5})
+        return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
+
+    def test_named_node_after_undirected_varlen_declines(self):
+        g = self._graphs()
+        ch = [n({"id": "p0"}), e_undirected(min_hops=1, max_hops=2), n(name="f")]
+        with pytest.raises(NotImplementedError, match="1741"):
+            g.chain(ch, engine="polars")
+
+    def test_cypher_undirected_varlen_declines_not_wrong(self):
+        g = self._graphs()
+        q = "MATCH (p:Person {id: 'p0'})-[:KNOWS*1..2]-(f:Person) RETURN f.id AS fid ORDER BY fid"
+        # pandas oracle: p0 is NOT a valid *1..2 endpoint (only path re-uses one edge)
+        assert g.gfql(q, engine="pandas")._nodes["fid"].tolist() == ["p1", "p2", "p4"]
+        with pytest.raises(NotImplementedError):
+            g.gfql(q, engine="polars")
+
+    def test_unnamed_undirected_varlen_still_native_parity(self):
+        g = self._graphs()
+        ch = [n({"id": "p0"}), e_undirected(min_hops=1, max_hops=2), n()]
+        _assert_chain_parity(g, ch, "unnamed undirected varlen", native=True)


### PR DESCRIPTION
## Summary

Fixes the silent-wrong-results half of #1741: on `engine='polars'`/`'polars-gpu'`, `MATCH (a {..})-[:T*1..2]-(f) RETURN f.id` returned rows pandas (the parity oracle) correctly excludes.

- Root cause: undirected multi-hop on the polars chain lacks pandas' backtrack avoidance. The node/edge **sets** still agree (reachability), but the **named-alias flag** on nodes after the undirected varlen edge tags nodes whose only path bounces back over a single edge — e.g. the seed at `*1..2`. Cypher `RETURN` projects those flags → silent wrong rows.
- Fix (interim, integrity-first): decline the affected shape — undirected non-single-hop edge + any node alias in the chain — with a `NotImplementedError` referencing #1741, per the parity-or-honest-NIE contract. Unnamed undirected varlen chains keep native execution (their parity is pinned by a new test).
- The real backtrack-avoidance port (which also unlocks LDBC IC6/IC11 on polars) stays tracked in #1741.

## Tests

- `TestUndirectedVarlenAliasNIE`: NIE on the named shape; the exact #1741 cypher repro now declines instead of returning a wrong row set (pandas oracle result pinned); unnamed undirected varlen keeps native parity.
- Full polars chain suite: 994 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6dQEcjdazEnzuvuwf73ZL