### PR TITLE
fix(dgx): cap host memory on CPU lanes, which RMM cannot contain

### DIFF
--- a/benchmarks/dgx/safe_run.sh
+++ b/benchmarks/dgx/safe_run.sh
@@ -6,14 +6,18 @@
 #  - preflight refuses obviously-oversized runs; host watchdog force-kills on low RAM;
 #    hard timeout + docker kill -s KILL so a hung container can't wedge the box.
 # Usage:
-#   safe_run.sh --name N --est-edges E [--rmm-gb 80] [--floor-gb 20] [--timeout 3600] \
+#   safe_run.sh --name N --est-edges E [--rmm-gb 80] [--host-gb G] [--floor-gb 20] [--timeout 3600] \
 #     [--pythonpath /opt/pygraphistry] -- <extra docker args e.g. -v ...> IMAGE <cmd...>
 set -uo pipefail
 NAME="dgxsafe_$$"; EST_EDGES=0; RMM_GB=80; FLOOR_GB=20; TIMEOUT=3600; PYPATH="/opt/pygraphistry"
+# --host-gb caps host address space (RLIMIT_AS) for CPU lanes, which RMM does not
+# contain. CPU-ONLY: CUDA reserves large virtual ranges, so do not set it on GPU runs.
+HOST_GB=""
 GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 while [[ $# -gt 0 ]]; do case "$1" in
   --name) NAME="$2"; shift 2;; --est-edges) EST_EDGES="$2"; shift 2;;
   --rmm-gb) RMM_GB="$2"; shift 2;; --floor-gb) FLOOR_GB="$2"; shift 2;;
+  --host-gb) HOST_GB="$2"; shift 2;;
   --timeout) TIMEOUT="$2"; shift 2;; --pythonpath) PYPATH="$2"; shift 2;;
   --) shift; break;; *) echo "unknown arg $1"; exit 2;; esac; done
 
@@ -21,7 +25,9 @@ if [[ "$EST_EDGES" -gt 0 ]]; then
   if ! python3 "$GUARD_DIR/preflight.py" "$EST_EDGES"; then
     echo "[safe_run] REFUSED: estimated peak > budget for $EST_EDGES edges."; exit 3; fi
 fi
-echo "[safe_run] name=$NAME rmm=${RMM_GB}GB floor=${FLOOR_GB}GB timeout=${TIMEOUT}s"
+HOST_ENV=()
+if [[ -n "$HOST_GB" ]]; then HOST_ENV=(-e "GFQL_HOST_LIMIT_GB=$HOST_GB"); fi
+echo "[safe_run] name=$NAME rmm=${RMM_GB}GB host=${HOST_GB:-none} floor=${FLOOR_GB}GB timeout=${TIMEOUT}s"
 
 ( while true; do
     avail=$(free -g | awk '/Mem:/{print $7}')
@@ -33,7 +39,7 @@ echo "[safe_run] name=$NAME rmm=${RMM_GB}GB floor=${FLOOR_GB}GB timeout=${TIMEOU
   done ) & WD=$!
 
 timeout -s KILL "$TIMEOUT" docker run --rm --name "$NAME" --gpus all \
-  -e GFQL_RMM_LIMIT_GB="$RMM_GB" -e PYTHONPATH="/dgx-guard:${PYPATH}" \
+  -e GFQL_RMM_LIMIT_GB="$RMM_GB" "${HOST_ENV[@]}" -e PYTHONPATH="/dgx-guard:${PYPATH}" \
   -v "$GUARD_DIR:/dgx-guard:ro" "$@"
 rc=$?
 docker kill -s KILL "$NAME" >/dev/null 2>&1; kill "$WD" >/dev/null 2>&1

--- a/benchmarks/dgx/sitecustomize.py
+++ b/benchmarks/dgx/sitecustomize.py
@@ -39,4 +39,41 @@ def _apply_rmm_limit() -> None:
         pass
 
 
+def _apply_host_limit() -> None:
+    """Cap host (pandas/numpy) address space when GFQL_HOST_LIMIT_GB is set.
+
+    RMM only contains device/unified allocations, so a pure-CPU workload has NO
+    hard cap: the safe_run.sh watchdog polls every 5 s and only fires once host
+    RAM has already fallen below the floor -- i.e. after the box is swapping.
+    That is the failure shape that cost 9.5 hours on a 1.8B-edge run.
+
+    RLIMIT_AS makes an over-allocating CPU run raise a clean MemoryError at the
+    allocation site instead, mirroring what the RMM cap does for GPU runs.
+
+    Caveat: RLIMIT_AS limits *virtual* address space, so it must not be applied
+    to GPU runs -- CUDA reserves large VA ranges up front and would fail
+    spuriously. Set GFQL_HOST_LIMIT_GB only on CPU lanes.
+    """
+    gb = _os.environ.get("GFQL_HOST_LIMIT_GB")
+    if not gb:
+        return
+    try:
+        limit = int(float(gb) * 1024 ** 3)
+    except ValueError:
+        return
+    try:
+        import resource
+        import sys
+        _soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+        if hard != resource.RLIM_INFINITY:
+            limit = min(limit, hard)
+        resource.setrlimit(resource.RLIMIT_AS, (limit, hard))
+        print(f"[dgx-guard] host address-space limit = {gb} GB (CPU-lane safety)",
+              file=sys.stderr)
+    except Exception:
+        # Never block the workload on a failure to tighten a guard.
+        pass
+
+
 _apply_rmm_limit()
+_apply_host_limit()

--- a/benchmarks/dgx/test_preflight.py
+++ b/benchmarks/dgx/test_preflight.py
@@ -23,3 +23,48 @@ def test_handoff_80m_is_allowed():
 def test_peak_scales_with_edges_and_cugraph_factor():
     assert preflight.peak_gb(1_000_000_000) > preflight.peak_gb(100_000_000)
     assert preflight.peak_gb(100_000_000, cugraph_factor=3.0) > preflight.peak_gb(100_000_000, cugraph_factor=1.0)
+
+
+# --- host address-space guard (sitecustomize GFQL_HOST_LIMIT_GB) -------------
+# RMM only contains device/unified allocs, so CPU lanes previously had NO hard
+# cap -- the watchdog fires only once the box is already swapping. These run in
+# subprocesses because setrlimit is process-wide and irreversible.
+
+import subprocess  # noqa: E402
+
+_GUARD_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _run_guarded(code: str, limit_gb: str | None):
+    env = dict(os.environ, PYTHONPATH=_GUARD_DIR)
+    env.pop("GFQL_HOST_LIMIT_GB", None)
+    if limit_gb is not None:
+        env["GFQL_HOST_LIMIT_GB"] = limit_gb
+    return subprocess.run([sys.executable, "-c", code], env=env,
+                          capture_output=True, text=True, timeout=120)
+
+
+def test_host_limit_blocks_oversized_cpu_allocation():
+    code = (
+        "import numpy as np\n"
+        "try:\n"
+        "    np.ones(8 * 1024**3 // 8, dtype='float64')\n"
+        "    print('ALLOCATED')\n"
+        "except MemoryError:\n"
+        "    print('REFUSED')\n"
+    )
+    assert "REFUSED" in _run_guarded(code, "3").stdout
+
+
+def test_host_limit_still_allows_normal_work():
+    code = "import numpy as np; print(len(np.arange(1_000_000)))"
+    out = _run_guarded(code, "3")
+    assert out.returncode == 0 and "1000000" in out.stdout
+
+
+def test_host_limit_is_a_noop_when_unset():
+    """Must not perturb GPU lanes, where RLIMIT_AS would break CUDA's large
+    virtual reservations."""
+    out = _run_guarded("import numpy; print('OK')", None)
+    assert out.returncode == 0 and "OK" in out.stdout
+    assert "host address-space limit" not in out.stderr

--- a/benchmarks/dgx/test_preflight.py
+++ b/benchmarks/dgx/test_preflight.py
@@ -5,6 +5,7 @@ cudf/cugraph run whose ~87 GB peak exceeds the ~80 GB unified-memory budget must
 be REFUSED, while the #1658 handoff's 80M-edge run must be allowed.
 """
 import os, sys
+from typing import Optional
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import preflight
 
@@ -35,7 +36,7 @@ import subprocess  # noqa: E402
 _GUARD_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def _run_guarded(code: str, limit_gb: str | None):
+def _run_guarded(code: str, limit_gb: Optional[str]):
     env = dict(os.environ, PYTHONPATH=_GUARD_DIR)
     env.pop("GFQL_HOST_LIMIT_GB", None)
     if limit_gb is not None:


### PR DESCRIPTION
## Problem

`benchmarks/dgx/sitecustomize.py` caps **RMM**, which covers cudf/cugraph device and unified allocations. It does not cover the host path at all.

So a pure-pandas benchmark lane on the shared GB10 ran with **no hard memory limit**. The only backstop was the 5-second watchdog in `safe_run.sh`, which fires *after* available RAM has already dropped below the floor — i.e. once the box is already swapping. That is the shape of the incident where a 1.8B-edge run thrashed this machine for ~9.5 hours.

I hit this while building a CPU benchmark lane: the guard I thought I had was not there.

## Change

- `GFQL_HOST_LIMIT_GB` → `resource.setrlimit(RLIMIT_AS)` in `sitecustomize`, so an over-allocating CPU run raises a clean `MemoryError` at the allocation site, mirroring what the RMM cap already does for GPU runs.
- `--host-gb` on `safe_run.sh` to inject it.

## Why it is opt-in, and CPU-only

`RLIMIT_AS` bounds **virtual** address space. CUDA reserves large virtual ranges up front, so applying this to a GPU run would fail spuriously. It is a no-op when the env var is unset, so existing lanes are unaffected.

Related gotcha worth knowing: `GFQL_RMM_LIMIT_GB` only takes effect when `sitecustomize` is on `PYTHONPATH`, which only `safe_run.sh` arranges. An ad-hoc `docker run` that merely sets the env var is **uncapped** — I confirmed this the hard way when a run "passed" standalone and then failed under `safe_run` against a cap that was, correctly, being applied.

## Tests

`benchmarks/dgx/test_preflight.py`, 6/6 passing. The new cases run in subprocesses because `setrlimit` is process-wide and irreversible: an oversized allocation is refused, ordinary work still runs under the limit, and an unset var perturbs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXm45Nzm1BgWs6iR2exufT