### PR TITLE
fix(gfql): cuDF incomparable ordering comparisons yield null, not False (#1934)

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -95,6 +95,8 @@ POLARS_TEST_FILES=(
     # polars params (Z-suffix text-temporal compare, IN [datetime(...)], mixed-type UNION
     # decline) only run here
     graphistry/tests/compute/gfql/test_temporal_and_union_semantics_1915.py
+    # #1934 incomparable-ordering-null pins: the polars typed-decline cells only run here
+    graphistry/tests/compute/gfql/test_incomparable_ordering_null_1934.py
     graphistry/tests/compute/gfql/index/test_indexed_bindings.py
     graphistry/tests/compute/gfql/test_reentry_caller_graph_immutability.py
     graphistry/tests/compute/gfql/test_rewrite_param_discard.py

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -631,8 +631,8 @@ class RowPipelineMixin:
 
         if _is_cudf_series(left) or _is_cudf_series(right):
             # A cuDF column holds one dtype, so a dtype-level TypeError means every row is incomparable -> null, never False.
-            false_series = self._gfql_broadcast_scalar(table_df, False)
-            return false_series.where(false_series, None)
+            false_series = self._gfql_broadcast_scalar(table_df, False)  # pragma: no cover - cuDF-only arm; no cuDF lane in the coverage gate (validated by test_incomparable_ordering_null_1934 on cuDF 25.10)
+            return false_series.where(false_series, None)  # pragma: no cover - cuDF-only arm; same gate gap
 
         left_series = left if hasattr(left, "astype") else self._gfql_broadcast_scalar(table_df, left)
         right_series = right if hasattr(right, "astype") else self._gfql_broadcast_scalar(table_df, right)

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -630,9 +630,11 @@ class RowPipelineMixin:
             return hasattr(value, "__class__") and value.__class__.__module__.startswith("cudf")
 
         if _is_cudf_series(left) or _is_cudf_series(right):
-            # cuDF raises dtype-level TypeError for mixed-type comparisons;
-            # preserve Cypher filtering semantics without host round-trips.
-            return self._gfql_broadcast_scalar(table_df, False)
+            # cuDF raises dtype-level TypeError for mixed-type comparisons, and a
+            # cuDF column holds ONE dtype, so every row is incomparable -> null
+            # (openCypher), never False: NOT (...) must drop these rows too (#1934).
+            false_series = self._gfql_broadcast_scalar(table_df, False)
+            return false_series.where(false_series, None)
 
         left_series = left if hasattr(left, "astype") else self._gfql_broadcast_scalar(table_df, left)
         right_series = right if hasattr(right, "astype") else self._gfql_broadcast_scalar(table_df, right)

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -630,9 +630,7 @@ class RowPipelineMixin:
             return hasattr(value, "__class__") and value.__class__.__module__.startswith("cudf")
 
         if _is_cudf_series(left) or _is_cudf_series(right):
-            # cuDF raises dtype-level TypeError for mixed-type comparisons, and a
-            # cuDF column holds ONE dtype, so every row is incomparable -> null
-            # (openCypher), never False: NOT (...) must drop these rows too (#1934).
+            # A cuDF column holds one dtype, so a dtype-level TypeError means every row is incomparable -> null, never False.
             false_series = self._gfql_broadcast_scalar(table_df, False)
             return false_series.where(false_series, None)
 

--- a/graphistry/tests/compute/gfql/test_incomparable_ordering_null_1934.py
+++ b/graphistry/tests/compute/gfql/test_incomparable_ordering_null_1934.py
@@ -1,0 +1,108 @@
+"""#1934: incomparable ordering comparisons yield NULL on every engine, never False.
+
+openCypher orders only within a type: STRING vs NUMBER ordering is incomparable ->
+null, so BOTH ``WHERE pred`` and ``WHERE NOT pred`` drop the row. #1919 fixed the
+pandas arm; the cuDF arm kept an early-return-False, so ``NOT (n.str_col < 1.0)``
+KEPT every non-null row on cuDF while pandas dropped it. Pinned here per engine:
+pandas serves null, cuDF serves null (post-fix), polars declines typed
+(parity-or-error by design). Equality is deliberately NOT rerouted: mixed-type
+``=`` stays the pre-existing typed GFQLSchemaError on both engines.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import graphistry
+
+
+NODES = pd.DataFrame({
+    "id": ["a", "b", "c"],
+    "str_col": ["x", "y", None],
+})
+EDGES = pd.DataFrame({"src": ["a"], "dst": ["b"]})
+
+
+def _graph(engine: str):
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        return graphistry.nodes(cudf.from_pandas(NODES), "id").edges(
+            cudf.from_pandas(EDGES), "src", "dst"
+        )
+    return graphistry.nodes(NODES, "id").edges(EDGES, "src", "dst")
+
+
+def _ids(result):
+    nodes = result._nodes
+    if hasattr(nodes, "to_pandas"):
+        nodes = nodes.to_pandas()
+    return sorted(nodes["id"].tolist())
+
+
+# Oracle (hand-computed): every ordering of str_col vs 1.0 is null for rows a/b
+# (incomparable) and null for row c (null input), so the row set is [] for the
+# predicate AND for its negation.
+DIRECT_ORDERINGS = [
+    ("lt", "MATCH (n) WHERE n.str_col < 1.0 RETURN n.id AS id"),
+    ("le", "MATCH (n) WHERE n.str_col <= 1.0 RETURN n.id AS id"),
+    ("gt", "MATCH (n) WHERE n.str_col > 1.0 RETURN n.id AS id"),
+    ("ge", "MATCH (n) WHERE n.str_col >= 1.0 RETURN n.id AS id"),
+    ("lt_rev", "MATCH (n) WHERE 1.0 < n.str_col RETURN n.id AS id"),
+    ("gt_rev", "MATCH (n) WHERE 1.0 > n.str_col RETURN n.id AS id"),
+]
+
+# The user-visible tell: null and False agree under WHERE, but NOT null is null
+# while NOT False is True -- the silent-False arm returned ['a', 'b'] here.
+NOT_ORDERINGS = [
+    ("not_lt", "MATCH (n) WHERE NOT (n.str_col < 1.0) RETURN n.id AS id"),
+    ("not_le", "MATCH (n) WHERE NOT (n.str_col <= 1.0) RETURN n.id AS id"),
+    ("not_gt", "MATCH (n) WHERE NOT (n.str_col > 1.0) RETURN n.id AS id"),
+    ("not_ge", "MATCH (n) WHERE NOT (n.str_col >= 1.0) RETURN n.id AS id"),
+    ("not_lt_rev", "MATCH (n) WHERE NOT (1.0 < n.str_col) RETURN n.id AS id"),
+    ("not_gt_rev", "MATCH (n) WHERE NOT (1.0 > n.str_col) RETURN n.id AS id"),
+]
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize("name,query", DIRECT_ORDERINGS, ids=[c[0] for c in DIRECT_ORDERINGS])
+def test_incomparable_ordering_matches_nothing(engine, name, query):
+    assert _ids(_graph(engine).gfql(query, engine=engine)) == []
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize("name,query", NOT_ORDERINGS, ids=[c[0] for c in NOT_ORDERINGS])
+def test_not_of_incomparable_ordering_also_matches_nothing(engine, name, query):
+    """#1934: red at master on cuDF (returned ['a', 'b']); pandas is the fence."""
+    assert _ids(_graph(engine).gfql(query, engine=engine)) == []
+
+
+@pytest.mark.parametrize(
+    "name,query",
+    DIRECT_ORDERINGS + NOT_ORDERINGS,
+    ids=[c[0] for c in DIRECT_ORDERINGS + NOT_ORDERINGS],
+)
+def test_polars_declines_typed_on_incomparable_ordering(name, query):
+    """polars: NotImplementedError (parity-or-error), never a silent row set."""
+    pytest.importorskip("polars")
+    with pytest.raises(NotImplementedError):
+        _graph("polars").gfql(query, engine="polars")
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_mixed_type_equality_stays_typed_not_null(engine):
+    """Equality is NOT ordering: mixed-type ``=`` keeps its pre-existing typed
+    decline on both engines -- the #1934 null reroute must not swallow it."""
+    from graphistry.compute.exceptions import GFQLSchemaError
+
+    with pytest.raises(GFQLSchemaError):
+        _graph(engine).gfql(
+            "MATCH (n) WHERE n.str_col = 1.0 RETURN n.id AS id", engine=engine
+        )
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_mixed_type_inequality_serves_spec_answer(engine):
+    """openCypher ``'x' <> 1.0`` is true (not null): non-null rows survive."""
+    assert _ids(_graph(engine).gfql(
+        "MATCH (n) WHERE n.str_col <> 1.0 RETURN n.id AS id", engine=engine
+    )) == ["a", "b"]


### PR DESCRIPTION
Fixes #1934

## The defect (introduced by #1919, zero cuDF coverage)

#1919 fixed the pandas arm of `_gfql_safe_mixed_comparison_op` to answer **null** for incomparable ordering comparisons (openCypher: ordering a STRING against a NUMBER is null), but the cuDF arm kept an early `return broadcast(False)`.

`WHERE` hid the divergence (null and False both filter), so the silent-wrong surfaced through negation:

```cypher
MATCH (n) WHERE NOT (n.str_col < 1.0) RETURN n.id
```

- pandas (correct): `[]` — NOT null is null, rows drop
- cuDF at master (wrong): `['a', 'b']` — NOT False is True, rows kept

Repro at master (str_col = `['x', 'y', None]` vs `1.0`, 9 shapes: `<`, `<=`, `>`, `>=`, both operand orders, NOT compositions): pandas 9/9 correct, cuDF wrong on all 3 NOT shapes. After the fix: both engines 9/9.

## The fix

A cuDF column holds ONE dtype, so a dtype-level ordering `TypeError` means every row is incomparable → return an all-null nullable-boolean series (cuDF supports `cudf.NA` booleans natively) instead of broadcast False. Equality never reaches this arm on cuDF (`==`/`!=` on mixed dtypes return False/True with null propagation — the spec answer — without raising), and openCypher mixed-type `=` is false-ish, not null, so equality is deliberately untouched.

## Pins (`test_incomparable_ordering_null_1934.py`, registered in `bin/test-polars.sh`)

- Direct orderings + NOT compositions × {`<`, `<=`, `>`, `>=`} × both operand orders, on pandas AND cuDF. Anti-vacuity: **6 cuDF NOT cells red at master**, all 40 green after; mutation-checked (revert fix → 6 red, restore → green).
- polars: all 12 shapes pinned as **typed `NotImplementedError` decline** (parity-or-error by design; no silent row set to diverge).
- Equality fence: mixed-type `=` stays the pre-existing typed `GFQLSchemaError` on both engines; `<>` serves the spec answer (`['a','b']`), so the null reroute cannot creep into equality.

## Sibling sweep of the same file

- Structural-equality cuDF branch already emits nulls correctly.
- Bool-vs-number ordering guard and native-datetime-vs-`datetime()` literal comparison verified correct on cuDF end-to-end.
- Remaining `except TypeError` sites are groupby/sort/dedup fallbacks, not comparison-result swallows.
- Known typed (not silent) divergence left in place: cuDF `NOT (n.int_col = 'x')` declines with `GFQLTypeError` where pandas serves `['a','b']`.

## Gates

- ruff clean; comment-density / cypher-surface / type-hygiene guards rc=0 (run in the worktree)
- mypy: error set byte-identical to master (4 pre-existing errors in 2 files)
- full `graphistry/tests/compute` under cuDF-enabled python: failure set identical to master baseline apart from this PR's intentional additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
