### PR TITLE
Fix indexing.rst doc-example failures

### DIFF
--- a/docs/source/gfql/indexing.rst
+++ b/docs/source/gfql/indexing.rst
@@ -177,6 +177,7 @@ time). Consequences:
 
 .. code-block:: python
 
+   new_edges_df = edges_df.assign(amount=edges_df["amount"] + 1)
    g2 = g_indexed.edges(new_edges_df, "src", "dst")
    g2.show_indexes()          # edge_out_adj / edge_in_adj now valid=False; node_id still True
    g2 = g2.gfql_index_all()   # pay again for the new frame; all valid=True


### PR DESCRIPTION
```
##Fix
* Fix indexing.rst doc-example failure — define new_edges_df before use in the invalidation example (was raising NameError).
```
