### PR TITLE
ci: surface baseline 9643 -> 9645 for the #1901+#1902 union

### DIFF
--- a/bin/ci_cypher_surface_guard_baseline.json
+++ b/bin/ci_cypher_surface_guard_baseline.json
@@ -13,5 +13,5 @@
       "max_properties": 0
     }
   },
-  "lowering_py_max_lines": 9643
+  "lowering_py_max_lines": 9645
 }


### PR DESCRIPTION
Master's `cypher-frontend-surface-guard` lane is red: lowering.py is 9645 lines, baseline allows 9643. Neither landed PR could see this — the baseline is a per-file snapshot, and #1901/#1902 each measured only its own merged tree; the 2-line overage is the union of two individually-green PRs (the recorded stale-snapshot hazard).

The two lines are #1901's chained-aggregate decline guards, reviewed and amplification-audited on that PR. This is a snapshot correction, not new headroom; the lowering.py refactor budget stays tracked in #1921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm