### PR TITLE
fix(gfql): polars declines must offer engine='cudf' alongside pandas

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -59,6 +59,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_semi_join_key_frame.py
     graphistry/tests/compute/gfql/test_fast_path_engagement.py
     graphistry/tests/compute/gfql/test_known_cross_engine_divergences.py
+    graphistry/tests/compute/gfql/test_decline_guidance_cross_engine.py
     graphistry/tests/compute/gfql/test_endpoint_closure_matrix.py
     graphistry/tests/compute/gfql/test_gfql_unified_routing_contracts.py
     graphistry/tests/compute/gfql/test_hop_kernel_contracts.py

--- a/graphistry/compute/gfql/cypher/reentry/execution.py
+++ b/graphistry/compute/gfql/cypher/reentry/execution.py
@@ -408,13 +408,13 @@ def compiled_query_reentry_state(
     if _is_polars_df(carried_ids) or _is_polars_df(aligned_prefix_rows) or _is_polars_df(base_nodes):
         # Whole-row re-entry that ALSO carries scalar WITH columns (e.g. `WITH a, a.val AS av
         # MATCH (a)-...`) threads hidden ``__cypher_reentry_*`` payload columns through the
-        # binding pipeline; that carry path is pandas-only so far. The seed-only whole-row case
-        # (no carried scalars) returned above. Decline honestly rather than run the pandas-only
-        # payload merge on polars frames (parity-or-NIE; no silent bridge).
+        # binding pipeline; that carry path is pandas/cuDF-only so far. The seed-only whole-row
+        # case (no carried scalars) returned above. Decline honestly rather than run the
+        # pandas/cuDF payload merge on polars frames (parity-or-NIE; no silent bridge).
         raise NotImplementedError(
             "polars engine does not yet natively support Cypher WITH -> MATCH re-entry that carries "
-            "scalar WITH columns into the trailing MATCH; use engine='pandas' for this query "
-            "(no pandas fallback; parity-or-error by design)"
+            "scalar WITH columns into the trailing MATCH; use engine='pandas' or engine='cudf' "
+            "for this query (no silent fallback; parity-or-error by design)"
         )
     duplicate_mask = carried_ids.duplicated()
     if bool(duplicate_mask.any()) if hasattr(duplicate_mask, "any") else False:

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -590,8 +590,8 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
             continue
         raise NotImplementedError(
             f"polars engine does not yet natively support cypher row op "
-            f"{getattr(op, 'function', op)!r}; use engine='pandas' for this query "
-            f"(no pandas fallback; parity-or-error by design)"
+            f"{getattr(op, 'function', op)!r}; use engine='pandas' or engine='cudf' for this "
+            f"query (no silent fallback; parity-or-error by design)"
         )
     # Attach/detach pair: the boundary run is done, so the context is spent and must not
     # ride out on the result the caller sees (see the twin in compute/chain.py).
@@ -760,11 +760,11 @@ def chain_polars(self: Plottable, ops, start_nodes: Optional[Any] = None) -> Plo
 
     if prefix:
         # decline (NIE): leading call() yields a row table the following traversal would have to
-        # re-enter as a graph. pandas cascades via _chain_impl, but it's not a cypher shape
+        # re-enter as a graph. pandas/cuDF cascade via _chain_impl, but it's not a cypher shape
         # (MATCH comes first) and the polars traversal doesn't yet consume a row-table input.
         raise NotImplementedError(
             "polars chain engine does not yet support call() before a traversal; "
-            "use engine='pandas' for this chain."
+            "use engine='pandas' or engine='cudf' for this chain."
         )
 
     from graphistry.compute.chain import serialize_binding_ops
@@ -857,7 +857,8 @@ def _bound_edge_endpoints(g: Plottable) -> Tuple[str, str]:
     if g._source is None or g._destination is None:
         raise NotImplementedError(
             "polars chain engine does not yet support traversing a graph with unbound edge "
-            "endpoints (e.g. a call() row-pipeline result); use engine='pandas' for this chain."
+            "endpoints (e.g. a call() row-pipeline result); use engine='pandas' or "
+            "engine='cudf' for this chain."
         )
     return g._source, g._destination
 
@@ -924,7 +925,7 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
             raise NotImplementedError(
                 "polars chain engine: a node alias after a forward/reverse variable-length edge "
                 "with min_hops>1 is not yet hop-gated (would tag nodes outside the hop window — "
-                "issue #1748); use engine='pandas' for this query"
+                "issue #1748); use engine='pandas' or engine='cudf' for this query"
             )
 
     edge_ops = [op for op in ops if isinstance(op, ASTEdge)]

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -508,7 +508,7 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
 
     if (
         middle
-        and any(getattr(op, "_name", None) is not None for op in middle)
+        and any(op._name is not None for op in middle)
         and isinstance(calls[0], ASTCall)
         and calls[0].function == "rows"
         and calls[0].params.get("binding_ops") is None
@@ -541,9 +541,16 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
     #    SAME path as the DAG/let() surface, keeping surfaces consistent. Row-vs-analytic split
     #    is MECHANICAL (is_row_pipeline_call), not curated. (umap/hypergraph never reach here —
     #    the generic chain routes schema-changers straight to execute_call.)
+    from graphistry.compute.ast import ASTCall
     from graphistry.compute.gfql.row.pipeline import is_row_pipeline_call
     from graphistry.compute.exceptions import ErrorCode, GFQLTypeError, GFQLValidationError
     for op in calls:
+        if not isinstance(op, ASTCall):
+            raise NotImplementedError(
+                f"polars engine does not yet natively support cypher row op "
+                f"{op!r}; use engine='pandas' or engine='cudf' for this "
+                f"query (no silent fallback; parity-or-error by design)"
+            )
         try:
             native = _try_native_row_op(g_cur, op)
         except GFQLTypeError:
@@ -556,12 +563,11 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
             # repo's control flow keys on `.code`. Scoped to GFQLValidationError, the one
             # divergence actually observed (an E108 from the var-length cycle guard);
             # other exception classes are left alone rather than blanket-normalized.
-            fn_name = getattr(op, "function", None)
             raise GFQLTypeError(
                 ErrorCode.E303,
-                f"Error executing '{fn_name}': {validation_error}",
+                f"Error executing '{op.function}': {validation_error}",
                 field="function",
-                value=fn_name,
+                value=op.function,
             ) from validation_error
         except _polars_error_types() as polars_error:
             # A THIRD-PARTY exception must never be the GFQL surface. On the pandas/cuDF side
@@ -570,27 +576,25 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
             # letting e.g. `polars.exceptions.InvalidOperationError: \`sum\` operation not
             # supported for dtype \`str\`` reach the caller verbatim. Same code, same message
             # shape as the pandas surface; the polars text is preserved as the cause.
-            fn_name = getattr(op, "function", None)
             raise GFQLTypeError(
                 ErrorCode.E303,
-                f"Error executing '{fn_name}': {polars_error}",
+                f"Error executing '{op.function}': {polars_error}",
                 field="function",
-                value=fn_name,
+                value=op.function,
             ) from polars_error
         if native is not None:
             g_cur = native
             continue
-        fn = getattr(op, "function", None)
-        if fn is not None and not is_row_pipeline_call(fn):
+        if not is_row_pipeline_call(op.function):
             from graphistry.compute.gfql.call.executor import execute_call
             from graphistry.compute.gfql.lazy import active_target, ExecutionTarget
             from graphistry.Engine import Engine as _Engine
             _eng = _Engine.POLARS_GPU if active_target() == ExecutionTarget.GPU else _Engine.POLARS
-            g_cur = execute_call(g_cur, fn, getattr(op, "params", {}) or {}, _eng)
+            g_cur = execute_call(g_cur, op.function, op.params or {}, _eng)
             continue
         raise NotImplementedError(
             f"polars engine does not yet natively support cypher row op "
-            f"{getattr(op, 'function', op)!r}; use engine='pandas' or engine='cudf' for this "
+            f"{op.function!r}; use engine='pandas' or engine='cudf' for this "
             f"query (no silent fallback; parity-or-error by design)"
         )
     # Attach/detach pair: the boundary run is done, so the context is spent and must not
@@ -618,7 +622,7 @@ def _try_native_row_op(g_cur, op):
     )
     from .search import search_any_polars
 
-    fn = getattr(op, "function", None)
+    fn = op.function
     if fn == "rows" and op.params.get("binding_ops") is not None:
         # #1731: single-entity boundary rows (MATCH (n) / EXISTS seeds) are handled by
         # the pattern-apply helper; try that narrow shape first.

--- a/graphistry/compute/gfql/lazy/engine/polars/predicates.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/predicates.py
@@ -340,8 +340,8 @@ def filter_expr_by_dict_polars(df: "Union[pl.DataFrame, pl.LazyFrame]", filter_d
                 # numeric-vs-string comparison -> polars ComputeError; decline (NIE).
                 raise NotImplementedError(
                     f"polars engine does not yet natively support a numeric-vs-string "
-                    f"comparison on column {resolved_col!r}; use engine='pandas' for this "
-                    f"query (no pandas fallback; parity-or-error by design)"
+                    f"comparison on column {resolved_col!r}; use engine='pandas' or "
+                    f"engine='cudf' for this query (no silent fallback; parity-or-error by design)"
                 )
             # String predicate on a non-`String` column: pandas/cuDF raise a clean
             # GFQLSchemaError (E302) at schema validation, but polars would build `.str.<op>` and

--- a/graphistry/compute/gfql/lazy/engine/polars/projection.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/projection.py
@@ -246,6 +246,6 @@ def apply_result_projection_polars(
     raise NotImplementedError(
         "polars engine does not yet natively render this cypher result projection "
         "(whole-entity RETURN over float/temporal/nested/multi-entity columns); "
-        "use engine='pandas' for this query "
-        "(no pandas fallback; parity-or-error by design)"
+        "use engine='pandas' or engine='cudf' for this query "
+        "(no silent fallback; parity-or-error by design)"
     )

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -5312,7 +5312,7 @@ def execute_row_pipeline_call(
         if unsupported:
             raise NotImplementedError(
                 f"polars row pipeline does not yet support op {function!r}; "
-                "use engine='pandas' for this query"
+                "use engine='pandas' or engine='cudf' for this query"
             )
     adapter = _RowPipelineAdapter(g)
     method = _ROW_PIPELINE_DISPATCH[function]

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -498,7 +498,7 @@ def _apply_connected_optional_match(
 
         seed_src = joined_rows[[joined_col]]
         # each branch builds ``seed_frame`` directly rather than rebinding ``seed_src``: the
-        # polars result would otherwise widen the variable and break the pandas branch below
+        # polars result would otherwise widen the variable and break the pandas/cuDF branch below
         # (``is_polars_df`` is a TypeGuard -- it does not narrow the negative branch back).
         if is_polars_df(seed_src):
             seed_frame = cast(DataFrameT, df_to_engine(
@@ -1749,7 +1749,7 @@ def _compile_string_query(
         )
     params_key = _compile_cache_params_key(params)
     # node_dtypes (from #1730/#1729 pushdown) makes compilation engine-dependent: the same
-    # (query, params) yields a different pushdown plan under pandas vs polars dtypes. The
+    # (query, params) yields a different pushdown plan under pandas/cuDF vs polars dtypes. The
     # compile cache (#1731) must therefore key on node_dtypes too, or a plan compiled for one
     # engine would be wrongly reused for another on the same graph.
     node_dtypes_key = _node_dtypes_cache_key(node_dtypes)
@@ -2361,12 +2361,12 @@ def _chain_dispatch(
     engine_name = engine.value if hasattr(engine, "value") else str(engine)
     if chain_obj.where and engine_name in (Engine.POLARS.value, Engine.POLARS_GPU.value):
         # Cross-entity / same-path WHERE routes through DFSamePathExecutor
-        # (df_executor.py), which has no native polars implementation. NO pandas
-        # fallback (no-silent-fallback policy) — raise honestly.
+        # (df_executor.py, serving pandas AND cuDF), which has no native polars
+        # implementation. No silent fallback — raise honestly.
         raise NotImplementedError(
             "polars engine does not yet natively support cross-entity (same-path) "
-            "WHERE; use engine='pandas' for this query "
-            "(no pandas fallback; parity-or-error by design)"
+            "WHERE; use engine='pandas' or engine='cudf' for this query "
+            "(no silent fallback; parity-or-error by design)"
         )
     if chain_obj.where:
         if start_nodes is not None:

--- a/graphistry/tests/compute/gfql/test_decline_guidance_cross_engine.py
+++ b/graphistry/tests/compute/gfql/test_decline_guidance_cross_engine.py
@@ -1,0 +1,207 @@
+"""Polars decline guidance must name every engine that actually serves the query.
+
+The polars engine declines some shapes with an honest NotImplementedError. Those shapes run
+on the pandas-idiom path, which serves pandas AND cuDF — so the decline message must offer
+BOTH engines, or a GPU user is sent to CPU for no reason (the #1928 report). Each pin here
+was verified empirically: polars raises a typed NIE naming the unsupported feature, while
+pandas and cuDF both serve the query with the hand-computed values asserted below.
+
+Counter-pins at the bottom cover shapes cuDF does NOT serve (mixed-type IsIn, List-vs-scalar):
+their messages stay pandas-only on purpose, and a test asserts they never advertise cuDF.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.Plottable import Plottable
+from graphistry.compute.ast import ASTLet, call
+from graphistry.compute.ast import n as ast_n
+from graphistry.compute.predicates.is_in import is_in
+
+BOTH_ENGINES = "use engine='pandas' or engine='cudf'"
+PANDAS_ONLY = "use engine='pandas'"
+
+NODES = pd.DataFrame({
+    "id": ["a", "b", "c", "d"],
+    "v": [1, 5, 3, 7],
+    "kind": ["person", "person", "company", "person"],
+})
+EDGES = pd.DataFrame({"s": ["a", "b", "a", "d"], "d": ["b", "c", "c", "a"]})
+
+#: Hand-computed from NODES/EDGES: edges where source v < destination v.
+SAME_PATH_LT_ROWS = [("a", "b"), ("a", "c")]
+#: Hand-computed: (person v, out-neighbor id) over all out-edges of person nodes.
+SCALAR_CARRY_ROWS = [(1, "b"), (1, "c"), (5, "c"), (7, "a")]
+#: Hand-computed: nodes reachable from 'a' in exactly 2..3 forward hops (a->b->c only).
+MIN_HOPS_TARGETS = ["c"]
+#: Hand-computed: each node's v twice, sorted.
+UNWIND_TWICE_SORTED = [1, 1, 3, 3, 5, 5, 7, 7]
+#: Hand-computed: node ids ordered by v descending.
+ORDER_BY_V_DESC_IDS = ["d", "b", "c", "a"]
+
+
+def _graph(engine: str) -> Plottable:
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        return graphistry.nodes(pl.from_pandas(NODES), "id").edges(pl.from_pandas(EDGES), "s", "d")
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        return graphistry.nodes(cudf.from_pandas(NODES), "id").edges(cudf.from_pandas(EDGES), "s", "d")
+    return graphistry.nodes(NODES, "id").edges(EDGES, "s", "d")
+
+
+def _rows(g: Plottable, cols: List[str]) -> List[Tuple[Any, ...]]:
+    df = g._nodes
+    pdf = df.to_pandas() if hasattr(df, "to_pandas") else df
+    return sorted(pdf[cols].itertuples(index=False, name=None))
+
+
+SAME_PATH_Q = "MATCH (x)-[e]->(y) WHERE x.v < y.v RETURN x.id AS xid, y.id AS yid"
+SCALAR_CARRY_Q = (
+    "MATCH (p {kind:'person'}) WITH p, p.v AS pv MATCH (p)-[]->(q) RETURN pv, q.id AS qid"
+)
+MIN_HOPS_Q = "MATCH (r {id:'a'})-[*2..3]->(t) RETURN t.id AS tid"
+UNWIND_Q = "MATCH (x) UNWIND [x.v, x.v] AS z RETURN z"
+
+
+class TestPolarsDeclineNamesBothServingEngines:
+    """Each polars NIE below is a shape pandas AND cuDF serve: the message must say so."""
+
+    @pytest.mark.parametrize("query,feature", [
+        (SAME_PATH_Q, "cross-entity (same-path) WHERE"),
+        (SCALAR_CARRY_Q, "scalar WITH columns into the trailing MATCH"),
+        (MIN_HOPS_Q, "not yet hop-gated"),
+        (UNWIND_Q, "cypher row op"),
+    ])
+    def test_polars_decline_offers_cudf(self, query: str, feature: str) -> None:
+        with pytest.raises(NotImplementedError) as nie:
+            _graph("polars").gfql(query, engine="polars")
+        msg = str(nie.value)
+        assert feature in msg, msg
+        assert BOTH_ENGINES in msg, msg
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_same_path_where_served(self, engine: str) -> None:
+        got = _rows(_graph(engine).gfql(SAME_PATH_Q, engine=engine), ["xid", "yid"])
+        assert got == SAME_PATH_LT_ROWS
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_scalar_with_carry_served(self, engine: str) -> None:
+        got = _rows(_graph(engine).gfql(SCALAR_CARRY_Q, engine=engine), ["pv", "qid"])
+        assert [(int(pv), qid) for pv, qid in got] == SCALAR_CARRY_ROWS
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_min_hops_alias_served(self, engine: str) -> None:
+        got = _rows(_graph(engine).gfql(MIN_HOPS_Q, engine=engine), ["tid"])
+        assert [t for (t,) in got] == MIN_HOPS_TARGETS
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_unwind_row_op_served(self, engine: str) -> None:
+        got = _rows(_graph(engine).gfql(UNWIND_Q, engine=engine), ["z"])
+        assert [int(z) for (z,) in got] == UNWIND_TWICE_SORTED
+
+
+class TestRowPipelineDagDecline:
+    """call('order_by') in a let() DAG: polars row pipeline declines naming both engines."""
+
+    DAG = ASTLet({"k": call("order_by", {"keys": [["v", "desc"]]})})
+
+    def test_polars_decline_offers_cudf(self) -> None:
+        with pytest.raises(NotImplementedError) as nie:
+            _graph("polars").gfql(self.DAG, output="k", engine="polars")
+        msg = str(nie.value)
+        assert "polars row pipeline does not yet support op 'order_by'" in msg, msg
+        assert BOTH_ENGINES in msg, msg
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_served_in_order(self, engine: str) -> None:
+        got = _graph(engine).gfql(self.DAG, output="k", engine=engine)._nodes
+        pdf = got.to_pandas() if hasattr(got, "to_pandas") else got
+        assert list(pdf["id"]) == ORDER_BY_V_DESC_IDS
+
+
+FLOAT_ENTITY_NODES = pd.DataFrame({
+    "id": ["s", "m", "c"], "lbl": ["Single", "M", "C"], "f": [1.5, 2.5, 3.5],
+})
+FLOAT_ENTITY_EDGES = pd.DataFrame({"s": ["s", "m"], "d": ["m", "c"]})
+FLOAT_ENTITY_Q = (
+    "MATCH (a {lbl:'Single'}), (x {lbl:'C'}) OPTIONAL MATCH (a)-[*]->(x) RETURN x"
+)
+#: Hand-computed legacy entity text for node c (id excluded): its lbl and float f.
+FLOAT_ENTITY_TEXT = "({lbl: 'C', f: 3.5})"
+
+
+class TestFloatWholeEntityProjectionDecline:
+    """Entity-text RETURN over a float column: polars declines naming both engines."""
+
+    @staticmethod
+    def _fgraph(engine: str) -> Plottable:
+        if engine == "polars":
+            pl = pytest.importorskip("polars")
+            return graphistry.nodes(pl.from_pandas(FLOAT_ENTITY_NODES), "id").edges(
+                pl.from_pandas(FLOAT_ENTITY_EDGES), "s", "d")
+        if engine == "cudf":
+            cudf = pytest.importorskip("cudf")
+            return graphistry.nodes(cudf.from_pandas(FLOAT_ENTITY_NODES), "id").edges(
+                cudf.from_pandas(FLOAT_ENTITY_EDGES), "s", "d")
+        return graphistry.nodes(FLOAT_ENTITY_NODES, "id").edges(FLOAT_ENTITY_EDGES, "s", "d")
+
+    def test_polars_decline_offers_cudf(self) -> None:
+        with pytest.raises(NotImplementedError) as nie:
+            self._fgraph("polars").gfql(FLOAT_ENTITY_Q, engine="polars")
+        msg = str(nie.value)
+        assert "cypher result projection" in msg, msg
+        assert BOTH_ENGINES in msg, msg
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_served(self, engine: str) -> None:
+        got = self._fgraph(engine).gfql(FLOAT_ENTITY_Q, engine=engine)._nodes
+        pdf = got.to_pandas() if hasattr(got, "to_pandas") else got
+        assert list(pdf["x"]) == [FLOAT_ENTITY_TEXT]
+
+
+NUM_VS_STR_Q = "MATCH (x) WHERE x.v > 'foo' RETURN x.id AS i"
+
+
+class TestNumericVsStringPredicateDecline:
+    """Cypher numeric-vs-string compare: polars declines; pandas/cuDF answer 0 rows."""
+
+    def test_polars_decline_offers_cudf(self) -> None:
+        with pytest.raises(NotImplementedError) as nie:
+            _graph("polars").gfql(NUM_VS_STR_Q, engine="polars")
+        msg = str(nie.value)
+        assert "numeric-vs-string" in msg, msg
+        assert BOTH_ENGINES in msg, msg
+
+    @pytest.mark.parametrize("engine", ["pandas", "cudf"])
+    def test_served_empty(self, engine: str) -> None:
+        got = _graph(engine).gfql(NUM_VS_STR_Q, engine=engine)._nodes
+        assert len(got) == 0
+
+
+class TestPandasOnlyDeclinesStayPandasOnly:
+    """Counter-pins: shapes cuDF does NOT serve keep a pandas-only suggestion."""
+
+    MIXED_ISIN = [ast_n({"v": is_in([1, "a"])})]
+
+    def test_polars_mixed_isin_decline_stays_pandas_only(self) -> None:
+        with pytest.raises(NotImplementedError) as nie:
+            _graph("polars").gfql(self.MIXED_ISIN, engine="polars")
+        msg = str(nie.value)
+        assert "IsIn predicate" in msg, msg
+        assert PANDAS_ONLY in msg, msg
+        assert "engine='cudf'" not in msg, msg
+
+    def test_pandas_serves_mixed_isin(self) -> None:
+        got = _graph("pandas").gfql(self.MIXED_ISIN, engine="pandas")._nodes
+        assert sorted(got["id"]) == ["a"]
+
+    def test_cudf_errors_on_mixed_isin(self) -> None:
+        # cuDF cannot build the mixed-type membership column, so the message must not offer it.
+        pytest.importorskip("cudf")
+        with pytest.raises(Exception):
+            _graph("cudf").gfql(self.MIXED_ISIN, engine="cudf")


### PR DESCRIPTION
Fixes the user-facing guidance the #1928 report flagged: polars-engine declines told users to `use engine='pandas'` even where the shape runs on the pandas-idiom path that serves pandas AND cuDF — sending GPU users to CPU for no reason. Every reworded message was verified empirically on this box (cuDF 25.10): a query provably reaching the exact raise on polars was re-run on cudf and pandas and the values compared.

## Classification of all 21 non-test `use engine='pandas'` sites

| Site | Class | Verdict | Evidence |
|---|---|---|---|
| `predicates/str.py:501` | A | unchanged | cuDF regex lacks lookaround/backrefs — genuine cuDF gap; user is already on cuDF |
| `predicates/str.py:511` | A | unchanged | cuDF regex lacks inline flags — same |
| `predicates/str.py:551` | A | unchanged | cuDF regex char-class edge cases — same |
| `gfql/call/executor.py:86` | A | unchanged | polars-gpu call with cuDF stack missing; pandas is the only remedy |
| `chain.py:1052` | A | unchanged | polars not installed |
| `gfql/search_any.py:107` | A (was listed as B candidate) | unchanged | raise fires ONLY on cuDF frames (`"cudf" in type(df).__module__` guard). Probed: pandas serves float explicit `columns=` (`[True, False]`), cuDF raises this NIE, cuDF string col serves. Suggesting cudf would be circular |
| `gfql_unified.py:2368` | B | **now names both** | `MATCH (a)-[e]->(b) WHERE a.v < b.v RETURN ...`: polars NIE; pandas rows=2 `{(a,b),(a,c)}` == cudf |
| `cypher/reentry/execution.py:416` | B | **now names both** | `WITH p, p.v AS pv MATCH (p)-[]->(q)`: polars NIE; pandas `{(1,b),(1,c),(5,c),(7,a)}` == cudf (int-vs-float dtype only) |
| `lazy/engine/polars/chain.py:593` | B | **now names both** | reached via `UNWIND [a.v,a.v]` (`'unwind'`) and comma-pattern pattern-WHERE (`'semi_apply_mark'`): pandas == cudf served |
| `lazy/engine/polars/chain.py:767` | B | **now names both** | `[call('limit',2), n()]`: polars NIE; pandas rows=2 == cudf |
| `lazy/engine/polars/chain.py:860` | B | **now names both** | let-DAG ref-after-`limit` traversal: polars NIE; pandas rows=2 == cudf |
| `lazy/engine/polars/chain.py:927` | B | **now names both** | `MATCH (a {id:'a'})-[*2..3]->(b)`: polars NIE (#1748); pandas `{e}` == cudf |
| `lazy/engine/polars/projection.py:249` | B | **now names both** | float whole-entity entity-text (`OPTIONAL MATCH ... RETURN x` row-guard): polars NIE; pandas `"({lbl: 'C', f: 3.5})"` == cudf |
| `lazy/engine/polars/predicates.py:343` | B | **now names both** | Cypher `WHERE n.v > 'foo'`: polars NIE; pandas rows=0 == cudf |
| `gfql/row/pipeline.py:5315` | B | **now names both** | DAG `call('order_by'/'unwind'/'where_rows')`: polars NIE; pandas == cudf on all three |
| `lazy/engine/polars/predicates.py:369` | B | **stays pandas-only** | mixed-type `is_in([1,'a'])`: pandas serves `[a]`, cuDF raises `MixedTypeError`. (IsIn-with-None and empty IsIn DO serve on cuDF, but one message covers all reaching shapes — a blanket cuDF promise would over-claim) |
| `lazy/engine/polars/predicates.py:387` | B | **stays pandas-only** | List-column vs scalar: pandas rows=0; cuDF raises `AttributeError: 'str' object has no attribute 'has_nulls'` |
| `cypher/lowering.py:8367` | B | unchanged (engine-independent) | pattern-predicate WHERE + `count(*)` in a comma-join: polars, pandas, AND cudf all raise the identical compile-time `GFQLValidationError` — no engine serves it; the message's advice is to rewrite the WHERE shape |
| `gfql_unified.py:186` | B | unreachable-by-construction | guard fires only if the projector did NOT record matched-seed ids, but both the polars projector (`projection.py::_record_entity_meta`) and the pandas projector (`result_postprocess.py:360`) always record `"ids"` whenever the id column is present; 16-shape OPTIONAL MATCH probe never reached it. Defensive; wording untouched per parity-or-error |
| `lazy/engine/polars/predicates.py:6` | comment | unchanged | module docstring stating the no-bridge policy; two of this file's three raises stay genuinely pandas-only |
| `lazy/engine/polars/row_pipeline.py:1701` | comment | unchanged (scoped off) | polars-gpu collect NIE advice; polars-gpu cannot run on this box (cupy `libnvrtc.so.12` broken), so cuDF service through that path is unverifiable |

**Scoped off:** polars-gpu execution and cupy-backed index kernels (broken `libnvrtc.so.12` on this box). All cuDF verification used dataframe ops only, which work on cuDF 25.10.

## Comment clarifications (the owner's pandas/cuDF ambiguity)

- `gfql_unified.py:501` — "break the pandas branch below" → "pandas/cuDF branch" (it is the `else` of `is_polars_df`, serving cuDF too)
- `gfql_unified.py:1752` — "pushdown plan under pandas vs polars dtypes" → "pandas/cuDF vs polars dtypes"
- `gfql_unified.py:2364` — DFSamePathExecutor comment now says it serves "pandas AND cuDF"
- `gfql_unified.py:~2077` cudf↔polars routing comment — reviewed, accurate as written, left alone
- `reentry/execution.py` and `polars/chain.py` decline comments: "pandas-only" → "pandas/cuDF-only" where verified

## Pins

New `graphistry/tests/compute/gfql/test_decline_guidance_cross_engine.py` (24 tests, all passing locally with cuDF cells executing on GPU):

- For same-path WHERE, scalar WITH carry, min_hops>1 alias, cypher row op, DAG row-pipeline op, float whole-entity projection, and numeric-vs-string compare: asserts polars raises a typed NIE naming the feature AND `use engine='pandas' or engine='cudf'`, and that pandas and cuDF both return the **hand-computed** values (not generated by running the code, not cross-engine agreement alone).
- Counter-pins: mixed-type IsIn keeps a pandas-only message, asserts `engine='cudf'` is NOT advertised, pandas serves the hand-computed row, and cuDF genuinely errors.

Registered in the polars lane (`bin/test-polars.sh` `POLARS_TEST_FILES`); `test_polars_lane_completeness.py` passes. No new SOURCE files, so `coverage_baselines/*.json` are unchanged.

## Gates

- `ruff check graphistry bin` clean
- All three guards clean, run from inside the worktree (comment-density, type-hygiene, cypher-surface)
- `mypy graphistry`: 4 errors in 2 files — byte-identical to master `ef98faaab` (polars-stub arg-type in `polars/degrees.py` etc.), no new errors
- Full `graphistry/tests/compute`: failure SET identical to master baseline on this box (102 pre-existing cuDF/cupy-`libnvrtc`/optional-dep failures; see PR checks for CI lanes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
