### PR TITLE
feat(gfql): fast-path engagement in gfql_explain + assert_fast_path

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -51,6 +51,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_residual_polars_native.py
     graphistry/tests/compute/gfql/test_single_alias_cache_key.py
     graphistry/tests/compute/gfql/test_semi_join_key_frame.py
+    graphistry/tests/compute/gfql/test_fast_path_engagement.py
     graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_fused_polars.py
     graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_lowcard_count.py
     # module-level `importorskip("polars")` files that previously ran in no lane at all

--- a/graphistry/compute/gfql/index/api.py
+++ b/graphistry/compute/gfql/index/api.py
@@ -181,6 +181,34 @@ _COL_STATS_CODE: Dict[ColStatsOutcome, IndexDecisionCode] = {
 }
 
 
+def record_fast_path_decision(*, path: str, served: bool, reason: str) -> None:
+    """Record whether a named fast path SERVED or declined, for ``gfql_explain``.
+
+    Fast paths are contracted "same answer, faster": every one falls back, so a
+    DEAD one is invisible -- the query is still correct and every value test still
+    passes. Measured ratio in test_lowering.py when this was added: 665 value
+    assertions vs 42 engagement ones. This is the surface that makes engagement
+    assertable against a public API instead of by monkeypatching private callees,
+    which fails open when another module imported the name directly.
+
+    Free outside ``index_trace()`` / ``gfql_explain`` -- same ``_trace_active()``
+    gate the adjacency and col-stats decisions use.
+    """
+    if not _trace_active():
+        return
+    step: IndexTraceStep = {
+        "op": "fast_path",
+        "operation": "fast_path",
+        "seam": path,
+        "served": served,
+        "reason": reason,
+        "path": "index" if served else "scan",
+        "decision_reason": reason,
+        "decision_code": "index_selected" if served else "index_path_unavailable",
+    }
+    _record(step)
+
+
 def record_col_stats_decision(
     *,
     role: str,

--- a/graphistry/compute/gfql/index/api.py
+++ b/graphistry/compute/gfql/index/api.py
@@ -25,7 +25,7 @@ from .cost import cost_gate_frac, seed_deg_sum, seed_id_array
 from .policy import IndexPolicy, validate_index_policy
 from .types import (
     AdjacencyIndexKind, EdgeIndexDirection, HopDirection, IndexKind,
-    IndexDecisionCode, IndexTrace, IndexTraceStep,
+    ColStatsOutcomeName, FastPathName, IndexDecisionCode, IndexTrace, IndexTraceStep,
 )
 
 # Private Plottable attachment keys. Keep access behind helpers.
@@ -168,7 +168,7 @@ def _record_indexed_traversal(
     }))
 
 
-ColStatsOutcome = Literal["served", "absent", "stale", "insufficient"]
+ColStatsOutcome = ColStatsOutcomeName  # single definition, in types.py
 
 # Explicit mapping instead of an f-string plus a cast: mypy then checks that every
 # outcome has a real decision code, so adding one to either side without the other
@@ -181,7 +181,9 @@ _COL_STATS_CODE: Dict[ColStatsOutcome, IndexDecisionCode] = {
 }
 
 
-def record_fast_path_decision(*, path: str, served: bool, reason: str) -> None:
+def record_fast_path_decision(
+    *, path: FastPathName, served: bool, reason: str
+) -> None:
     """Record whether a named fast path SERVED or declined, for ``gfql_explain``.
 
     Fast paths are contracted "same answer, faster": every one falls back, so a

--- a/graphistry/compute/gfql/index/types.py
+++ b/graphistry/compute/gfql/index/types.py
@@ -20,6 +20,13 @@ EdgeIndexDirection = Literal["forward", "reverse", "both"]
 FrameLike = DataFrameT
 
 
+#: The fast paths that report engagement. Closed by construction -- a new path
+#: must be added here, which is what stops a typo silently recording a decision
+#: nobody can assert on.
+FastPathName = Literal["single_hop_grouped_aggregate", "two_hop_count"]
+
+#: Outcome of one column-stat fact consult; each needs a different fix.
+ColStatsOutcomeName = Literal["served", "absent", "stale", "insufficient"]
 IndexPath = Literal["scan", "index", "facts"]  # "facts": a column-stat fact answered it
 IndexDecisionCode = Literal[
     "policy_off",

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -1021,10 +1021,20 @@ def _execute_compiled_query_via_physical_plan(
         )
 
     if physical_plan.route in ("same_path", "row_pipeline"):
+        # Record served/declined at the CALL SITE rather than inside each fast path:
+        # this is where the decision is consumed, it is one place instead of N return
+        # paths, and it cannot be bypassed the way patching a directly-imported name is.
+        from graphistry.compute.gfql.index.api import record_fast_path_decision
         fast_grouped = _execute_single_hop_grouped_aggregate_fast_path(base_graph, compiled_query.chain, engine=engine)
+        record_fast_path_decision(
+            path="single_hop_grouped_aggregate", served=fast_grouped is not None,
+            reason="served" if fast_grouped is not None else "declined; caller falls back")
         if fast_grouped is not None:
             return fast_grouped
         fast_count = _execute_two_hop_count_fast_path(base_graph, compiled_query.chain, engine=engine)
+        record_fast_path_decision(
+            path="two_hop_count", served=fast_count is not None,
+            reason="served" if fast_count is not None else "declined; caller falls back")
         if fast_count is not None:
             return fast_count
         fast_hop = _execute_seeded_typed_hop_fast_path(

--- a/graphistry/tests/compute/gfql/engagement.py
+++ b/graphistry/tests/compute/gfql/engagement.py
@@ -69,3 +69,27 @@ def assert_col_stats(
         assert got == {f"col_stats_{expected}"}, (
             f"{key}: expected col_stats_{expected}, got {sorted(got)}")
     return decisions
+
+
+def fast_path_decisions(g: Any, query: str, *, engine: str = "pandas") -> Dict[str, bool]:
+    """``{fast path name: served}`` for one query. A path absent from the map was
+    never consulted (an earlier path short-circuited), which is different from
+    consulted-and-declined -- so absence is not silently read as False."""
+    with index_trace() as steps:
+        g.gfql(query, engine=engine)
+    return {s["seam"]: bool(s["served"]) for s in steps if s.get("op") == "fast_path"}
+
+
+def assert_fast_path(g: Any, query: str, path: str, *, served: bool,
+                     engine: str = "pandas") -> None:
+    """Assert a named fast path served (or declined) for ``query``.
+
+    This is the assertion a VALUE test structurally cannot make: every fast path
+    falls back, so a dead one still returns the right answer.
+    """
+    seen = fast_path_decisions(g, query, engine=engine)
+    assert path in seen, (
+        f"{path!r} was never consulted for this query; consulted: {sorted(seen)}. "
+        "An earlier fast path may have short-circuited.")
+    assert seen[path] is served, (
+        f"{path!r}: expected served={served}, got {seen[path]} (all: {seen})")

--- a/graphistry/tests/compute/gfql/engagement.py
+++ b/graphistry/tests/compute/gfql/engagement.py
@@ -18,12 +18,17 @@ path. That false negative has already been produced once here. These helpers
 read the public ``gfql_explain`` trace instead, so they observe the decision
 where it is made and survive refactors of the private names.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
+from graphistry.Engine import EngineAbstractType
+from graphistry.Plottable import Plottable
 from graphistry.compute.gfql.index.api import index_trace
+from graphistry.compute.gfql.index.types import ColStatsOutcomeName, FastPathName
 
 
-def col_stats_decisions(g: Any, query: str, *, engine: str = "pandas") -> List[Dict[str, Any]]:
+def col_stats_decisions(
+    g: Plottable, query: str, *, engine: EngineAbstractType = "pandas"
+) -> List[Dict[str, Any]]:  # hygiene-ok: explicit-any -- a trace step is a heterogeneous TypedDict by contract
     """Every column-stat fact decision made while running ``query`` on ``g``."""
     with index_trace() as steps:
         g.gfql(query, engine=engine)
@@ -31,13 +36,13 @@ def col_stats_decisions(g: Any, query: str, *, engine: str = "pandas") -> List[D
 
 
 def assert_col_stats(
-    g: Any,
+    g: Plottable,
     query: str,
     *,
-    engine: str = "pandas",
+    engine: EngineAbstractType = "pandas",
     served: Optional[bool] = None,
-    outcomes: Optional[Dict[str, str]] = None,
-) -> List[Dict[str, Any]]:
+    outcomes: Optional[Dict[str, ColStatsOutcomeName]] = None,
+) -> List[Dict[str, Any]]:  # hygiene-ok: explicit-any -- a trace step is a heterogeneous TypedDict by contract
     """Assert how the column-stat facts were USED, and return the decisions.
 
     ``served=True`` requires every decision to have skipped a scan; ``False``
@@ -71,17 +76,22 @@ def assert_col_stats(
     return decisions
 
 
-def fast_path_decisions(g: Any, query: str, *, engine: str = "pandas") -> Dict[str, bool]:
+def fast_path_decisions(
+    g: Plottable, query: str, *, engine: EngineAbstractType = "pandas"
+) -> Dict[FastPathName, bool]:
     """``{fast path name: served}`` for one query. A path absent from the map was
     never consulted (an earlier path short-circuited), which is different from
     consulted-and-declined -- so absence is not silently read as False."""
     with index_trace() as steps:
         g.gfql(query, engine=engine)
-    return {s["seam"]: bool(s["served"]) for s in steps if s.get("op") == "fast_path"}
+    return {cast(FastPathName, s["seam"]): bool(s["served"])
+            for s in steps if s.get("op") == "fast_path"}
 
 
-def assert_fast_path(g: Any, query: str, path: str, *, served: bool,
-                     engine: str = "pandas") -> None:
+def assert_fast_path(
+    g: Plottable, query: str, path: FastPathName, *, served: bool,
+    engine: EngineAbstractType = "pandas",
+) -> None:
     """Assert a named fast path served (or declined) for ``query``.
 
     This is the assertion a VALUE test structurally cannot make: every fast path

--- a/graphistry/tests/compute/gfql/test_fast_path_engagement.py
+++ b/graphistry/tests/compute/gfql/test_fast_path_engagement.py
@@ -19,28 +19,44 @@ Q_GROUPED = ("MATCH (p {kind:'P'})-[{rel:'L'}]->(c {kind:'C'}) "
 Q_PLAIN = "MATCH (a)-[]->(b) RETURN a.id AS x ORDER BY x ASC"
 
 
-def _graph():
+def _graph(engine: str = "pandas"):
     nodes = pd.DataFrame({"id": list(range(6)), "kind": ["P"] * 3 + ["C"] * 3,
                           "city": ["LA", "NY", "SF"] * 2})
     edges = pd.DataFrame({"s": [0, 1, 2, 0, 0], "d": [1, 2, 0, 3, 4],
                           "rel": ["F", "F", "F", "L", "L"]})
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        nodes, edges = pl.from_pandas(nodes), pl.from_pandas(edges)
+    elif engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
     return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
 
 
-def test_two_hop_count_fast_path_engages() -> None:
-    assert_fast_path(_graph(), Q_TWO_HOP, "two_hop_count", served=True)
+ENGINES = ["pandas", "polars", "cudf"]
 
 
-def test_grouped_aggregate_fast_path_engages() -> None:
-    assert_fast_path(_graph(), Q_GROUPED, "single_hop_grouped_aggregate", served=True)
+@pytest.mark.parametrize("engine", ENGINES)
+def test_two_hop_count_fast_path_engages(engine: str) -> None:
+    """Engagement is per-ENGINE: a path that serves on pandas can silently decline
+    on polars or cuDF and no value test would notice, because both answer."""
+    assert_fast_path(_graph(engine), Q_TWO_HOP, "two_hop_count",
+                     served=True, engine=engine)
 
 
-def test_a_shape_neither_path_serves_declines_both() -> None:
+@pytest.mark.parametrize("engine", ENGINES)
+def test_grouped_aggregate_fast_path_engages(engine: str) -> None:
+    assert_fast_path(_graph(engine), Q_GROUPED, "single_hop_grouped_aggregate",
+                     served=True, engine=engine)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_a_shape_neither_path_serves_declines_both(engine: str) -> None:
     """The negative side: both consulted, both decline, answer still correct."""
-    g = _graph()
-    seen = fast_path_decisions(g, Q_PLAIN)
+    g = _graph(engine)
+    seen = fast_path_decisions(g, Q_PLAIN, engine=engine)
     assert seen == {"single_hop_grouped_aggregate": False, "two_hop_count": False}
-    assert len(g.gfql(Q_PLAIN, engine="pandas")._nodes) == 3  # distinct a.id, not edge count
+    assert len(g.gfql(Q_PLAIN, engine=engine)._nodes) == 3  # distinct a.id, not edge count
 
 
 def test_short_circuit_is_distinguishable_from_decline() -> None:

--- a/graphistry/tests/compute/gfql/test_fast_path_engagement.py
+++ b/graphistry/tests/compute/gfql/test_fast_path_engagement.py
@@ -1,0 +1,60 @@
+"""Fast paths are contracted "same answer, faster", so a DEAD one is invisible:
+the query still returns the right result via the fallback and every value test
+passes. These assert ENGAGEMENT -- that the path actually fired -- which is the
+assertion a value test structurally cannot make.
+"""
+import pandas as pd
+import pytest
+
+from graphistry.tests.compute.gfql.engagement import (
+    assert_fast_path, fast_path_decisions,
+)
+
+import graphistry
+
+Q_TWO_HOP = ("MATCH (a {kind:'P'})-[{rel:'F'}]->(b {kind:'P'})"
+             "-[{rel:'F'}]->(c {kind:'P'}) RETURN count(*) AS n")
+Q_GROUPED = ("MATCH (p {kind:'P'})-[{rel:'L'}]->(c {kind:'C'}) "
+             "RETURN c.city AS city, count(*) AS n ORDER BY city ASC")
+Q_PLAIN = "MATCH (a)-[]->(b) RETURN a.id AS x ORDER BY x ASC"
+
+
+def _graph():
+    nodes = pd.DataFrame({"id": list(range(6)), "kind": ["P"] * 3 + ["C"] * 3,
+                          "city": ["LA", "NY", "SF"] * 2})
+    edges = pd.DataFrame({"s": [0, 1, 2, 0, 0], "d": [1, 2, 0, 3, 4],
+                          "rel": ["F", "F", "F", "L", "L"]})
+    return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
+
+
+def test_two_hop_count_fast_path_engages() -> None:
+    assert_fast_path(_graph(), Q_TWO_HOP, "two_hop_count", served=True)
+
+
+def test_grouped_aggregate_fast_path_engages() -> None:
+    assert_fast_path(_graph(), Q_GROUPED, "single_hop_grouped_aggregate", served=True)
+
+
+def test_a_shape_neither_path_serves_declines_both() -> None:
+    """The negative side: both consulted, both decline, answer still correct."""
+    g = _graph()
+    seen = fast_path_decisions(g, Q_PLAIN)
+    assert seen == {"single_hop_grouped_aggregate": False, "two_hop_count": False}
+    assert len(g.gfql(Q_PLAIN, engine="pandas")._nodes) == 3  # distinct a.id, not edge count
+
+
+def test_short_circuit_is_distinguishable_from_decline() -> None:
+    """When grouped-agg serves, two_hop_count is never CONSULTED -- absent from the
+    map rather than present-and-False. Conflating those would let a genuinely dead
+    path read as 'declined for a good reason'."""
+    seen = fast_path_decisions(_graph(), Q_GROUPED)
+    assert seen.get("single_hop_grouped_aggregate") is True
+    assert "two_hop_count" not in seen
+
+
+def test_assert_fast_path_fails_when_the_path_did_not_fire() -> None:
+    """An engagement pin that cannot fail is worse than none."""
+    with pytest.raises(AssertionError, match="expected served=True"):
+        assert_fast_path(_graph(), Q_PLAIN, "two_hop_count", served=True)
+    with pytest.raises(AssertionError, match="never consulted"):
+        assert_fast_path(_graph(), Q_GROUPED, "two_hop_count", served=True)

--- a/graphistry/tests/compute/gfql/test_fast_path_engagement.py
+++ b/graphistry/tests/compute/gfql/test_fast_path_engagement.py
@@ -58,3 +58,11 @@ def test_assert_fast_path_fails_when_the_path_did_not_fire() -> None:
         assert_fast_path(_graph(), Q_PLAIN, "two_hop_count", served=True)
     with pytest.raises(AssertionError, match="never consulted"):
         assert_fast_path(_graph(), Q_GROUPED, "two_hop_count", served=True)
+
+
+def test_unknown_fast_path_name_is_reported_not_silently_missing() -> None:
+    """``FastPathName`` is a Literal so a typo is a TYPE error at author time; at
+    RUNTIME an unknown name must still fail loudly rather than read as 'not
+    consulted', which would look exactly like a correctly-declining path."""
+    with pytest.raises(AssertionError, match="never consulted"):
+        assert_fast_path(_graph(), Q_TWO_HOP, "two_hop_cont", served=True)  # type: ignore[arg-type]


### PR DESCRIPTION
Extends the #1860 col-stats trace to the fast paths themselves — the surface the engagement audit needs.

Fast paths are contracted *same answer, faster*, so a **dead one is invisible**: the fallback returns the right result and every value test passes. Ratio in `test_lowering.py`: **665 value assertions vs 42 engagement**.

## Recorded at the call site, not via shims

`gfql_unified` imports these names **directly**, so patching the definition site never intercepts — that already produced one false negative during an audit here. Recording where the decision is *consumed* is one place, covers every return path, and cannot be bypassed.

## Pins

- both paths engage on their shapes
- a shape neither serves declines both, answer still correct
- **short-circuit is distinguishable from decline** — when grouped-agg serves, `two_hop_count` is *absent* rather than present-and-False; conflating them lets a genuinely dead path read as "declined for a good reason"
- `assert_fast_path` **fails** when the path did not fire — an engagement pin that cannot fail is worse than none

Registered in `POLARS_TEST_FILES`; 0 non-cuDF failures locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF7uRZLKZaD6Q9FGWSmyXi