### PR TITLE
docs(gfql): fix indexing.rst doc-example NameError (cherry-pick of #1850)

### DIFF
--- a/docs/source/gfql/indexing.rst
+++ b/docs/source/gfql/indexing.rst
@@ -177,6 +177,7 @@ time). Consequences:
 
 .. code-block:: python
 
+   new_edges_df = edges_df.assign(amount=edges_df["amount"] + 1)
    g2 = g_indexed.edges(new_edges_df, "src", "dst")
    g2.show_indexes()          # edge_out_adj / edge_in_adj now valid=False; node_id still True
    g2 = g2.gfql_index_all()   # pay again for the new frame; all valid=True


### PR DESCRIPTION
Cherry-pick of vaimdevs' one-line fix from #1850, which is stacked on #1721 and would otherwise wait for that review. Original commit `4e7654bce` — authorship preserved.

Verified: `new_edges_df` is used at `indexing.rst:180` with no definition anywhere on the page (NameError for anyone running the snippets sequentially); the fix's `amount` column exists in the page's own `edges_df`; and `assign` returning a NEW frame is exactly the invalidation lesson the example teaches (edge adjacency → valid=False, node_id stays True).

#1850 can be closed as superseded once this lands, or left to auto-resolve when #1721 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm