### PR TITLE
fix(gfql): crash family — polars filter helpers (#1882, #1913-f4) + nodes-only pandas Cypher (#1879)

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -64,6 +64,9 @@ POLARS_TEST_FILES=(
     # polars params (bound validation, hops=None run-to-closure, edges-only node output)
     # only ever run in this lane
     graphistry/tests/compute/gfql/test_hop_semantics_1918.py
+    # #1882/#1913-f4/#1879 crash-family pins: the polars params (filter helpers on polars
+    # frames, polars prune_self_edges, nodes-only typed-decline advice) only run here
+    graphistry/tests/compute/gfql/test_crash_family_1882_1879.py
     graphistry/tests/compute/gfql/test_polars_rows_entity_groupby.py
     graphistry/tests/compute/gfql/test_seeded_typed_hop_fastpath.py
     graphistry/tests/compute/gfql/test_residual_polars_native.py

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -576,11 +576,10 @@ class ComputeMixin(Plottable):
     def prune_self_edges(self):
         edges = self._edges
         if "polars" in type(edges).__module__:
-            # boolean __getitem__ is a pandas/cuDF idiom; polars masks select COLUMNS (#1913).
-            # fill_null(True) keeps null-endpoint rows, as pandas NaN != x does.
+            # polars boolean __getitem__ selects COLUMNS; fill_null(True) keeps null endpoints like pandas NaN != x
             import polars as pl
             return self.edges(edges.filter(
-                (pl.col(self._source) != pl.col(self._destination)).fill_null(True)))
+                (pl.col(self._source) != pl.col(self._destination)).fill_null(True)))  # #1913 finding-4
         return self.edges(edges[ edges[self._source] != edges[self._destination] ])
 
     def collapse(

--- a/graphistry/compute/ComputeMixin.py
+++ b/graphistry/compute/ComputeMixin.py
@@ -574,7 +574,14 @@ class ComputeMixin(Plottable):
         return self.edges(df[mask])
 
     def prune_self_edges(self):
-        return self.edges(self._edges[ self._edges[self._source] != self._edges[self._destination] ])
+        edges = self._edges
+        if "polars" in type(edges).__module__:
+            # boolean __getitem__ is a pandas/cuDF idiom; polars masks select COLUMNS (#1913).
+            # fill_null(True) keeps null-endpoint rows, as pandas NaN != x does.
+            import polars as pl
+            return self.edges(edges.filter(
+                (pl.col(self._source) != pl.col(self._destination)).fill_null(True)))
+        return self.edges(edges[ edges[self._source] != edges[self._destination] ])
 
     def collapse(
         self,

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1197,12 +1197,11 @@ def _chain_impl(
 
         synthesized_empty_edges = False
         if g._edges is None and all(isinstance(op, ASTNode) for op in ops):
-            # Nodes-only graph + node-only chain (#1879): steps only ever slice edges[:0],
-            # so a synthetic empty frame serves; the result drops it (mirrors the input).
+            # node-only steps only ever slice edges[:0], so an empty frame serves; result drops it (#1879)
             synthesized_empty_edges = True
-            src_col = generate_safe_column_name('src', g._nodes, prefix='__gfql_', suffix='__')
-            dst_col = generate_safe_column_name('dst', g._nodes, prefix='__gfql_', suffix='__')
-            g = g.edges(df_cons(engine_concrete)({src_col: [], dst_col: []}), src_col, dst_col)
+            synth_src = generate_safe_column_name('src', g._nodes, prefix='__gfql_', suffix='__')
+            synth_dst = generate_safe_column_name('dst', g._nodes, prefix='__gfql_', suffix='__')
+            g = g.edges(df_cons(engine_concrete)({synth_src: [], synth_dst: []}), synth_src, synth_dst)
         elif g._edges is None and any(isinstance(op, ASTEdge) for op in ops):
             from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError
             raise GFQLSchemaError(

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Any, Dict, Union, cast, List, Tuple, Sequence, Optional, TYPE_CHECKING
-from graphistry.Engine import Engine, EngineAbstract, POLARS_ENGINES, align_shared_column_dtypes, df_concat, df_to_engine, resolve_engine, safe_map_series, safe_row_concat, s_na
+from graphistry.Engine import Engine, EngineAbstract, POLARS_ENGINES, align_shared_column_dtypes, df_concat, df_cons, df_to_engine, resolve_engine, safe_map_series, safe_row_concat, s_na
 from graphistry.compute.dataframe_utils import dbg_df
 
 from graphistry.Plottable import Plottable
@@ -1195,6 +1195,22 @@ def _chain_impl(
     try:
         g = self.materialize_nodes(engine=EngineAbstract(engine_concrete.value))
 
+        synthesized_empty_edges = False
+        if g._edges is None and all(isinstance(op, ASTNode) for op in ops):
+            # Nodes-only graph + node-only chain (#1879): steps only ever slice edges[:0],
+            # so a synthetic empty frame serves; the result drops it (mirrors the input).
+            synthesized_empty_edges = True
+            src_col = generate_safe_column_name('src', g._nodes, prefix='__gfql_', suffix='__')
+            dst_col = generate_safe_column_name('dst', g._nodes, prefix='__gfql_', suffix='__')
+            g = g.edges(df_cons(engine_concrete)({src_col: [], dst_col: []}), src_col, dst_col)
+        elif g._edges is None and any(isinstance(op, ASTEdge) for op in ops):
+            from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError
+            raise GFQLSchemaError(
+                ErrorCode.E304,
+                'Cannot traverse edges: graph has no edges bound',
+                suggestion='Bind edges via g.edges(df, source, destination), or use a node-only pattern'
+            )
+
         if g._edges is None:
             added_edge_index = False
         elif g._edge is None:
@@ -1409,6 +1425,9 @@ def _chain_impl(
                 g_out = self.nodes(final_nodes_df, g._node).edges(final_edges_df, edge=original_edge)
             else:
                 g_out = g.nodes(final_nodes_df).edges(final_edges_df)
+
+            if synthesized_empty_edges:
+                g_out = self.nodes(final_nodes_df, g._node)
 
             if g_out._edges is not None and len(g_out._edges) > 0:
                 concat_fn = df_concat(engine_concrete)

--- a/graphistry/compute/filter_by_dict.py
+++ b/graphistry/compute/filter_by_dict.py
@@ -109,9 +109,8 @@ def filter_by_dict(df: DataFrameT, filter_dict: Optional[dict] = None, engine: U
     logger.debug('filter_by_dict engine: %s => %s', engine, engine_concrete)
 
     if engine_concrete in POLARS_ENGINES:
-        # polars stays polars-native: filter_mask_by_dict/df[hits] are pandas/cuDF idioms (#1882)
         from graphistry.compute.gfql.lazy.engine.polars.predicates import filter_by_dict_polars
-        return filter_by_dict_polars(df, filter_dict)
+        return filter_by_dict_polars(df, filter_dict)  # mask path below is pandas/cuDF-idiom (#1882)
 
     hits = filter_mask_by_dict(df, filter_dict)
     return df[hits]

--- a/graphistry/compute/filter_by_dict.py
+++ b/graphistry/compute/filter_by_dict.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Mapping, Optional, Tuple, Union, cast
 import pandas as pd
 
-from graphistry.Engine import EngineAbstract, df_to_engine, resolve_engine
+from graphistry.Engine import EngineAbstract, POLARS_ENGINES, df_to_engine, resolve_engine
 from graphistry.util import setup_logger
 
 from graphistry.Plottable import Plottable
@@ -107,6 +107,11 @@ def filter_by_dict(df: DataFrameT, filter_dict: Optional[dict] = None, engine: U
     engine_concrete = resolve_engine(engine, df)
     df = df_to_engine(df, engine_concrete)
     logger.debug('filter_by_dict engine: %s => %s', engine, engine_concrete)
+
+    if engine_concrete in POLARS_ENGINES:
+        # polars stays polars-native: filter_mask_by_dict/df[hits] are pandas/cuDF idioms (#1882)
+        from graphistry.compute.gfql.lazy.engine.polars.predicates import filter_by_dict_polars
+        return filter_by_dict_polars(df, filter_dict)
 
     hits = filter_mask_by_dict(df, filter_dict)
     return df[hits]

--- a/graphistry/tests/compute/gfql/test_crash_family_1882_1879.py
+++ b/graphistry/tests/compute/gfql/test_crash_family_1882_1879.py
@@ -1,0 +1,203 @@
+"""Crash-family pins: #1882 (+#1913 finding-4) and #1879's pandas half.
+
+Every case reproduces a verified-live crash at master ``e6625ed28`` with a hand-computed
+oracle, plus the both-sides pins that lock the behavior that already worked:
+
+* #1882 -- PUBLIC ``filter_nodes_by_dict`` / ``filter_edges_by_dict`` / ``filter_by_dict``
+  on polars frames raised ``AttributeError: 'DataFrame' object has no attribute 'assign'``
+  (``filter_by_dict.py`` built the mask with pandas idioms after the resolver routed
+  POLARS). Fixed by dispatching to the existing native ``filter_by_dict_polars``; a
+  polars-in graph must come back polars (no silent engine swap).
+* #1913 finding-4 -- same family: ``prune_self_edges`` on polars edges hit polars'
+  column-selecting boolean ``__getitem__`` (raw ``ValueError``; silently selects COLUMNS
+  when the row count equals the column count). Now polars-native, with pandas'
+  ``NaN != x -> keep`` null-endpoint semantics.
+* #1879 pandas half -- Cypher/chain on a nodes-only graph (edges NEVER bound) died with a
+  bare ``TypeError: 'NoneType' object is not subscriptable`` (``ast.py`` slicing
+  ``g._edges[:0]``), with or without a policy attached (the policy toggle was inert
+  because BOTH paths crashed). Now a node-only pattern is served (it needs no edges) and
+  an edge pattern declines with a typed GFQLSchemaError; polars keeps its typed decline,
+  whose advice recommends engines that must actually serve (pinned live here).
+* empty-but-BOUND edges kept working throughout -- pinned on both engines so the
+  nodes-only fix can never regress it.
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import e_forward, n
+from graphistry.compute.exceptions import GFQLSchemaError
+from graphistry.compute.filter_by_dict import filter_by_dict
+
+try:
+    import polars as pl
+    HAS_POLARS = True
+except ImportError:
+    HAS_POLARS = False
+
+polars_only = pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")
+
+ENGINES = ["pandas", pytest.param("polars", marks=polars_only)]
+
+
+def _frame(engine, df):
+    return pl.from_pandas(df) if engine == "polars" else df
+
+
+def _pd(df):
+    return df.to_pandas() if hasattr(df, "to_pandas") else df
+
+
+def _attr_graph(engine):
+    """0(a) -x-> 1(b) -y-> 2(a)"""
+    ndf = pd.DataFrame({"id": [0, 1, 2], "kind": ["a", "b", "a"]})
+    edf = pd.DataFrame({"s": [0, 1], "d": [1, 2], "rel": ["x", "y"]})
+    return graphistry.nodes(_frame(engine, ndf), "id").edges(_frame(engine, edf), "s", "d")
+
+
+def _nodes_only(engine):
+    ndf = pd.DataFrame({"id": [0, 1, 2], "label__Person": [True, True, False], "v": [10, 20, 30]})
+    return graphistry.nodes(_frame(engine, ndf), "id")
+
+
+# --------------------------------------------------------------------- #1882 helpers
+class TestFilterByDictPolars:
+    """#1882: the three public surfaces serve polars frames, polars-in => polars-out."""
+
+    @polars_only
+    def test_filter_nodes_by_dict_polars(self):
+        out = _attr_graph("polars").filter_nodes_by_dict({"kind": "a"})
+        assert isinstance(out._nodes, pl.DataFrame)  # no silent engine swap
+        assert sorted(_pd(out._nodes)["id"].tolist()) == [0, 2]
+
+    @polars_only
+    def test_filter_edges_by_dict_polars(self):
+        out = _attr_graph("polars").filter_edges_by_dict({"rel": "x"})
+        assert isinstance(out._edges, pl.DataFrame)
+        assert _pd(out._edges)[["s", "d"]].values.tolist() == [[0, 1]]
+
+    @polars_only
+    def test_filter_by_dict_bare_polars(self):
+        df = pl.DataFrame({"id": [0, 1, 2], "kind": ["a", "b", "a"]})
+        out = filter_by_dict(df, {"kind": "a"})
+        assert isinstance(out, pl.DataFrame)
+        assert sorted(out["id"].to_list()) == [0, 2]
+
+    @polars_only
+    @pytest.mark.parametrize("filter_dict", [
+        {"kind": "a"},
+        {"kind": ["a", "b", None]},  # membership 3VL: a null cell is never a member
+        {"id": 2},
+    ])
+    def test_polars_matches_pandas_oracle(self, filter_dict):
+        ndf = pd.DataFrame({"id": [0, 1, 2, 3], "kind": ["a", "b", None, "a"]})
+        expect = filter_by_dict(ndf, filter_dict)["id"].tolist()
+        got = filter_by_dict(pl.from_pandas(ndf), filter_dict)["id"].to_list()
+        assert got == expect
+
+    def test_filter_nodes_by_dict_pandas_unchanged(self):
+        out = _attr_graph("pandas").filter_nodes_by_dict({"kind": "a"})
+        assert isinstance(out._nodes, pd.DataFrame)
+        assert sorted(out._nodes["id"].tolist()) == [0, 2]
+
+
+class TestPruneSelfEdges:
+    """#1913 finding-4: prune_self_edges is engine-dispatched, identical row semantics."""
+
+    #: (0,0) self -> drop; (1,2) keep; (2,2) self -> drop; (None,None) keep (pandas NaN != NaN)
+    _EDF = pd.DataFrame({"s": [0.0, 1.0, 2.0, None], "d": [0.0, 2.0, 2.0, None]})
+
+    @pytest.mark.parametrize("engine", ENGINES)
+    def test_prune_self_edges(self, engine):
+        g = graphistry.nodes(_frame(engine, pd.DataFrame({"id": [0, 1, 2]})), "id") \
+            .edges(_frame(engine, self._EDF), "s", "d")
+        out = g.prune_self_edges()
+        got = _pd(out._edges)
+        assert got[["s", "d"]].values.tolist()[0] == [1.0, 2.0]
+        assert len(got) == 2 and got[["s", "d"]].isna().all(axis=1).iloc[1]
+        if engine == "polars":
+            assert isinstance(out._edges, pl.DataFrame)  # no silent engine swap
+
+
+# --------------------------------------------------------------------- #1879 pandas half
+NODES_ONLY_QUERIES = [
+    ("plain", "MATCH (a) RETURN a.id AS id ORDER BY id", [0, 1, 2]),
+    ("label", "MATCH (a:Person) RETURN a.id AS id ORDER BY id", [0, 1]),
+    ("where", "MATCH (a) WHERE a.v > 15 RETURN a.id AS id ORDER BY id", [1, 2]),
+    ("agg", "MATCH (a) RETURN count(*) AS c", None),
+]
+
+
+class TestNodesOnlyCypherPandas:
+    """#1879: pandas serves node-only patterns on a graph whose edges were NEVER bound."""
+
+    @pytest.mark.parametrize("_name,query,expect", NODES_ONLY_QUERIES)
+    def test_nodes_only_serves(self, _name, query, expect):
+        res = _nodes_only("pandas").gfql(query, engine="pandas")
+        if expect is None:
+            assert res._nodes["c"].tolist() == [3]
+        else:
+            assert res._nodes["id"].tolist() == expect
+
+    @pytest.mark.parametrize("_name,query,expect", NODES_ONLY_QUERIES)
+    def test_policy_does_not_toggle_answers(self, _name, query, expect):
+        """#1879: attaching a policy must not change the answer (it used to flip paths)."""
+        calls = []
+        res = _nodes_only("pandas").gfql(
+            query, engine="pandas", policy={"preload": lambda ctx: calls.append(ctx["hook"])})
+        assert calls == ["preload"]  # the hook actually fired
+        baseline = _nodes_only("pandas").gfql(query, engine="pandas")
+        pd.testing.assert_frame_equal(
+            res._nodes.reset_index(drop=True), baseline._nodes.reset_index(drop=True))
+
+    def test_chain_node_only_serves_and_result_stays_nodes_only(self):
+        out = _nodes_only("pandas").chain([n({"id": 0})])
+        assert out._nodes["id"].tolist() == [0]
+        assert out._edges is None  # result mirrors the nodes-only input
+
+    def test_chain_with_policy_serves_and_result_stays_nodes_only(self):
+        """A policy forces the non-fast chain path -- the path that crashed at ast.py:265 --
+        and the served result must still drop the internally synthesized empty edges."""
+        out = _nodes_only("pandas").gfql(
+            [n({"id": 0})], engine="pandas", policy={"preload": lambda ctx: None})
+        assert out._nodes["id"].tolist() == [0]
+        assert out._edges is None  # result mirrors the nodes-only input
+
+    def test_edge_pattern_declines_typed_cypher(self):
+        with pytest.raises(GFQLSchemaError, match="no edges"):
+            _nodes_only("pandas").gfql("MATCH (a)-[r]->(b) RETURN a.id AS id", engine="pandas")
+
+    def test_edge_op_declines_typed_chain(self):
+        with pytest.raises(GFQLSchemaError, match="no edges"):
+            _nodes_only("pandas").chain([n(), e_forward(), n()])
+
+
+class TestNodesOnlyPolarsDecline:
+    """#1879 polars side: still a typed decline, and its advice must name WORKING engines."""
+
+    @polars_only
+    def test_polars_declines_typed_with_live_advice(self):
+        with pytest.raises(NotImplementedError) as exc:
+            _nodes_only("polars").gfql("MATCH (a) RETURN a.id AS id ORDER BY id", engine="polars")
+        advice = str(exc.value)
+        assert "pandas" in advice
+        # the advice is only valid because the recommended engine now serves -- run it
+        res = _nodes_only("pandas").gfql("MATCH (a) RETURN a.id AS id ORDER BY id", engine="pandas")
+        assert res._nodes["id"].tolist() == [0, 1, 2]
+
+
+class TestEmptyBoundEdgesStillServe:
+    """Both-sides pin: empty-but-BOUND edges worked before the fix and must keep working."""
+
+    @pytest.mark.parametrize("engine", ENGINES)
+    @pytest.mark.parametrize("_name,query,expect", NODES_ONLY_QUERIES)
+    def test_empty_bound_edges(self, engine, _name, query, expect):
+        g = _nodes_only(engine).edges(
+            _frame(engine, pd.DataFrame({"s": pd.Series([], dtype="int64"),
+                                         "d": pd.Series([], dtype="int64")})), "s", "d")
+        res = g.gfql(query, engine=engine)
+        got = _pd(res._nodes)
+        if expect is None:
+            assert got["c"].tolist() == [3]
+        else:
+            assert got["id"].tolist() == expect


### PR DESCRIPTION
Pre-release crash-family fixes, all verified live at master `e6625ed28` with hand-computed oracles.

## #1882 — public `filter_by_dict` helpers crash on polars frames (FIXED — Fixes #1882)

`filter_nodes_by_dict` / `filter_edges_by_dict` / bare `filter_by_dict` on polars frames raised `AttributeError: 'DataFrame' object has no attribute 'assign'` (`filter_by_dict.py` built the mask with pandas idioms after `resolve_engine` routed POLARS). Fix: `filter_by_dict` now dispatches POLARS-resolved frames to the existing native `filter_by_dict_polars` (same column resolution via the shared `resolve_filter_column`, same typed E301/E302 errors, same 3VL membership semantics). Polars-in comes back polars — no silent engine swap; explicit `engine='pandas'` coercion is unchanged. Exotic predicates with no native polars lowering keep the engine's existing parity-or-error NIE contract (as GFQL polars chains already do).

The two secondary findings in the #1882 body (`seeded_typed_hop` lazy-frame decline, `get_degrees` nodes-only divergence) are NOT addressed here — #1882 can close on its headline defect per its title, or stay open if those are tracked under it.

## #1913 finding-4 — same family on `prune_self_edges` (PARTIAL: finding 4 only)

`prune_self_edges` on polars edges hit polars' column-selecting boolean `__getitem__`: raw `ValueError`, and it would silently select COLUMNS whenever the row count equals the column count. Now polars-native (`.filter` expression, eager and lazy), preserving pandas' `NaN != x -> keep` null-endpoint row semantics; polars-in stays polars. The `filter_nodes_by_dict`/`filter_edges_by_dict` half of finding 4 falls out of the #1882 fix and is pinned. **#1913 stays open**: findings 1–3 (stale-index rebind resurrection, recovery-recipe failures, completeness-lock blind spots) are untouched here.

## #1879 — Cypher/chain on nodes-only graphs (PARTIAL: pandas half + advice)

On a graph whose edges were NEVER bound, all pandas Cypher/chain died with a bare `TypeError: 'NoneType' object is not subscriptable` (`ast.py:265` slicing `g._edges[:0]`), with or without a policy attached — the policy toggle was inert because both paths crashed. Now:

- **pandas serves node-only patterns** (`MATCH (n) …` needs no edges): the chain executor synthesizes an internal empty edge frame for node-only op lists and drops it from the result (nodes-only in, nodes-only out; policy on/off agree, and the pins assert the hooks actually fire).
- **edge patterns decline typed**: `GFQLSchemaError` E304 "Cannot traverse edges: graph has no edges bound" instead of the bare TypeError, on both the Cypher and `chain()` surfaces.
- **polars advice is no longer broken**: polars keeps its typed `NotImplementedError` decline, and its "use engine='pandas'" guidance now points at an engine that serves — pinned live (the pin runs the recommended engine and checks the answer).
- **empty-but-BOUND edges** kept working throughout — pinned on both engines.

**#1879 stays open** for the polars half: polars still declines node-only patterns on nodes-only graphs (typed, with working advice) rather than serving them; serving there means teaching `_chain_traversal_polars` / its node-only fast case to run without bound edge endpoints. ASTCall-bearing chains on nodes-only graphs also keep their pre-existing behavior (out of scope).

## Pins & anti-vacuity

`graphistry/tests/compute/gfql/test_crash_family_1882_1879.py` (registered in `bin/test-polars.sh` POLARS_TEST_FILES): 30 tests, **19 red at master `e6625ed28` / 11 both-sides pins green there; all 30 green at this head**. Mutation checks: each fix piece reverted independently is caught (filter dispatch → 6 pins; prune polars branch → 1; chain synthesize → 10; typed decline → 2; result strip → 1).

## Gates

- ruff clean; comment-density / cypher-surface / type-hygiene guards rc=0
- full-tree mypy: identical 4 pre-existing errors vs master (diff empty)
- full `graphistry/tests/compute` failure SET identical to master's baseline apart from the new pins (details in checks); `gfql/index/test_index.py` (#1913 rebind/index contracts) failure set identical to master (its 38 cudf-param fails are environmental — `libnvrtc.so.12` missing on this box, identical at master; pandas/polars all pass)
- polars-lane registration for the new polars-mentioning test file (lane-completeness guard green); no new source files, so no coverage-baseline entries needed
- cuDF spot-checked live for both fixes (dataframe ops lane; cupy-only lanes are broken on this box and were not run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
