### PR TITLE
fix(typing): two real defects CI's type gate cannot see (#1791)

### DIFF
--- a/graphistry/compute/gfql/search_any.py
+++ b/graphistry/compute/gfql/search_any.py
@@ -10,7 +10,7 @@ rules as ``=~``."""
 import re
 from typing import List, Optional
 
-from graphistry.compute.typing import DataFrameT, SeriesT
+from graphistry.compute.typing import DataFrameT, DType, SeriesT
 
 # inspector's numeric-term gate (streamgl-viz sortAndFilterRowsByQuery.js)
 _NUMERIC_TERM_RE = re.compile(r"^[0-9.\-]+$")
@@ -20,12 +20,12 @@ def is_numeric_term(term: str) -> bool:
     return bool(_NUMERIC_TERM_RE.match(term))
 
 
-def _is_searchable_string_dtype(dtype: object) -> bool:
+def _is_searchable_string_dtype(dtype: DType) -> bool:
     import pandas.api.types as pat  # cuDF mirrors the pandas dtype API
     return bool(pat.is_string_dtype(dtype)) or bool(pat.is_object_dtype(dtype))
 
 
-def _is_int_dtype(dtype: object) -> bool:
+def _is_int_dtype(dtype: DType) -> bool:
     import pandas.api.types as pat
     return bool(pat.is_integer_dtype(dtype))
 
@@ -93,11 +93,14 @@ def search_any_mask(
         # truncate) and temporal is unverified — decline honestly rather than
         # silently mismatch the pandas oracle (wave-3 W3-1). string/int/bool render
         # identically (bool parity is pinned) and stay native.
-        import pandas.api.types as pat
+        # NB: aliased ``pd_types``, not ``pat`` — ``pat`` is rebound below to the search
+        # PATTERN string, and a module/str double-binding in one scope is one statement
+        # reorder away from ``AttributeError: 'str' object has no attribute ...``.
+        import pandas.api.types as pd_types
         for c in cols:
             dt = df[c].dtype
             if not (_is_searchable_string_dtype(dt) or _is_int_dtype(dt)
-                    or bool(pat.is_bool_dtype(dt))):
+                    or bool(pd_types.is_bool_dtype(dt))):
                 raise NotImplementedError(
                     "cuDF searchAny explicit columns support string/int/bool dtypes "
                     "only (float/temporal stringification diverges from pandas); "

--- a/graphistry/plugins/graphviz.py
+++ b/graphistry/plugins/graphviz.py
@@ -27,10 +27,30 @@ def g_to_pgv(
     include_positions: bool = False
 ) -> AGraph:
 
-    import pygraphviz as pgv
-
     assert g._nodes is not None
     assert g._edges is not None
+
+    # The id/endpoint BINDINGS are Optional and are not implied by the frames being set:
+    # ``g.nodes(df)`` (no ``node=``) / ``g.edges(df)`` (no source/destination) leave them
+    # None, and ``layout_graphviz``/``render_graphviz`` only ``materialize_nodes()`` when
+    # ``_nodes`` is None -- so an explicitly-bound-but-unlabelled nodes frame reached
+    # ``row[None]`` below and died with a bare ``KeyError: None`` from deep inside the row
+    # loop. Resolve them once, up front, into non-Optional locals.
+    node_col = g._node
+    src_col = g._source
+    dst_col = g._destination
+    if node_col is None:
+        raise ValueError(
+            "graphviz export requires a bound node id column; "
+            "use g.nodes(df, node='id') or g.materialize_nodes()"
+        )
+    if src_col is None or dst_col is None:
+        raise ValueError(
+            "graphviz export requires bound edge endpoint columns; "
+            "use g.edges(df, source='src', destination='dst')"
+        )
+
+    import pygraphviz as pgv
 
     graph = pgv.AGraph(directed=directed, strict=strict)
 
@@ -58,7 +78,7 @@ def g_to_pgv(
         if pos_cols is not None:
             attrs['pos'] = f"{row[pos_cols[0]]},{row[pos_cols[1]]}"
         graph.add_node(
-            row[g._node],
+            row[node_col],
             **attrs
         )
 
@@ -75,8 +95,8 @@ def g_to_pgv(
     edges_pdf = ensure_pandas(g._edges)
     for _, row in edges_pdf.iterrows():
         graph.add_edge(
-            row[g._source],
-            row[g._destination],
+            row[src_col],
+            row[dst_col],
             **{c: row[c] for c in edge_attr_cols if row[c] is not None}
         )
 

--- a/graphistry/tests/plugins/test_graphviz.py
+++ b/graphistry/tests/plugins/test_graphviz.py
@@ -156,3 +156,28 @@ class Test_graphviz():
 
         svg_bytes = render_graphviz(tree_g, "dot", format="svg", max_nodes=100, max_edges=200)
         assert b'<svg' in svg_bytes
+
+
+class Test_graphviz_bindings:
+    """#1791: the id/endpoint bindings are Optional and are NOT implied by the frames
+    being set. Before the fix these reached ``row[None]`` and raised a bare
+    ``KeyError: None`` from inside the row loop. No pygraphviz needed: the bindings are
+    validated before the optional backend import."""
+
+    def test_unbound_node_column_raises_value_error(self) -> None:
+        # .nodes(df) with no node= leaves _node None while _nodes is set, so
+        # layout_graphviz/render_graphviz do NOT materialize_nodes() over it
+        g = graphistry.edges(
+            pd.DataFrame({'s': ['a'], 'd': ['b']}), 's', 'd'
+        ).nodes(pd.DataFrame({'id': ['a', 'b']}))
+        assert g._node is None
+        with pytest.raises(ValueError, match='bound node id column'):
+            g_to_pgv(g)
+
+    def test_unbound_edge_endpoints_raise_value_error(self) -> None:
+        g = graphistry.edges(
+            pd.DataFrame({'s': ['a'], 'd': ['b']})
+        ).nodes(pd.DataFrame({'id': ['a', 'b']}), 'id')
+        assert g._source is None and g._destination is None
+        with pytest.raises(ValueError, match='bound edge endpoint columns'):
+            g_to_pgv(g)


### PR DESCRIPTION
Two real defects surfaced by #1791, plus the evidence that CI's type gate cannot see them.

## The gate is off, not mis-pinned

The premise in #1791 was that CI pins an *older* `pandas-stubs` than the container. The opposite is true, and neither pin is the cause.

| | mypy | pandas-stubs | result |
|---|---|---|---|
| CI, as it actually runs today | 2.3.0 (uvx) | **none** | `Success: no issues found in 324 source files` |
| CI's own locked env (`requirements/test-py3.12.lock`) | 2.1.0 | 3.0.3.260530 | **140 errors in 10 files** |
| `test-rapids-official:26.02-gfql-polars` | 1.19.1 | 3.0.0.260204 | 173 errors in 12 files |

`bin/typecheck.sh` resolves `MYPY_CMD` to `uvx mypy` whenever `uvx` is on PATH — and CI puts it there (`python -m pip install --upgrade pip uv`). `uvx` runs mypy in an **isolated ephemeral environment**, so the `--require-hashes` lockfile install of `pandas-stubs`, `types-requests`, `types-tqdm`, `types-defusedxml` and the project's own deps is never visible to it. `mypy.ini` then has `ignore_missing_imports = True` for `pandas.*`, `numpy.*`, `pyarrow.*` etc., so every external symbol degrades to `Any` and the whole file set passes vacuously.

Two independent confirmations:
- CI's log installs `mypy==2.1.0` from the lock, then reports `mypy 2.3.0 (compiled: yes)` at run time — a different interpreter entirely.
- `mypy --no-site-packages` reproduces CI's output byte for byte, including the file count: `Success: no issues found in 324 source files`.

`bin/lint.sh` has the same `uvx ruff` shape. Less harmful (ruff needs no imports and still reads `pyproject.toml`), but the locked ruff version is likewise bypassed, so a new ruff release can turn CI red with no repo change.

Full triage of all 140 in #1791.

## What this PR fixes

Two bucket-B items — real code defects, worth fixing regardless of any stub decision.

### 1. `graphviz`: `KeyError: None` on a bound-but-unlabelled frame

`g_to_pgv` asserts `_nodes`/`_edges` are set, but not that the *bindings* are. `g.nodes(df)` with no `node=` leaves `_node` None while `_nodes` is set — and `layout_graphviz`/`render_graphviz` only call `materialize_nodes()` when `_nodes` **is None**, so that graph sails through and reaches `row[None]`.

```
# master
g._node = None
RESULT: KeyError : None

# this PR
RESULT: ValueError : graphviz export requires a bound node id column;
        use g.nodes(df, node='id') or g.materialize_nodes()
```

Same for `g.edges(df)` with no source/destination. Bindings are now resolved once into non-Optional locals; validation moved ahead of the optional `pygraphviz` import so a caller error is not masked by a missing-backend error, and so it is testable without the optional dep. Two regression tests added — they fail on master, pass here, and are not skipped when pygraphviz is absent.

### 2. `search_any`: `pat` bound to both a module and a str in one scope

```python
import pandas.api.types as pat     # line 95
...
    or bool(pat.is_bool_dtype(dt))  # line 100  -> module
...
pat, case = term, case_sensitive    # line 110  -> str
pred = Contains(pat, ...)           # line 118
```

Exactly the shadowed-name shape #1791 predicted. Ordering saves it today (module use strictly precedes the rebind), so this is a latent hazard rather than a live failure — one statement reorder from `AttributeError: 'str' object has no attribute 'is_bool_dtype'`. Module alias renamed to `pd_types`. No behaviour change, so no test; the mypy differential is the evidence.

Also corrects two `dtype: object` params to the engine-agnostic `DType` alias — they receive pandas/cuDF/polars dtypes, so `object` was both less accurate and on the repo's banned-annotation list.

## No suppressions

Zero `# type: ignore` added, zero `Any`/`cast`/`getattr`/`setattr`/`Dict[str, Any]`/`object`. Every one of the 12 errors goes away because the code got more correct.

## Gates

- **mypy differential**, CI's own pin (mypy 2.1.0 + pandas-stubs 3.0.3.260530): **140 → 128**, **zero new errors**, diffed error-set to error-set. `search_any.py` 9→0, `graphviz.py` 3→0. Under the container stubs: 173 → 161.
- **ruff** (`bin/ruff.sh`, with `pyproject.toml` present): clean.
- **`graphistry/tests/compute` with `--gpus all`**: `9 failed, 7030 passed, 90 skipped, 15 xfailed` — identical to the master baseline; all 9 are the pre-existing igraph/cudf/dask failures.
- **`graphistry/tests/plugins/test_graphviz.py`**: 2 passed, 9 skipped (pygraphviz absent); the 2 new tests run and pass.

All measured in `graphistry/test-rapids-official:26.02-gfql-polars` on dgx-spark.

## Not in this PR

Turning the gate back on. It is a two-line change to `bin/typecheck.sh`, but it flips CI from green to 128 errors, so it needs its own staged PR — recommendation in #1791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YsqAZQLbqjSDrYSFz2GoB
