### PR TITLE
fix(gfql): DAG bindings consume the root graph, deterministic output order (#1923)

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -74,6 +74,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_reentry_caller_graph_immutability.py
     graphistry/tests/compute/gfql/test_rewrite_param_discard.py
     graphistry/tests/compute/test_engine_coercion.py
+    graphistry/tests/compute/test_let_binding_contracts.py
     # index tests exercise the seeded-index hook in the polars hop entry (hop.py) — without
     # them the hook dominates the now-thin file and trips its per-file coverage floor
     graphistry/tests/compute/gfql/index/test_index.py

--- a/graphistry/compute/chain_let.py
+++ b/graphistry/compute/chain_let.py
@@ -5,6 +5,7 @@ from graphistry.Engine import Engine, EngineAbstract, resolve_engine
 from graphistry.Plottable import Plottable
 from graphistry.util import setup_logger
 from .ast import ASTObject, ASTLet, ASTRef, ASTRemoteGraph, ASTNode, ASTEdge, ASTCall
+from .exceptions import ErrorCode, GFQLValidationError
 from .execution_context import ExecutionContext
 from .engine_coercion import ensure_engine_match
 from .gfql.policy import PolicyContext, PolicyException
@@ -35,10 +36,8 @@ def extract_dependencies(ast_obj: Union[ASTObject, 'Chain', 'Plottable']) -> Set
             deps.update(extract_dependencies(op))
     
     elif isinstance(ast_obj, ASTLet):
-        # Nested let is an opaque execution unit — no external dependencies.
-        # Inner bindings are resolved in the inner DAG's own scope.
-        pass
-    
+        deps.update(free_variables(ast_obj))
+
     elif isinstance(ast_obj, Chain):
         # Chain may contain ASTRef operations
         for op in ast_obj.chain:
@@ -51,6 +50,19 @@ def extract_dependencies(ast_obj: Union[ASTObject, 'Chain', 'Plottable']) -> Set
     
     # Other AST types (ASTCall, ASTRemoteGraph) have no dependencies
     return deps
+
+
+def free_variables(dag: ASTLet) -> Set[str]:
+    """Names a let reads from its enclosing scope: inner references minus inner bindings
+
+    :param dag: Let whose bindings are scanned
+    :returns: Set of binding names the let expects its parent scope to provide
+    :rtype: Set[str]
+    """
+    referenced: Set[str] = set()
+    for inner_obj in dag.bindings.values():
+        referenced.update(extract_dependencies(inner_obj))
+    return referenced - set(dag.bindings.keys())
 
 
 def build_dependency_graph(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']]) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
@@ -76,27 +88,35 @@ def build_dependency_graph(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plotta
     return dependencies, dependents
 
 
-def validate_dependencies(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']], 
-                        dependencies: Dict[str, Set[str]]) -> None:
+def validate_dependencies(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']],
+                        dependencies: Dict[str, Set[str]],
+                        enclosing_names: Optional[Set[str]] = None) -> None:
     """Check for missing references and self-cycles
-    
+
     :param bindings: Dictionary of available GraphOperation bindings
     :param dependencies: Dictionary of dependencies per binding
-    :raises ValueError: If missing references or self-cycles found
+    :param enclosing_names: Binding names an enclosing let already provides
+    :raises GFQLValidationError: If missing references or self-cycles found
     """
-    all_names = set(bindings.keys())
-    
+    resolvable = set(bindings.keys()) | (enclosing_names or set())
+
     for name, deps in dependencies.items():
         # Check self-reference
         if name in deps:
-            raise ValueError(f"Self-reference cycle detected: '{name}' depends on itself")
-        
+            raise GFQLValidationError(
+                ErrorCode.E153,
+                f"Self-reference cycle detected: '{name}' depends on itself",
+                field=name,
+            )
+
         # Check missing references
-        missing = deps - all_names
+        missing = deps - resolvable
         if missing:
-            raise ValueError(
+            raise GFQLValidationError(
+                ErrorCode.E151,
                 f"Node '{name}' references undefined nodes: {sorted(missing)}. "
-                f"Available nodes: {sorted(all_names)}"
+                f"Available nodes: {sorted(resolvable)}",
+                field=name,
             )
 
 
@@ -114,7 +134,7 @@ def detect_cycles(dependencies: Dict[str, Set[str]]) -> Optional[List[str]]:
         color[node] = GRAY
         path.append(node)
         
-        for neighbor in dependencies.get(node, set()):
+        for neighbor in sorted(dependencies.get(node, set())):
             if color.get(neighbor, WHITE) == GRAY:
                 # Found cycle - build cycle path
                 cycle_start = path.index(neighbor)
@@ -140,73 +160,95 @@ def detect_cycles(dependencies: Dict[str, Set[str]]) -> Optional[List[str]]:
 def topological_sort(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']],
                     dependencies: Dict[str, Set[str]],
                     dependents: Dict[str, Set[str]]) -> List[str]:
-    """Kahn's algorithm for topological sort"""
+    """Kahn's algorithm for topological sort, ties broken by declaration order"""
+    declaration_order = {name: index for index, name in enumerate(bindings)}
+
     # Calculate in-degrees
     in_degree = {name: len(dependencies.get(name, set())) for name in bindings}
-    
+
     # Start with nodes that have no dependencies
     queue = [name for name, degree in in_degree.items() if degree == 0]
     result = []
-    
+
     while queue:
         # Process node with no remaining dependencies
         current = queue.pop(0)
         result.append(current)
-        
+
         # Update dependents
-        for dependent in dependents.get(current, set()):
+        for dependent in sorted(dependents.get(current, set()), key=declaration_order.__getitem__):
             in_degree[dependent] -= 1
             if in_degree[dependent] == 0:
                 queue.append(dependent)
-    
+
     if len(result) != len(bindings):
         # Cycle detected - use DFS to find it for better error
         cycle = detect_cycles(dependencies)
         if cycle:
-            raise ValueError(
+            raise GFQLValidationError(
+                ErrorCode.E153,
                 f"Circular dependency detected: {' -> '.join(cycle)}. "
-                "Please restructure your DAG to remove cycles."
+                "Please restructure your DAG to remove cycles.",
             )
         else:
             # Should not happen, but be defensive
-            raise ValueError("Failed to determine execution order (possible circular dependency)")
-    
+            raise GFQLValidationError(
+                ErrorCode.E153,
+                "Failed to determine execution order (possible circular dependency)",
+            )
+
     return result
 
 
-def determine_execution_order(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']]) -> List[str]:
+def determine_execution_order(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']],
+                              enclosing_names: Optional[Set[str]] = None) -> List[str]:
     """Determine topological execution order for DAG bindings
-    
+
     Validates dependencies and computes execution order that respects
     all dependencies. Detects cycles and missing references.
-    
+
     :param bindings: Dictionary of name -> GraphOperation bindings
+    :param enclosing_names: Binding names an enclosing let already provides
     :returns: List of binding names in execution order
     :rtype: List[str]
-    :raises ValueError: If cycles detected or references missing
+    :raises GFQLValidationError: If cycles detected or references missing
     """
     # Handle trivial cases
     if not bindings:
         return []
-    if len(bindings) == 1:
-        return list(bindings.keys())
-    
+
     # Build dependency graph
     dependencies, dependents = build_dependency_graph(bindings)
-    
+
     # Validate all references exist
-    validate_dependencies(bindings, dependencies)
-    
+    validate_dependencies(bindings, dependencies, enclosing_names)
+
+    same_scope_dependencies = {name: deps & set(bindings.keys()) for name, deps in dependencies.items()}
+
     # Check for cycles with detailed error
-    cycle = detect_cycles(dependencies)
+    cycle = detect_cycles(same_scope_dependencies)
     if cycle:
-        raise ValueError(
+        raise GFQLValidationError(
+            ErrorCode.E153,
             f"Circular dependency detected: {' -> '.join(cycle)}. "
-            "Please restructure your DAG to remove cycles."
+            "Please restructure your DAG to remove cycles.",
         )
-    
+
     # Compute topological sort
-    return topological_sort(bindings, dependencies, dependents)
+    return topological_sort(bindings, same_scope_dependencies, dependents)
+
+
+def keeps_type_across_binding_boundary(err: BaseException) -> bool:
+    """Whether a binding failure reaches the caller unwrapped
+
+    Engine-capability declines and GFQL validation errors carry a contract the
+    caller dispatches on; a RuntimeError wrapper would erase it.
+
+    :param err: Exception raised while executing a binding
+    :returns: True if the error propagates as-is
+    :rtype: bool
+    """
+    return isinstance(err, (NotImplementedError, GFQLValidationError))
 
 
 def execute_node(name: str, ast_obj: Union[ASTObject, 'Chain', 'Plottable'], g: Plottable,
@@ -223,14 +265,14 @@ def execute_node(name: str, ast_obj: Union[ASTObject, 'Chain', 'Plottable'], g: 
 
     :param name: Binding name for this node
     :param ast_obj: GraphOperation to execute
-    :param g: Input graph
+    :param g: Root graph every binding kind filters from
     :param context: Execution context for storing/retrieving results
     :param engine: Engine to use (pandas/cudf)
     :param policy: Optional policy dictionary with preload/postload/precall/postcall hooks
     :param global_query: The global query AST for policy context
     :returns: Resulting Plottable
     :rtype: Plottable
-    :raises ValueError: If reference not found in context
+    :raises GFQLValidationError: If reference not found in context
     :raises NotImplementedError: For unsupported types
     """
     logger.debug("Executing node '%s' of type %s", name, type(ast_obj).__name__)
@@ -241,19 +283,18 @@ def execute_node(name: str, ast_obj: Union[ASTObject, 'Chain', 'Plottable'], g: 
         # - reads fall through to parent (inner can see outer bindings)
         # - writes stay local (inner bindings don't leak to outer scope)
         child_ctx = context.child_context()
-        # Pass the original graph (not accumulated_result) so the inner let
-        # filters independently, same as Chain/ASTNode bindings in the outer scope.
-        original_g = context.get_binding('__original_graph__') if context.has_binding('__original_graph__') else g
-        result = chain_let_impl(original_g, ast_obj, EngineAbstract(engine.value), policy=policy, context=child_ctx)
+        result = chain_let_impl(g, ast_obj, EngineAbstract(engine.value), policy=policy, context=child_ctx)
     elif isinstance(ast_obj, ASTRef):
         # Resolve reference from context
         try:
             referenced_result = context.get_binding(ast_obj.ref)
         except KeyError as e:
             available = sorted(context.get_all_bindings().keys())
-            raise ValueError(
+            raise GFQLValidationError(
+                ErrorCode.E151,
                 f"Node '{name}' references '{ast_obj.ref}' which has not been executed yet. "
-                f"Available bindings: {available}"
+                f"Available bindings: {available}",
+                field=name,
             ) from e
 
         # Execute the chain on the referenced result
@@ -272,16 +313,9 @@ def execute_node(name: str, ast_obj: Union[ASTObject, 'Chain', 'Plottable'], g: 
         else:
             # Empty chain - just return the referenced result
             result = referenced_result
-    elif isinstance(ast_obj, ASTNode):
-        # ASTNode operates on the original graph (unless accessed via ASTRef)
-        original_g = context.get_binding('__original_graph__') if context.has_binding('__original_graph__') else g
+    elif isinstance(ast_obj, (ASTNode, ASTEdge)):
         from .chain import chain as chain_impl
-        result = chain_impl(original_g, [ast_obj], EngineAbstract(engine.value), policy=policy, context=context)
-    elif isinstance(ast_obj, ASTEdge):
-        # ASTEdge operates on the original graph (unless accessed via ASTRef)
-        original_g = context.get_binding('__original_graph__') if context.has_binding('__original_graph__') else g
-        from .chain import chain as chain_impl
-        result = chain_impl(original_g, [ast_obj], EngineAbstract(engine.value), policy=policy, context=context)
+        result = chain_impl(g, [ast_obj], EngineAbstract(engine.value), policy=policy, context=context)
     elif isinstance(ast_obj, ASTRemoteGraph):
         # Create a new plottable bound to the remote dataset_id
         # This doesn't fetch the data immediately - it just creates a reference
@@ -357,12 +391,8 @@ def execute_node(name: str, ast_obj: Union[ASTObject, 'Chain', 'Plottable'], g: 
         # Check if it's a Chain or Plottable
         from graphistry.compute.chain import Chain
         if isinstance(ast_obj, Chain):
-            # Execute the chain operations
-            # For DAG context: Chain should filter from the original graph independently
-            # Get the original graph from the context (stored at initialization)
             from .chain import chain as chain_impl
-            original_g = context.get_binding('__original_graph__') if context.has_binding('__original_graph__') else g
-            result = chain_impl(original_g, ast_obj.chain, EngineAbstract(engine.value), policy=policy, context=context)
+            result = chain_impl(g, ast_obj.chain, EngineAbstract(engine.value), policy=policy, context=context)
         elif isinstance(ast_obj, Plottable):
             # Direct Plottable instance - just return it
             result = ast_obj
@@ -396,7 +426,7 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
     :rtype: Plottable
     :raises TypeError: If dag is not an ASTLet
     :raises RuntimeError: If node execution fails
-    :raises ValueError: If output binding not found
+    :raises GFQLValidationError: If output binding not found
     """
     if isinstance(engine, str):
         engine = EngineAbstract(engine)
@@ -419,15 +449,12 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
     if context is None:
         context = ExecutionContext()
 
-    # Store original graph for independent Chain filtering
-    context.set_binding('__original_graph__', g)
-
     # Handle empty let bindings
     if not dag.bindings:
         return g
-    
+
     # Determine execution order
-    order = determine_execution_order(dag.bindings)
+    order = determine_execution_order(dag.bindings, set(context.get_all_bindings().keys()))
     logger.debug("DAG execution order: %s", order)
 
     # Build dependency graph for binding hooks
@@ -437,7 +464,7 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
     result = None
     error = None
     success = False
-    last_result = None
+    last_result: Plottable = g
 
     try:
         # Prelet hook - fires BEFORE any bindings execute
@@ -466,9 +493,6 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
                 raise
 
         # Execute nodes in topological order
-        # Start with the original graph and accumulate all binding columns
-        accumulated_result = g
-
         for binding_index, node_name in enumerate(order):
             ast_obj = dag.bindings[node_name]
             logger.debug("Executing node '%s' in DAG", node_name)
@@ -513,12 +537,10 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
             context.push_path(f"binding:{node_name}")
 
             try:
-                # Execute node - this adds the binding name as a column
-                binding_result = execute_node(node_name, ast_obj, accumulated_result, context, engine_concrete, policy, dag)
+                binding_result = execute_node(node_name, ast_obj, g, context, engine_concrete, policy, dag)
                 binding_success = True
 
-                # Accumulate the new column(s) onto our result
-                accumulated_result = binding_result
+                last_result = binding_result
                 result = binding_result
 
             except Exception as e:
@@ -535,9 +557,7 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
                 policy_error = None
                 if policy and 'postletbinding' in policy:
 
-                    # Extract stats from binding result (if success) or current graph (if error)
-                    # Cast: if binding_success=True, binding_result is guaranteed to be a Plottable
-                    graph_for_stats = cast(Plottable, binding_result) if binding_success else accumulated_result
+                    graph_for_stats = binding_result if binding_result is not None else last_result
                     stats = extract_graph_stats(graph_for_stats)
 
                     current_path = context.operation_path
@@ -580,10 +600,7 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
                 else:
                     raise policy_error
             elif binding_error is not None:
-                # Honest engine-capability declines propagate as-is so a DAG caller can catch
-                # NotImplementedError and retry on engine='pandas' (matching the chain surface);
-                # don't bury them in a RuntimeError.
-                if isinstance(binding_error, NotImplementedError):
+                if keeps_type_across_binding_boundary(binding_error):
                     raise binding_error
                 # Wrap other failures in RuntimeError with context
                 raise RuntimeError(
@@ -591,19 +608,16 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
                     f"Error: {type(binding_error).__name__}: {str(binding_error)}"
                 ) from binding_error
 
-        last_result = accumulated_result
-
         # Return requested output or last executed result
         if output is not None:
             if output not in context.get_all_bindings():
-                # Filter out internal bindings from the error message
-                available = sorted([
-                    k for k in context.get_all_bindings().keys()
-                    if not k.startswith('__')
-                ])
-                raise ValueError(
+                available = sorted(context.get_all_bindings().keys())
+                raise GFQLValidationError(
+                    ErrorCode.E151,
                     f"Output binding '{output}' not found. "
-                    f"Available bindings: {available}"
+                    f"Available bindings: {available}",
+                    field='output',
+                    value=output,
                 )
             result = context.get_binding(output)
         else:

--- a/graphistry/compute/chain_let.py
+++ b/graphistry/compute/chain_let.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set, List, Optional, Tuple, Union, cast, TYPE_CHECKING, Callable, Any
+from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union, cast, TYPE_CHECKING, Callable, Any
 from typing_extensions import Literal
 import pandas as pd
 from graphistry.Engine import Engine, EngineAbstract, resolve_engine
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
     from graphistry.compute.chain import Chain
 
 logger = setup_logger(__name__)
+
+
+def in_declaration_order(
+    names: Iterable[str], declaration_order: Mapping[str, int]
+) -> List[str]:
+    unranked = len(declaration_order)
+    return sorted(names, key=lambda name: (declaration_order.get(name, unranked), name))
+
+
+def declaration_order_of(bindings: Mapping[str, object]) -> Dict[str, int]:
+    return {name: index for index, name in enumerate(bindings)}
+
+
+def executed_binding_names(context: ExecutionContext) -> List[str]:
+    return sorted(context.get_all_bindings().keys())
 
 
 def extract_dependencies(ast_obj: Union[ASTObject, 'Chain', 'Plottable']) -> Set[str]:
@@ -120,7 +135,10 @@ def validate_dependencies(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottab
             )
 
 
-def detect_cycles(dependencies: Dict[str, Set[str]]) -> Optional[List[str]]:
+def detect_cycles(
+    dependencies: Dict[str, Set[str]],
+    declaration_order: Optional[Mapping[str, int]] = None,
+) -> Optional[List[str]]:
     """Use DFS to detect cycles and return the cycle path if found
     
     :param dependencies: Dictionary mapping nodes to their dependencies
@@ -128,13 +146,14 @@ def detect_cycles(dependencies: Dict[str, Set[str]]) -> Optional[List[str]]:
     :rtype: Optional[List[str]]
     """
     WHITE, GRAY, BLACK = 0, 1, 2
+    order = declaration_order or {}
     color = {node: WHITE for node in dependencies}
     
     def dfs(node: str, path: List[str]) -> Optional[List[str]]:
         color[node] = GRAY
         path.append(node)
         
-        for neighbor in sorted(dependencies.get(node, set())):
+        for neighbor in in_declaration_order(dependencies.get(node, set()), order):
             if color.get(neighbor, WHITE) == GRAY:
                 # Found cycle - build cycle path
                 cycle_start = path.index(neighbor)
@@ -148,7 +167,7 @@ def detect_cycles(dependencies: Dict[str, Set[str]]) -> Optional[List[str]]:
         color[node] = BLACK
         return None
     
-    for node in dependencies:
+    for node in in_declaration_order(dependencies, order):
         if color[node] == WHITE:
             cycle = dfs(node, [])
             if cycle:
@@ -161,7 +180,7 @@ def topological_sort(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']]
                     dependencies: Dict[str, Set[str]],
                     dependents: Dict[str, Set[str]]) -> List[str]:
     """Kahn's algorithm for topological sort, ties broken by declaration order"""
-    declaration_order = {name: index for index, name in enumerate(bindings)}
+    declaration_order = declaration_order_of(bindings)
 
     # Calculate in-degrees
     in_degree = {name: len(dependencies.get(name, set())) for name in bindings}
@@ -176,14 +195,14 @@ def topological_sort(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plottable']]
         result.append(current)
 
         # Update dependents
-        for dependent in sorted(dependents.get(current, set()), key=declaration_order.__getitem__):
+        for dependent in in_declaration_order(dependents.get(current, set()), declaration_order):
             in_degree[dependent] -= 1
             if in_degree[dependent] == 0:
                 queue.append(dependent)
 
     if len(result) != len(bindings):
         # Cycle detected - use DFS to find it for better error
-        cycle = detect_cycles(dependencies)
+        cycle = detect_cycles(dependencies, declaration_order)
         if cycle:
             raise GFQLValidationError(
                 ErrorCode.E153,
@@ -226,7 +245,7 @@ def determine_execution_order(bindings: Dict[str, Union[ASTObject, 'Chain', 'Plo
     same_scope_dependencies = {name: deps & set(bindings.keys()) for name, deps in dependencies.items()}
 
     # Check for cycles with detailed error
-    cycle = detect_cycles(same_scope_dependencies)
+    cycle = detect_cycles(same_scope_dependencies, declaration_order_of(bindings))
     if cycle:
         raise GFQLValidationError(
             ErrorCode.E153,
@@ -289,7 +308,7 @@ def execute_node(name: str, ast_obj: Union[ASTObject, 'Chain', 'Plottable'], g: 
         try:
             referenced_result = context.get_binding(ast_obj.ref)
         except KeyError as e:
-            available = sorted(context.get_all_bindings().keys())
+            available = executed_binding_names(context)
             raise GFQLValidationError(
                 ErrorCode.E151,
                 f"Node '{name}' references '{ast_obj.ref}' which has not been executed yet. "
@@ -611,7 +630,7 @@ def chain_let_impl(g: Plottable, dag: ASTLet,
         # Return requested output or last executed result
         if output is not None:
             if output not in context.get_all_bindings():
-                available = sorted(context.get_all_bindings().keys())
+                available = executed_binding_names(context)
                 raise GFQLValidationError(
                     ErrorCode.E151,
                     f"Output binding '{output}' not found. "

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -875,6 +875,16 @@ def _try_indexed_middle_polars(
     return try_indexed_connected_bindings_state(g, middle, engine=engine), True
 
 
+def _bound_edge_endpoints(g: Plottable) -> Tuple[str, str]:
+    """The graph's (source, destination) columns; a row-pipeline call() result leaves them unbound."""
+    if g._source is None or g._destination is None:
+        raise NotImplementedError(
+            "polars chain engine does not yet support traversing a graph with unbound edge "
+            "endpoints (e.g. a call() row-pipeline result); use engine='pandas' for this chain."
+        )
+    return g._source, g._destination
+
+
 def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = None) -> Plottable:
     import polars as pl
     from graphistry.compute.chain import Chain
@@ -886,6 +896,8 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
     if len(ops) == 0:
         return self
 
+    edge_src, edge_dst = _bound_edge_endpoints(self)
+
     # Node-only fast path: single MATCH (n) — the dominant tabular/viz/crossfilter shape.
     # Result is just the filtered node table + empty edges, so skip forward/backward/combine +
     # collect_all, whose fixed cost dominates at the small sizes this shape runs at.
@@ -895,7 +907,7 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
         op0 = ops[0]
         g0 = ensure_nodes_polars(self)
         nc = g0._node
-        assert nc is not None and g0._source is not None and g0._destination is not None
+        assert nc is not None
         nodes = filter_by_dict_polars(g0._nodes, op0.filter_dict)
         if start_nodes is not None:
             from graphistry.Engine import Engine as _E, df_to_engine as _d2e
@@ -903,7 +915,7 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
             nodes = _semi(nodes, seed, nc, nc)
         if op0._name is not None:
             nodes = nodes.with_columns(pl.lit(True).alias(op0._name))
-        return g0.nodes(nodes, nc).edges(g0._edges.clear(), g0._source, g0._destination)
+        return g0.nodes(nodes, nc).edges(g0._edges.clear(), edge_src, edge_dst)
 
     if isinstance(ops[0], ASTEdge):
         ops = [ASTNode()] + ops

--- a/graphistry/tests/compute/test_call_operations.py
+++ b/graphistry/tests/compute/test_call_operations.py
@@ -309,7 +309,10 @@ class TestCallInDAG:
             .nodes(nodes_df)\
             .bind(source='source', destination='target', node='node')
     
-    def test_call_in_dag(self, sample_graph):
+    #: Undirected incident-edge count over the fixture's 0->1, 1->2, 2->0, 2->3, 3->0.
+    ROOT_DEGREE = {0: 3, 1: 2, 2: 3, 3: 2}
+
+    def test_call_in_dag_reads_the_root_graph_not_the_preceding_binding(self, sample_graph):
         dag = ASTLet({
             'filtered': Chain([n({'type': 'user'})]),
             'with_degrees': ASTCall('get_degrees', {'col': 'degree'})
@@ -317,9 +320,20 @@ class TestCallInDAG:
 
         result = chain_let_impl(sample_graph, dag, EngineAbstract.PANDAS)
 
-        assert 'degree' in result._nodes.columns
-        assert len(result._nodes) == 3  # Only 'user' nodes
-    
+        assert dict(zip(result._nodes['node'], result._nodes['degree'])) == self.ROOT_DEGREE
+
+    def test_call_in_dag_leaves_a_sibling_filter_binding_alone(self, sample_graph):
+        dag = ASTLet({
+            'filtered': Chain([n({'type': 'user'})]),
+            'with_degrees': ASTCall('get_degrees', {'col': 'degree'})
+        })
+
+        result = chain_let_impl(sample_graph, dag, EngineAbstract.PANDAS, output='filtered')
+
+        assert sorted(result._nodes['node'].tolist()) == [0, 1, 3]
+        assert 'degree' not in result._nodes.columns
+
+
     def test_multiple_calls(self, sample_graph):
         dag1 = ASTLet({
             'with_degrees': ASTCall('get_degrees', {'col': 'deg'})

--- a/graphistry/tests/compute/test_chain_let.py
+++ b/graphistry/tests/compute/test_chain_let.py
@@ -14,7 +14,9 @@ from graphistry.compute.chain_let import (
     detect_cycles, determine_execution_order
 )
 from graphistry.compute.execution_context import ExecutionContext
-from graphistry.compute.exceptions import GFQLTypeError, GFQLSyntaxError, ErrorCode
+from graphistry.compute.exceptions import (
+    GFQLTypeError, GFQLSyntaxError, GFQLValidationError, ErrorCode
+)
 from graphistry.tests.test_compute import CGFull
 
 
@@ -44,12 +46,20 @@ class TestChainDagHelpers:
         deps = extract_dependencies(nested)
         assert deps == {'a', 'b'}
 
-        # Nested ASTLet is an opaque unit — no external dependencies
+    def test_extract_dependencies_nested_let_reports_free_variables(self):
+        """A nested let depends on the names it reads from the enclosing scope"""
         dag = ASTLet({
             'inner': ASTRef('outer', [n()])
         })
-        deps = extract_dependencies(dag)
-        assert deps == set(), "Nested ASTLet should be opaque (no external deps)"
+        assert extract_dependencies(dag) == {'outer'}
+
+    def test_extract_dependencies_nested_let_hides_own_bindings(self):
+        """Names a nested let binds itself are not dependencies of the enclosing scope"""
+        dag = ASTLet({
+            'own': n(),
+            'inner': ASTRef('own', [n()])
+        })
+        assert extract_dependencies(dag) == set()
     
     def test_build_dependency_graph(self):
         """Test building dependency and dependent mappings"""
@@ -89,9 +99,10 @@ class TestChainDagHelpers:
         }
         dependencies = {'a': {'missing'}}
         
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             validate_dependencies(bindings, dependencies)
-        
+
+        assert exc_info.value.code == ErrorCode.E151
         assert "references undefined nodes: ['missing']" in str(exc_info.value)
         assert "Available nodes: ['a']" in str(exc_info.value)
     
@@ -102,9 +113,10 @@ class TestChainDagHelpers:
         }
         dependencies = {'a': {'a'}}
         
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             validate_dependencies(bindings, dependencies)
-        
+
+        assert exc_info.value.code == ErrorCode.E153
         assert "Self-reference cycle detected: 'a' depends on itself" in str(exc_info.value)
     
     def test_detect_cycles_no_cycle(self):
@@ -231,10 +243,10 @@ class TestExecutionContext:
         # Create ASTRef that references non-existent binding
         chain_ref = ASTRef('missing_ref', [])
         
-        # Should raise ValueError with helpful message
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             execute_node('test', chain_ref, g, context, Engine.PANDAS)
-        
+
+        assert exc_info.value.code == ErrorCode.E151
         assert "references 'missing_ref' which has not been executed yet" in str(exc_info.value)
         assert "Available bindings: []" in str(exc_info.value)
     
@@ -582,9 +594,10 @@ class TestErrorHandling:
         })
         
         g = CGFull().edges(pd.DataFrame({'s': ['x'], 'd': ['y']}), 's', 'd')
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             g.gfql(dag)
-        
+
+        assert exc_info.value.code == ErrorCode.E153
         error_msg = str(exc_info.value)
         assert "Circular dependency detected" in error_msg
         assert "->" in error_msg  # Shows the cycle path
@@ -620,9 +633,10 @@ class TestErrorHandling:
         })
         
         g = CGFull().edges(pd.DataFrame({'s': ['x'], 'd': ['y']}), 's', 'd')
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             g.gfql(dag)
-        
+
+        assert exc_info.value.code == ErrorCode.E151
         error_msg = str(exc_info.value)
         assert "references undefined nodes: ['data3']" in error_msg
         assert "Available nodes: ['data1', 'data2', 'result']" in error_msg
@@ -731,8 +745,9 @@ class TestExecutionMechanics:
             'ref_fail': ASTRef('node1', [])  # Should fail - node1 not in this context
         })
         
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             g.gfql(dag2)
+        assert exc_info.value.code == ErrorCode.E151
         assert "references undefined nodes: ['node1']" in str(exc_info.value)
     
     def test_execution_order_logging(self):
@@ -1290,9 +1305,10 @@ class TestChainDagInternal:
         g = CGFull().edges(pd.DataFrame({'s': ['a'], 'd': ['b']}), 's', 'd')
         dag = ASTLet({'node1': Chain([n()])})
         
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(GFQLValidationError) as exc_info:
             g.gfql(dag, output='missing')
-        
+
+        assert exc_info.value.code == ErrorCode.E151
         error_msg = str(exc_info.value)
         assert "Output binding 'missing' not found" in error_msg
         assert "Available bindings: ['node1']" in error_msg
@@ -1492,7 +1508,7 @@ class TestNestedLetScopeIsolation:
             'inner': ASTLet({'secret': self._persons()}),
             'bad': ASTRef('secret', [])
         })
-        with pytest.raises(ValueError, match="references undefined nodes"):
+        with pytest.raises(GFQLValidationError, match="references undefined nodes"):
             g.gfql(dag)
 
     def test_sibling_inner_lets_same_binding_names_no_collision(self):
@@ -1592,7 +1608,7 @@ class TestNestedLetScopeIsolation:
             'left': ASTLet({'people': self._persons()}),
             'right': ASTLet({'bad': ASTRef('people', [])}),
         })
-        with pytest.raises((ValueError, RuntimeError)):
+        with pytest.raises(GFQLValidationError, match="references undefined nodes"):
             g.gfql(dag)
 
     def test_inner_ref_to_not_yet_executed_outer_fails(self):
@@ -1602,7 +1618,7 @@ class TestNestedLetScopeIsolation:
             'inner': ASTLet({'bad': ASTRef('outer_late', [])}),
             'outer_late': ASTRef('inner', [])
         })
-        with pytest.raises((ValueError, RuntimeError, KeyError)):
+        with pytest.raises(GFQLValidationError, match="Circular dependency detected"):
             g.gfql(dag)
 
     # ==================================================================

--- a/graphistry/tests/compute/test_let_binding_contracts.py
+++ b/graphistry/tests/compute/test_let_binding_contracts.py
@@ -1,0 +1,323 @@
+"""Contracts a ``let()`` DAG binding must satisfy regardless of how the bindings dict is written.
+
+Issue #1923.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import Dict, List, Tuple
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.Plottable import Plottable
+from graphistry.compute.typing import DataFrameT
+from graphistry.compute.ast import ASTLet, ASTRef, call, n
+from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError, GFQLValidationError
+
+ENGINES: Tuple[str, ...] = ("pandas", "polars")
+
+NODES = pd.DataFrame({
+    "id": ["a", "b", "c", "d", "e"],
+    "type": ["person", "person", "company", "person", "company"],
+})
+EDGES = pd.DataFrame({
+    "s": ["a", "b", "a", "d", "c"],
+    "d": ["b", "c", "c", "a", "e"],
+})
+
+#: Hand-computed from EDGES. Undirected incident-edge count per node.
+ROOT_DEGREE: Dict[str, int] = {"a": 3, "b": 2, "c": 3, "d": 1, "e": 1}
+#: Hand-computed from EDGES. Incoming-edge count per node.
+ROOT_DEGREE_IN: Dict[str, int] = {"a": 1, "b": 1, "c": 2, "d": 0, "e": 1}
+ROOT_NODE_COUNT = 5
+ROOT_EDGE_COUNT = 5
+PERSON_IDS = ["a", "b", "d"]
+
+
+def _frame(engine: str, df: pd.DataFrame) -> DataFrameT:
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        return pl.from_pandas(df)
+    return df
+
+
+def _graph(engine: str) -> Plottable:
+    return graphistry.nodes(_frame(engine, NODES), "id").edges(
+        _frame(engine, EDGES), "s", "d"
+    )
+
+
+def _to_pandas(df: DataFrameT) -> pd.DataFrame:
+    return df if "pandas" in type(df).__module__ else df.to_pandas()
+
+
+def _node_column(g: Plottable, col: str) -> Dict[str, int]:
+    nodes = _to_pandas(g._nodes)
+    return dict(zip(nodes["id"], nodes[col]))
+
+
+def _node_ids(g: Plottable) -> List[str]:
+    return sorted(_to_pandas(g._nodes)["id"].tolist())
+
+
+# --- Every binding kind filters from the DAG's root graph (#1923 F2)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_call_get_degrees_binding_reads_root_graph_not_the_previous_binding(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"flt": n({"type": "person"}), "deg": call("get_degrees")}),
+        output="deg",
+        engine=engine,
+    )
+    assert _node_column(result, "degree") == ROOT_DEGREE
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_call_get_indegrees_binding_reads_root_graph_not_the_previous_binding(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"flt": n({"type": "person"}), "deg": call("get_indegrees")}),
+        output="deg",
+        engine=engine,
+    )
+    assert _node_column(result, "degree_in") == ROOT_DEGREE_IN
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_call_hop_binding_reads_root_graph_not_the_previous_binding(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"flt": n({"type": "person"}), "hopped": call("hop", {"hops": 1})}),
+        output="hopped",
+        engine=engine,
+    )
+    assert _node_ids(result) == sorted(NODES["id"].tolist())
+    assert len(result._edges) == ROOT_EDGE_COUNT
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_call_count_table_binding_reads_root_graph_not_the_previous_binding(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"flt": n({"type": "person"}), "cnt": call("count_table")}),
+        output="cnt",
+        engine=engine,
+    )
+    assert _to_pandas(result._nodes)["count(*)"].tolist() == [ROOT_NODE_COUNT]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_call_after_call_bindings_do_not_accumulate_each_others_columns(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"first": call("get_degrees"), "second": call("get_indegrees")}),
+        output="second",
+        engine=engine,
+    )
+    assert _node_column(result, "degree_in") == ROOT_DEGREE_IN
+    assert "degree" not in _to_pandas(result._nodes).columns
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("output", ["deg", "flt"])
+def test_reordering_independent_binding_keys_does_not_change_answers(engine: str, output: str) -> None:
+    flt_first = ASTLet({"flt": n({"type": "person"}), "deg": call("get_degrees")})
+    deg_first = ASTLet({"deg": call("get_degrees"), "flt": n({"type": "person"})})
+
+    g = _graph(engine)
+    assert _node_ids(g.gfql(flt_first, output=output, engine=engine)) == \
+        _node_ids(g.gfql(deg_first, output=output, engine=engine))
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_filter_binding_is_unaffected_by_a_sibling_call_binding(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"flt": n({"type": "person"}), "deg": call("get_degrees")}),
+        output="flt",
+        engine=engine,
+    )
+    assert _node_ids(result) == PERSON_IDS
+    assert "degree" not in _to_pandas(result._nodes).columns
+
+
+# --- Default output is the last declared binding, in every process (#1923 F1)
+
+_SIBLING_ORDER_PROGRAM = """
+import sys
+import pandas as pd
+import graphistry
+from graphistry.compute.ast import ASTLet, ASTRef, n
+
+engine = sys.argv[1]
+nodes = pd.DataFrame({'id': ['a', 'b', 'c', 'd', 'e'], 'k': ['A', 'B', 'C', 'A', 'B']})
+edges = pd.DataFrame({'s': ['a', 'b'], 'd': ['b', 'c']})
+if engine == 'polars':
+    import polars as pl
+    nodes, edges = pl.from_pandas(nodes), pl.from_pandas(edges)
+g = graphistry.nodes(nodes, 'id').edges(edges, 's', 'd')
+result = g.gfql(ASTLet({
+    'root': n({}),
+    'q1': ASTRef('root', [n({'k': 'A'})]),
+    'q2': ASTRef('root', [n({'k': 'B'})]),
+    'q3': ASTRef('root', [n({'k': 'C'})]),
+}), engine=engine)
+ids = result._nodes['id']
+print(','.join(sorted(ids.to_list() if hasattr(ids, 'to_list') else ids.tolist())))
+"""
+
+#: ``q3`` is declared last and every sibling is ready at the same time, so ``q3`` is the answer.
+_SIBLING_ORDER_ANSWER = "c"
+
+
+def _importable_root() -> str:
+    """Directory to put on the child's path so it imports THIS checkout of graphistry."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(graphistry.__file__)))
+
+
+def _run_sibling_order(engine: str, hash_seed: str) -> str:
+    root = _importable_root()
+    env = dict(os.environ, PYTHONHASHSEED=hash_seed, PYTHONPATH=root)
+    completed = subprocess.run(
+        [sys.executable, "-c", _SIBLING_ORDER_PROGRAM, engine],
+        cwd=root, env=env, capture_output=True, text=True, timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    return completed.stdout.strip()
+
+
+@pytest.mark.parametrize("hash_seed", ["0", "1", "2", "3", "7", "13"])
+def test_default_output_is_the_last_declared_binding_under_every_hash_seed(hash_seed: str) -> None:
+    assert _run_sibling_order("pandas", hash_seed) == _SIBLING_ORDER_ANSWER
+
+
+@pytest.mark.parametrize("hash_seed", ["0", "1", "7"])
+def test_default_output_is_the_last_declared_binding_under_every_hash_seed_polars(hash_seed: str) -> None:
+    pytest.importorskip("polars")
+    assert _run_sibling_order("polars", hash_seed) == _SIBLING_ORDER_ANSWER
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_default_output_prefers_declaration_order_over_name_order(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({
+            "root": n({}),
+            "zebra": ASTRef("root", [n({"type": "company"})]),
+            "alpha": ASTRef("root", [n({"type": "person"})]),
+        }),
+        engine=engine,
+    )
+    assert _node_ids(result) == PERSON_IDS
+
+
+# --- The DAG root is not reachable through the user binding namespace (#1923 F3)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_binding_named_original_graph_does_not_reroot_later_bindings(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({"__original_graph__": n({"type": "company"}), "x": n({})}),
+        output="x",
+        engine=engine,
+    )
+    assert _node_ids(result) == sorted(NODES["id"].tolist())
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_root_graph_is_not_addressable_as_an_output_binding(engine: str) -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _graph(engine).gfql(ASTLet({"x": n({})}), output="__original_graph__", engine=engine)
+    assert exc_info.value.code == ErrorCode.E151
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_output_binding_error_lists_only_user_bindings(engine: str) -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _graph(engine).gfql(ASTLet({"x": n({})}), output="nope", engine=engine)
+    assert "Available bindings: ['x']" in str(exc_info.value)
+
+
+# --- Traversing a row-pipeline result (#1923 F4)
+
+
+def test_ref_traversal_after_row_call_declines_typed_on_polars() -> None:
+    pytest.importorskip("polars")
+    dag = ASTLet({"lim": call("limit", {"value": 2}), "after": ASTRef("lim", [n({})])})
+    with pytest.raises(NotImplementedError, match="unbound edge endpoints"):
+        _graph("polars").gfql(dag, output="after", engine="polars")
+
+
+def test_ref_traversal_after_row_call_runs_on_pandas() -> None:
+    dag = ASTLet({"lim": call("limit", {"value": 2}), "after": ASTRef("lim", [n({})])})
+    result = _graph("pandas").gfql(dag, output="after", engine="pandas")
+    assert len(result._nodes) == 2
+
+
+def test_polars_traversal_on_a_graph_without_bound_edges_declines_typed() -> None:
+    pl = pytest.importorskip("polars")
+    g = graphistry.nodes(pl.from_pandas(NODES), "id")
+    with pytest.raises(NotImplementedError, match="unbound edge endpoints"):
+        g.gfql(n({}), engine="polars")
+
+
+# --- Scheduling and error typing (#1923 F5-F8)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_nested_let_reads_an_enclosing_binding_declared_after_it(engine: str) -> None:
+    result = _graph(engine).gfql(
+        ASTLet({
+            "inner": ASTLet({"z": ASTRef("outer", [n({"type": "person"})])}),
+            "outer": n({}),
+        }),
+        output="inner",
+        engine=engine,
+    )
+    assert _node_ids(result) == PERSON_IDS
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_nested_let_cycle_through_an_enclosing_binding_is_a_coded_error(engine: str) -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _graph(engine).gfql(
+            ASTLet({
+                "inner": ASTLet({"bad": ASTRef("later", [])}),
+                "later": ASTRef("inner", []),
+            }),
+            engine=engine,
+        )
+    assert exc_info.value.code == ErrorCode.E153
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_binding_schema_failure_keeps_its_gfql_error_type(engine: str) -> None:
+    with pytest.raises(GFQLSchemaError) as exc_info:
+        _graph(engine).gfql(
+            ASTLet({"x": n({"nosuchcol": 1}), "y": n({})}), output="x", engine=engine
+        )
+    assert exc_info.value.code == ErrorCode.E301
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_single_binding_self_reference_reports_self_reference(engine: str) -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _graph(engine).gfql(ASTLet({"x": ASTRef("x", [])}), engine=engine)
+    assert exc_info.value.code == ErrorCode.E153
+    assert "Self-reference cycle detected: 'x' depends on itself" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_single_binding_missing_reference_is_a_coded_error(engine: str) -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _graph(engine).gfql(ASTLet({"x": ASTRef("nope", [])}), engine=engine)
+    assert exc_info.value.code == ErrorCode.E151
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_multi_binding_cycle_is_a_coded_error(engine: str) -> None:
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _graph(engine).gfql(
+            ASTLet({"a": ASTRef("b", []), "b": ASTRef("c", []), "c": ASTRef("a", [])}),
+            engine=engine,
+        )
+    assert exc_info.value.code == ErrorCode.E153

--- a/graphistry/tests/compute/test_let_binding_contracts.py
+++ b/graphistry/tests/compute/test_let_binding_contracts.py
@@ -17,6 +17,7 @@ from graphistry.Plottable import Plottable
 from graphistry.compute.typing import DataFrameT
 from graphistry.compute.ast import ASTLet, ASTRef, call, n
 from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError, GFQLValidationError
+from graphistry.compute.chain_let import detect_cycles, in_declaration_order
 
 ENGINES: Tuple[str, ...] = ("pandas", "polars")
 
@@ -321,3 +322,33 @@ def test_multi_binding_cycle_is_a_coded_error(engine: str) -> None:
             engine=engine,
         )
     assert exc_info.value.code == ErrorCode.E153
+
+
+# --- the one ordering primitive the scheduler and the cycle report share ---------------------
+
+
+def test_in_declaration_order_follows_the_declaration_index() -> None:
+    order = {"z": 0, "a": 1, "m": 2}
+    assert in_declaration_order({"a", "m", "z"}, order) == ["z", "a", "m"]
+
+
+def test_enclosing_scope_names_trail_the_declared_ones_ordered_by_name() -> None:
+    order = {"z": 0, "a": 1}
+    assert in_declaration_order({"a", "z", "outer2", "outer1"}, order) == [
+        "z", "a", "outer1", "outer2",
+    ]
+
+
+def test_without_a_declaration_order_names_fall_back_to_name_order() -> None:
+    assert in_declaration_order({"m", "a", "z"}, {}) == ["a", "m", "z"]
+
+
+def test_cycle_is_reported_in_declaration_order_not_name_order() -> None:
+    dependencies = {"z": {"a"}, "a": {"z"}}
+    assert detect_cycles(dependencies, {"z": 0, "a": 1}) == ["z", "a", "z"]
+    assert detect_cycles(dependencies, {"a": 0, "z": 1}) == ["a", "z", "a"]
+
+
+def test_cycle_report_is_stable_when_no_declaration_order_is_supplied() -> None:
+    dependencies = {"z": {"a"}, "a": {"z"}}
+    assert detect_cycles(dependencies) == detect_cycles(dependencies)


### PR DESCRIPTION
Independent of the GFQL stack — based on master, merges on its own.

Three silent-wrongs on the `let()`/`ref()`/`call()` surface, all found by round-012 probing, **all cases where both engines agree and both are wrong** (differential testing could not have found them).

**F2 — an `ASTCall` binding consumed the previous binding's output.** Every binding kind except `ASTCall` re-fetched the root back out of the namespace; `ASTCall` used the threaded `accumulated_result` as-is. So **reordering two dict keys changed the answer** — `get_degrees` reported every person as degree 0 when a filter binding preceded it. Fixed structurally rather than by patching the call site: `execute_node`'s `g` parameter now **is** the root, and all four namespace lookups are deleted.

**F1 — the default output was nondeterministic across processes.** `topological_sort` iterated a `Set[str]`; with per-process hash randomization, master produces **three distinct answers** across seeds. Ties now break by declaration order, and cycle reporting sorts its neighbours so error paths are stable too.

**F3 — a user binding named `__original_graph__` hijacked the root.** Fell out of F2: the root is no longer stored in the user namespace, so that name is an ordinary binding and `output='__original_graph__'` is not addressable. The `startswith('__')` filter in the output error is also gone — it was hiding user bindings.

**F4** replaces a bare empty-message `assert` with a typed `NotImplementedError` naming unbound edge endpoints, matching how the chain surface already declines the same shape (it also covers an edgeless graph, which died on that assert). **F5–F8**: nested-`let` dependencies now resolve via `free_variables()`; the single-binding validation shortcut is gone; `GFQLValidationError` propagates unwrapped instead of being downgraded to `RuntimeError`; and structural errors use the `E151`/`E153` codes the Cypher parser already uses instead of bare `ValueError`.

## Two places where fixing one exposed another

**F7 broke lexical read-through, and F5 explained why.** Removing the single-binding shortcut made a nested `let` validate its own bindings, so an outer `ref` read as undefined — the shortcut had been *masking* that, and a two-binding inner let was already broken at master. Fixed by threading enclosing scope through validation and intersecting deps with the local scope before scheduling.

**F2 exposed a test that pinned the bug.** `test_call_operations.py::TestCallInDAG::test_call_in_dag` asserted `len(result._nodes) == 3  # Only 'user' nodes` — i.e. that a call binding inherits the sibling's filter, precisely the behavior #1923 calls silent-wrong and that `test_let_matchers.py::test_matchers_operate_on_root_graph` contradicts. Rewritten as two named contract pins with a hand-computed degree oracle.

## Anti-vacuity: 38 of 48 new cells fail at master

`test_let_binding_contracts.py`. The 10 that pass at master are reported honestly: two hash seeds happen to give the right answer, and the sibling-isolation cells were never wrong. F1's pin runs the DAG in **subprocesses across `PYTHONHASHSEED` 0/1/2/3/7/13** — the existing `test_execution_order_deterministic` cannot see the bug because it never leaves the process.

## Gates
`graphistry/tests/compute` master `102 failed, 9340 passed` → branch `102 failed, 9391 passed`, **failure sets byte-identical**. Let/scoping suites 140 passed; `test_call_operations.py` 27 passed; polars chain/hop/row-pipeline + new file 1588 passed. ruff, mypy (328 files), both guards clean.

Two earlier baseline runs were **discarded as contaminated** (one ran inside the worktree being edited; one had the new test file temporarily present in the master worktree, tripping the polars lane-completeness lock) and re-run in a dedicated clean worktree.

Self-review gate: zero added comments in `graphistry/compute/**`, zero `Any`/`type: ignore`/`hygiene-ok`/`cast(` — it also *removed* a pre-existing `cast(Plottable, ...)` on a touched line in favour of an `is not None` narrowing.

**NIE-tier deliberately left** (reported, not fixed): undeclared schema effects, `collapse` leaking an internal column, docstrings advertising an idiom pinned to return empty, `circle_layout`'s raw `KeyError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF7uRZLKZaD6Q9FGWSmyXi