### PR TITLE
test(gfql): assert_col_stats helper — engagement pins against a public surface

### DIFF
--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -18225,22 +18225,36 @@ def _col_stats_trace(g: Any, query: str) -> List[Tuple[str, str, str]]:
 
 def test_t6_col_stats_decisions_are_visible_in_the_trace() -> None:
     """A dead fact is otherwise INVISIBLE: values stay correct, so no value test
-    can fail. The trace distinguishes the outcomes because their fixes differ --
-    absent (build them), insufficient (whole-frame facts cannot prove a typed
-    claim), served (a scan was skipped)."""
+    can fail. The trace distinguishes outcomes because their fixes differ."""
+    from graphistry.tests.compute.gfql.engagement import assert_col_stats
+
     nodes, edges = _t6_typed_frames()
     base = _mk_graph(nodes, edges)
 
-    assert all(c == "col_stats_absent" for _, _, c in
-               _col_stats_trace(base, _T6_TYPED_QUERY))
+    assert_col_stats(base, _T6_TYPED_QUERY, served=False,
+                     outcomes={"nodes.id": "absent", "edges.s": "absent"})
     # whole-frame facts EXIST but cannot prove a typed claim -- the exact
     # structural limitation per-type facts were added to fix
-    whole = _col_stats_trace(base.gfql_index_col_stats(), _T6_TYPED_QUERY)
-    assert ("edges", "s", "col_stats_insufficient") in whole
-    typed = _col_stats_trace(
+    assert_col_stats(base.gfql_index_col_stats(), _T6_TYPED_QUERY, served=False,
+                     outcomes={"edges.s": "insufficient", "edges.d": "insufficient"})
+    assert_col_stats(
         base.gfql_index_col_stats(node_type_column="kind", edge_type_column="rel"),
-        _T6_TYPED_QUERY)
-    assert all(c == "col_stats_served" for _, _, c in typed)
+        _T6_TYPED_QUERY, served=True,
+        outcomes={"nodes.id": "served", "edges.s": "served"})
+
+
+def test_t6_assert_col_stats_helper_fails_loudly() -> None:
+    """The helper must FAIL when the optimization did not fire -- an engagement
+    pin that cannot fail is worse than none, which is the whole failure mode
+    this surface exists to close."""
+    from graphistry.tests.compute.gfql.engagement import assert_col_stats
+
+    nodes, edges = _t6_typed_frames()
+    base = _mk_graph(nodes, edges)
+    with pytest.raises(AssertionError, match="expected every fact consult to be served"):
+        assert_col_stats(base, _T6_TYPED_QUERY, served=True)
+    with pytest.raises(AssertionError, match="expected col_stats_served"):
+        assert_col_stats(base, _T6_TYPED_QUERY, outcomes={"nodes.id": "served"})
 
 
 def test_t6_col_stats_trace_is_free_when_not_tracing() -> None:

--- a/graphistry/tests/compute/gfql/engagement.py
+++ b/graphistry/tests/compute/gfql/engagement.py
@@ -1,0 +1,71 @@
+"""Assert that an optimization actually FIRED, not merely that the answer is right.
+
+WHY THIS EXISTS. GFQL's fast paths are contracted "same answer, faster": every
+one of them falls back to a scan when it declines, so a completely dead
+optimization still returns the correct result. Value tests are therefore
+structurally blind to it -- measured in ``test_lowering.py``, 665 assertions
+check values and 42 check engagement, and three real bugs slipped through that
+gap (a boolean label form that never engaged, a fingerprint change that made
+every fact look stale, and an opt-in flag that silently did nothing). None could
+have failed a value test.
+
+WHY NOT MONKEYPATCH. The usual way to write these -- patch a private callee on
+its defining module and count calls -- is unreliable in a way that FAILS OPEN. If
+another module did ``from .gfql_fast_paths import _execute_two_hop_count_fast_path``,
+that module holds its own reference and patching the definition site never
+intercepts; the pin then cannot fail, and the silence reads like a dead code
+path. That false negative has already been produced once here. These helpers
+read the public ``gfql_explain`` trace instead, so they observe the decision
+where it is made and survive refactors of the private names.
+"""
+from typing import Any, Dict, List, Optional
+
+from graphistry.compute.gfql.index.api import index_trace
+
+
+def col_stats_decisions(g: Any, query: str, *, engine: str = "pandas") -> List[Dict[str, Any]]:
+    """Every column-stat fact decision made while running ``query`` on ``g``."""
+    with index_trace() as steps:
+        g.gfql(query, engine=engine)
+    return [dict(s) for s in steps if s.get("op") == "col_stats"]
+
+
+def assert_col_stats(
+    g: Any,
+    query: str,
+    *,
+    engine: str = "pandas",
+    served: Optional[bool] = None,
+    outcomes: Optional[Dict[str, str]] = None,
+) -> List[Dict[str, Any]]:
+    """Assert how the column-stat facts were USED, and return the decisions.
+
+    ``served=True`` requires every decision to have skipped a scan; ``False``
+    requires that none did. ``outcomes`` maps ``"<role>.<column>"`` to an expected
+    outcome (``served`` / ``absent`` / ``stale`` / ``insufficient``) for finer
+    checks. Failures name what actually happened, since "the optimization did not
+    fire" is otherwise indistinguishable from "the test asserted nothing".
+    """
+    decisions = col_stats_decisions(g, query, engine=engine)
+    assert decisions, (
+        "no col_stats decisions were recorded -- the consult was never reached, "
+        "so this assertion would have passed vacuously")
+
+    if served is not None:
+        actual = {d["decision_code"] for d in decisions}
+        if served:
+            assert all(d["served"] for d in decisions), (
+                f"expected every fact consult to be served, got {sorted(actual)}")
+        else:
+            assert not any(d["served"] for d in decisions), (
+                f"expected no fact consult to be served, got {sorted(actual)}")
+
+    for key, expected in (outcomes or {}).items():
+        role, _, column = key.partition(".")
+        matching = [d for d in decisions if d["role"] == role and d["column"] == column]
+        assert matching, f"no col_stats decision for {key!r}; saw " + str(
+            sorted({f"{d['role']}.{d['column']}" for d in decisions}))
+        got = {d["decision_code"] for d in matching}
+        assert got == {f"col_stats_{expected}"}, (
+            f"{key}: expected col_stats_{expected}, got {sorted(got)}")
+    return decisions


### PR DESCRIPTION
**Stacked on #1860** (base is `feat/gfql-colstats-trace`).

Step 1 of closing the defect class behind three bugs in this stack: perf work is contracted *same answer, faster*, so a dead optimization is **invisible** — the scan fallback returns the right result and every value test stays green. Measured in `test_lowering.py`: **665 value assertions vs 42 engagement assertions**.

`assert_col_stats(g, query, served=..., outcomes={"edges.s": "insufficient"})` makes an engagement pin a one-liner, and refuses to pass vacuously when no consult was reached.

## Why it reads the trace instead of monkeypatching

The usual approach — patch a private callee, count calls — **fails open**. If another module did `from .gfql_fast_paths import X` it holds its own reference, so patching the definition site never intercepts: the pin cannot fail, and the silence reads like a dead code path. I produced exactly that false negative while auditing this stack (`gfql_unified.py:568` imports `_execute_two_hop_count_fast_path` directly). Reading the public trace observes the decision where it is made and survives renames of the private callees.

Audited the existing pins while here: **0 of 8** patched names are bypassed, so what we have is sound — the gap is coverage, not validity.

## Pins

The existing trace tests now dogfood the helper, plus a self-test asserting the helper **fails** when the optimization did not fire — an engagement pin that cannot fail is worse than none.

Next on the stack: extend the trace to the other fast paths, then re-run the engagement audit properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF7uRZLKZaD6Q9FGWSmyXi