### PR TITLE
Mark illustrative GFQL indexing snippets as non-runnable

### DIFF
--- a/docs/source/gfql/indexing.rst
+++ b/docs/source/gfql/indexing.rst
@@ -11,6 +11,8 @@ lifecycle: what the indexes are, what engages them, when they go stale, and what
 For the planner policy knobs and competitive benchmarks, see
 :doc:`Seeded Traversal Indexes <index_adjacency>`.
 
+.. doc-test: skip
+
 .. code-block:: python
 
    g = g.gfql_index_all()   # pay once ...
@@ -134,6 +136,8 @@ time). Consequences:
 - ``g.show_indexes()`` reports liveness in the ``valid`` column, so you can see at a
   glance whether a rebind knocked an index out.
 - Rebuild by calling ``gfql_index_all()`` again on the rebound ``g``.
+
+.. doc-test: skip
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary

- Mark two incomplete illustrative Python snippets in `docs/source/gfql/indexing.rst` as skipped by the docs-example runner.
- Preserve rendered prose and GFQL behavior unchanged.

## Root cause

The docs-example collector treats Python code blocks as runnable unless they carry a `doc-test` marker. One illustration contains a literal `...`; the other references illustrative `new_edges_df` that is not defined in that block. This latent master issue surfaced in #1767's broader suite but is unrelated to #1767's GFQL behavior.

## Validation

- Static review: one file, +4/-0; clean credential/diff checks; two consecutive no-advance review waves with zero findings.
- Guarded DGX Python 3.8.20: exact `indexing.rst` selector, `1 passed in 1.62s`.
- Guarded DGX Python 3.14.2: exact selector, `1 passed in 2.09s`.
- No project code or tests were run locally.

## Follow-up

- The pre-existing docs-only CI classification gap can skip the minimal-Python lane for docs-only PRs; this narrow fix does not broaden into workflow changes.
