### PR TITLE
fix(gfql): stop WITH re-entry mutating the caller's Plottable (#1786)

### DIFF
--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -684,6 +684,7 @@ def _handle_boundary_calls(
     # Function-scope import: `gfql.index` transitively imports this module, so a
     # module-scope import would be a cycle.
     from .gfql.index.handoff import attach_handoff
+    from .gfql.exec_context import attach_row_exec_context, clear_row_exec_context
 
     g_temp = self
     suffix_base_graph = g_temp
@@ -732,9 +733,13 @@ def _handle_boundary_calls(
 
     if suffix:
         logger.debug('Executing boundary suffix calls: %s', suffix)
-        if start_nodes is not None:
-            g_temp._gfql_start_nodes = start_nodes
-        g_temp._gfql_rows_base_graph = suffix_base_graph
+        # #1786: per-execution state rides on an INTERNAL COPY. Without prefix/middle
+        # ops (or a handoff) nothing above rebuilt `g_temp`, so it is still the CALLER's
+        # graph -- assigning here left the WITH re-entry seed on the user's object and
+        # the next, unrelated query was answered against it (silent wrong count).
+        g_temp = attach_row_exec_context(
+            g_temp, start_nodes=start_nodes, rows_base_graph=suffix_base_graph
+        )
         if (
             middle
             and any(getattr(op, "_name", None) is not None for op in middle)
@@ -779,7 +784,9 @@ def _handle_boundary_calls(
             start_nodes
         )
 
-    return g_temp
+    # Each site that attaches the row context also detaches it: the suffix chain has run,
+    # so the context is spent, and a caller who queries THIS result must not inherit it.
+    return clear_row_exec_context(g_temp)
 
 
 def _chain_otel_attrs(

--- a/graphistry/compute/gfql/exec_context.py
+++ b/graphistry/compute/gfql/exec_context.py
@@ -1,0 +1,57 @@
+"""Per-execution row context: the ``WITH`` re-entry seed and the boundary base graph.
+
+The row pipeline reads its re-entry seed (``_gfql_start_nodes``) and the graph a
+boundary suffix must re-match against (``_gfql_rows_base_graph``) off the graph it is
+handed. Both are state of ONE execution, not properties of the user's graph, so they
+must ride on an INTERNAL COPY. Assigning them to the caller's ``Plottable`` leaves them
+behind after the query returns, and the next -- entirely unrelated -- query on the same
+object is then answered against the stale seed: a silent wrong count, no error, on every
+engine (#1786).
+
+Mirrors ``gfql/index/handoff.attach_handoff``. The fields are DECLARED on ``Plottable``
+(defaults on ``PlotterBase``), so every access here is ordinary typed attribute access.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from graphistry.Plottable import Plottable
+    from graphistry.compute.typing import DataFrameT
+
+
+def attach_row_exec_context(
+    g: "Plottable",
+    *,
+    start_nodes: Optional["DataFrameT"] = None,
+    rows_base_graph: Optional["Plottable"] = None,
+) -> "Plottable":
+    """Return an internal copy of ``g`` carrying this execution's row context.
+
+    ``None`` means "keep whatever ``g`` already carries" for either field, so a nested
+    execution inherits the enclosing one's seed exactly as it did before -- the change
+    is only ever WHICH object the value lands on, never the value itself.
+    """
+    out = g.bind()
+    if start_nodes is not None:
+        out._gfql_start_nodes = start_nodes
+    if rows_base_graph is not None:
+        out._gfql_rows_base_graph = rows_base_graph
+    return out
+
+
+def clear_row_exec_context(g: "Plottable") -> "Plottable":
+    """Return ``g`` stripped of the row context, for a result handed back to the caller.
+
+    The mirror of ``attach_row_exec_context``: each site that attaches also detaches, so
+    the plumbing never escapes on a user-visible result. Without this the RESULT of a
+    ``WITH`` query carries the seed, and a follow-up query on that result -- a different
+    graph entirely -- is answered against it (the same #1786 defect, one hop removed).
+    Returns ``g`` unchanged when there is nothing to strip, so the common path is free.
+    """
+    if g._gfql_start_nodes is None and g._gfql_rows_base_graph is None:
+        return g
+    out = g.bind()
+    out._gfql_start_nodes = None
+    out._gfql_rows_base_graph = None
+    return out

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -503,14 +503,16 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
     """
     from graphistry.compute.ast import ASTCall, ASTNode as _ASTNode, ASTEdge as _ASTEdge, rows as rows_fn
     from graphistry.compute.chain import serialize_binding_ops
+    from graphistry.compute.gfql.exec_context import attach_row_exec_context, clear_row_exec_context
 
     calls = list(calls)
     if not calls:
         return g_cur
 
-    if start_nodes is not None:
-        g_cur._gfql_start_nodes = start_nodes
-    g_cur._gfql_rows_base_graph = base_graph
+    # #1786: twin of the generic chain -- per-execution state on an INTERNAL COPY.
+    # `g_cur` is the CALLER's graph on the all-calls boundary run, so assigning here
+    # left the WITH re-entry seed behind for the next, unrelated query.
+    g_cur = attach_row_exec_context(g_cur, start_nodes=start_nodes, rows_base_graph=base_graph)
 
     if (
         middle
@@ -585,7 +587,9 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
             f"{getattr(op, 'function', op)!r}; use engine='pandas' for this query "
             f"(no pandas fallback; parity-or-error by design)"
         )
-    return g_cur
+    # Attach/detach pair: the boundary run is done, so the context is spent and must not
+    # ride out on the result the caller sees (see the twin in compute/chain.py).
+    return clear_row_exec_context(g_cur)
 
 
 

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -30,6 +30,7 @@ from graphistry.compute.gfql.same_path_types import (
 )
 from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
 from graphistry.compute.gfql.cypher.parser import parse_cypher
+from graphistry.compute.gfql.exec_context import attach_row_exec_context, clear_row_exec_context
 from graphistry.compute.gfql.cypher.lowering import (
     ConnectedMatchJoinPlan,
     CompiledCypherGraphQuery,
@@ -1120,9 +1121,14 @@ def _execute_compiled_query_chain_non_union(
             and getattr(_first_op, "function", None) == "rows"
             and getattr(_first_op, "params", {}).get("binding_ops") is not None
         ):
-            dispatch_graph._gfql_start_nodes = start_nodes
+            # #1786: on the no-seed-rows path `_seeded_dispatch_graph` hands back
+            # `base_graph` ITSELF (the caller's object), so this must land on a copy.
+            dispatch_graph = attach_row_exec_context(dispatch_graph, start_nodes=start_nodes)
 
     result = _chain_dispatch(dispatch_graph, compiled_query.chain, engine, policy, context, start_nodes=start_nodes)
+    # Attach/detach pair (#1786): the chain has run, so the seed is spent and must not
+    # ride out on the result -- a follow-up query on it is about a DIFFERENT graph.
+    result = clear_row_exec_context(result)
     if compiled_query.empty_result_row is not None:
         result = _apply_empty_result_row(
             result,
@@ -1847,8 +1853,14 @@ def gfql(self: Plottable,
                     e.query_type = policy_context.get('query_type')
                 raise
 
+        # #1786: `shortest_path_backend` is an argument to THIS call, not a property of
+        # the caller's graph, so it may not be written onto `self`. Copy only when the
+        # value actually differs: the default call then keeps `self`'s identity, and the
+        # compiled-query memo cache below is owned by `self` either way.
         dispatch_self = self
-        dispatch_self._gfql_shortest_path_backend = shortest_path_backend
+        if self._gfql_shortest_path_backend != shortest_path_backend:
+            dispatch_self = self.bind()
+            dispatch_self._gfql_shortest_path_backend = shortest_path_backend
         compiled_query = None
 
         if where_param and isinstance(query, (dict, ASTLet)):
@@ -1904,7 +1916,9 @@ def gfql(self: Plottable,
                     query,
                     language=language,
                     params=params,
-                    cache_owner=dispatch_self,
+                    # `self`, not `dispatch_self`: the memo cache must outlive the call,
+                    # and `dispatch_self` is a throwaway copy on the non-default backend.
+                    cache_owner=self,
                     node_dtypes=_node_dtypes_for_pushdown(self, engine),
                 )
             except GFQLValidationError as exc:

--- a/graphistry/tests/compute/gfql/test_reentry_caller_graph_immutability.py
+++ b/graphistry/tests/compute/gfql/test_reentry_caller_graph_immutability.py
@@ -1,0 +1,138 @@
+"""A query must not mutate the ``Plottable`` it was run on (#1786).
+
+``WITH`` re-entry seeds the follow-up ``MATCH`` from the carried nodes. That seed used to be
+assigned to the CALLER's graph and never cleared, so the next -- entirely unrelated -- query on
+the same object was answered against the stale seed: no error, just the previous query's count.
+Engine-independent (wrong on pandas too), so an engine A/B never surfaces it.
+
+Everything here is written to FAIL if the leak comes back: the assertions compare a query run on
+a re-used graph against the SAME query run on a pristine one, and pin the absolute counts so a
+fix that merely makes both sides equally wrong is caught too.
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+
+
+def _engines():
+    out = ["pandas"]
+    try:
+        import polars  # noqa: F401
+        out.append("polars")
+    except Exception:
+        pass
+    return out
+
+
+ENGINES = _engines()
+
+# The #1786 repro graph. `kind` alternates a/b/a/b/a/b/a, so `{kind:'a'}` selects 4 of 7 nodes.
+NODES = pd.DataFrame({"id": list(range(7)), "kind": ["a", "b"] * 3 + ["a"]})
+EDGES = pd.DataFrame(
+    [(0, 3), (1, 2), (4, 6), (3, 5), (5, 6), (0, 6), (3, 4)], columns=["s", "d"]
+)
+
+PLAIN = "MATCH (a)-[*]->(b) RETURN count(*) AS c"
+REENTRY = "MATCH (a {kind:'a'}) WITH a MATCH (a)-[*]->(b) RETURN count(*) AS c"
+NESTED = (
+    "MATCH (a {kind:'a'}) WITH a MATCH (a)-[]->(b) WITH b MATCH (b)-[]->(c) "
+    "RETURN count(*) AS c"
+)
+
+# Independently established on this fixed graph (identical on both engines).
+PLAIN_COUNT = 13
+REENTRY_COUNT = 7
+NESTED_COUNT = 2
+
+
+def _g():
+    """A PRISTINE graph. Every oracle needs one: re-using a graph is the thing under test."""
+    return graphistry.nodes(NODES, "id").edges(EDGES, "s", "d")
+
+
+def _count(g, query, engine):
+    return int(g.gfql(query, engine=engine)._nodes["c"].to_list()[0])
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_reentry_then_unrelated_query_is_unaffected(engine):
+    """THE regression: two independent queries, one graph. The second must not see the first."""
+    g = _g()
+    assert _count(g, REENTRY, engine) == REENTRY_COUNT
+    assert _count(g, PLAIN, engine) == PLAIN_COUNT
+    # ... and identical to the same query on a graph that never ran the re-entry query.
+    assert _count(g, PLAIN, engine) == _count(_g(), PLAIN, engine)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_reentry_leaves_no_execution_state_on_caller_graph(engine):
+    """Directly: the per-execution fields on the caller's object are untouched."""
+    g = _g()
+    g.gfql(REENTRY, engine=engine)
+    assert g._gfql_start_nodes is None
+    assert g._gfql_rows_base_graph is None
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_reentry_still_works(engine):
+    """Do not "fix" the leak by breaking WITH: the re-entry answer itself must survive."""
+    assert _count(_g(), REENTRY, engine) == REENTRY_COUNT
+    assert REENTRY_COUNT != PLAIN_COUNT  # else the test above proves nothing
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_repeated_reentry_is_stable(engine):
+    """Re-entry twice on one graph: the second run must not inherit the first's seed."""
+    g = _g()
+    assert [_count(g, REENTRY, engine) for _ in range(3)] == [REENTRY_COUNT] * 3
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_nested_reentry(engine):
+    """Two WITH boundaries in one query, then an unrelated query on the same graph."""
+    g = _g()
+    assert _count(g, NESTED, engine) == NESTED_COUNT
+    assert g._gfql_start_nodes is None
+    assert _count(g, PLAIN, engine) == PLAIN_COUNT
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_query_order_does_not_change_answers(engine):
+    """Whole point of immutability: the answers do not depend on execution order."""
+    g1 = _g()
+    plain_first = (_count(g1, PLAIN, engine), _count(g1, REENTRY, engine))
+    g2 = _g()
+    reentry_first = (_count(g2, REENTRY, engine), _count(g2, PLAIN, engine))
+    assert plain_first == (PLAIN_COUNT, REENTRY_COUNT)
+    assert reentry_first == (REENTRY_COUNT, PLAIN_COUNT)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_reentry_result_does_not_carry_execution_state(engine):
+    """The same defect one hop out: a RESULT that carries the seed poisons queries on IT."""
+    out = _g().gfql("MATCH (a {kind:'a'}) WITH a MATCH (a)-[]->(b) RETURN a", engine=engine)
+    assert out._gfql_start_nodes is None
+    assert out._gfql_rows_base_graph is None
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_pure_call_chain_result_does_not_carry_execution_state(engine):
+    """The all-calls boundary run (``let()`` bodies) hands its graph straight through.
+
+    On polars that graph is the one the run started from, so the boundary's base-graph
+    write lands on the returned object unless it is attached to a copy and cleared.
+    """
+    from graphistry.compute.ast import call
+
+    out = _g().gfql([call("rows", {"table": "nodes"})], engine=engine)
+    assert out._gfql_rows_base_graph is None
+    assert out._gfql_start_nodes is None
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_shortest_path_backend_is_not_written_onto_caller_graph(engine):
+    """A per-CALL argument is not a property of the graph; it must not persist on it."""
+    g = _g()
+    g.gfql(PLAIN, engine=engine, shortest_path_backend="bfs")
+    assert g._gfql_shortest_path_backend == "auto"


### PR DESCRIPTION
Fixes #1786.

## The defect

```python
g = graphistry.nodes(N, "id").edges(E, "s", "d")
g.gfql("MATCH (a {kind:'a'}) WITH a MATCH (a)-[*]->(b) RETURN count(*) AS c")  # 7 (correct)
g.gfql("MATCH (a)-[*]->(b) RETURN count(*) AS c")                              # 7  <-- was WRONG, is 13
```

`WITH` re-entry wrote its seed onto the caller's `Plottable` and never cleared it, so the next -- entirely unrelated -- query on the same object was answered against the stale seed. Fails **open**: no error, just the previous query's count. Engine-independent, so an engine A/B never surfaces it.

## Leak sites (all `_gfql_*` fields assigned during execution were audited)

| site | what leaked | caller-visible today? |
|---|---|---|
| `gfql_unified._execute_compiled_query_chain_non_union` | `_gfql_start_nodes` | **yes** -- `_seeded_dispatch_graph` hands back `base_graph` ITSELF when the compiled query has no seed rows, so the write lands on the user's graph. This is the reported bug. |
| `gfql_unified.gfql` (`dispatch_self = self`) | `_gfql_shortest_path_backend` | **yes** -- a per-CALL argument persisted on the caller's graph and became the default for its next query. |
| `chain._handle_boundary_calls` | `_gfql_start_nodes`, `_gfql_rows_base_graph` | no (its `g_temp` is always rebuilt by the middle ops first) -- same pattern, converted for uniformity. |
| `polars.chain._run_calls_polars` | `_gfql_start_nodes`, `_gfql_rows_base_graph` | not onto `g`, but onto the **result** on the all-calls path -- a follow-up query on that result is then answered against another graph's seed. |

Left alone deliberately: `row/pipeline.py`'s `_gfql_native_sp_cache` (an edges-identity-keyed memo, semantically neutral) and the compiled-string-query memo cache (now explicitly owned by `self`, so it still works).

## Approach and why

Carry the state on an **internal copy**, not a `try/finally` restore. This mechanism already exists in the codebase -- `gfql/index/handoff.py` attaches its boundary decision with `g.bind()` -- so `gfql/exec_context.py` is the same shape for the row context, and every site now attaches on the way in and clears on the way out.

- Threading the seed through `ExecutionContext` would be the purest fix, but it is read deep inside the pandas row pipeline and both polars pattern appliers; that is a large refactor, not a bug fix.
- A `finally` restore was rejected: it still mutates a shared object for the duration of the call, and it cannot fix the second half of the defect -- the state escaping on the **result** graph.

Clearing on the way out matters independently: the result of a `WITH` query used to carry the seed, so a follow-up query on that result got the same wrong answer one hop removed.

No banned constructs (`Any`, `cast`, `getattr`, `setattr`, bare `list`, `Dict[str, Any]`, `object`) -- the fields are already declared on `Plottable`, so it is ordinary typed attribute access throughout.

## Tests

`graphistry/tests/compute/gfql/test_reentry_caller_graph_immutability.py`, 9 cases x {pandas, polars}: two independent queries on one graph, the re-entry answer itself, repeated re-entry, nested (two `WITH`s), order-independence, the caller's fields after a query, the result's fields, the pure-call chain result, and the shortest-path-backend argument.

**Mutation-checked** (each leak reintroduced in-container, suite re-run, then restored):

| reintroduced | new tests failing |
|---|---|
| `dispatch_graph._gfql_start_nodes = start_nodes` | 8 |
| `dispatch_self._gfql_shortest_path_backend = ...` | 2 |
| all three `clear_row_exec_context` calls | 3 |
| polars `clear_row_exec_context` alone | 1 |
| everything | 13 |

The two attach sites that are not independently observable (chain / polars) are documented as such above rather than claimed as tested.

## Verification

All on dgx-spark in `graphistry/test-rapids-official:26.02-gfql-polars` with `--gpus all`.

- `graphistry/tests/compute`: master `c76f23a3` = **9 failed, 7050 passed, 90 skipped, 16 xfailed**; this branch = **9 failed, 7068 passed, 90 skipped, 16 xfailed**. Identical failure set (7 igraph-cudf round-trip + 1 cudf coercion + 1 dask, all pre-existing); +18 = the new tests.
- mypy: 161 errors on master, 161 on this branch -- zero added.
- ruff: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YsqAZQLbqjSDrYSFz2GoB