### PR TITLE
fix(gfql): polars honours rows(alias_prefilters=); HAS_<Label> dup-id narrowing in the grouped-aggregate fast path

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -98,6 +98,12 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/index/test_indexed_bindings.py
     graphistry/tests/compute/gfql/test_reentry_caller_graph_immutability.py
     graphistry/tests/compute/gfql/test_rewrite_param_discard.py
+    # #1804 rows(alias_prefilters=...) native honouring: the polars params (and the typed
+    # NIE decline) only ever run here
+    graphistry/tests/compute/gfql/test_engine_polars_alias_prefilters.py
+    # #1739 HAS_<Label> dup-id disambiguation on the grouped-aggregate fast path: the
+    # polars params only ever run here
+    graphistry/tests/compute/gfql/test_has_label_dup_id_fast_path.py
     graphistry/tests/compute/test_engine_coercion.py
     graphistry/tests/compute/test_let_binding_contracts.py
     # index tests exercise the seeded-index hook in the polars hop entry (hop.py) — without

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -625,9 +625,13 @@ def _try_native_row_op(g_cur, op):
     fn = op.function
     if fn == "rows" and op.params.get("binding_ops") is not None:
         # #1731: single-entity boundary rows (MATCH (n) / EXISTS seeds) are handled by
-        # the pattern-apply helper; try that narrow shape first.
+        # the pattern-apply helper; try that narrow shape first. alias_prefilters
+        # thread through — a helper that ignored them would silently drop the filter.
         if op.params.get("source") is None:
-            out = rows_binding_ops_polars(g_cur, op.params["binding_ops"])
+            out = rows_binding_ops_polars(
+                g_cur, op.params["binding_ops"],
+                alias_prefilters=op.params.get("alias_prefilters"),
+            )
             if out is not None:
                 return out
         # #1730 gate: only take the multi-alias bindings table when alias_endpoints is
@@ -638,7 +642,8 @@ def _try_native_row_op(g_cur, op):
             # pattern handler below (EXISTS/searchAny); returning None here would turn
             # those already-native shapes into an NIE.
             bindings_result = binding_rows_polars(
-                g_cur, op.params["binding_ops"], op.params.get("attach_prop_aliases")
+                g_cur, op.params["binding_ops"], op.params.get("attach_prop_aliases"),
+                alias_prefilters=op.params.get("alias_prefilters"),
             )
             if bindings_result is not None:
                 return bindings_result

--- a/graphistry/compute/gfql/lazy/engine/polars/pattern_apply.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/pattern_apply.py
@@ -17,6 +17,7 @@ from graphistry.Plottable import Plottable
 if TYPE_CHECKING:
     import polars as pl
     from graphistry.compute.ast import ASTObject
+    from graphistry.compute.gfql.row.prefilter import AliasPrefilters
 
 from .dtypes import is_lazy
 from .row_pipeline import _active_table, _rewrap
@@ -39,15 +40,21 @@ def _binding_ast_ops(binding_ops: Sequence[Dict[str, JSONVal]]) -> Optional[List
         return None
 
 
-def rows_binding_ops_polars(g: Plottable, binding_ops: Sequence[Dict[str, JSONVal]]) -> Optional[Plottable]:
+def rows_binding_ops_polars(
+    g: Plottable,
+    binding_ops: Sequence[Dict[str, JSONVal]],
+    alias_prefilters: "Optional[AliasPrefilters]" = None,
+) -> Optional[Plottable]:
     """Native ``rows(binding_ops=[...])`` for the SINGLE named-Node case — the shape the
     boundary rewrite emits for a one-entity MATCH (the EXISTS pipeline's left table).
     Mirrors the pandas ``_gfql_node_alias_lookup_frame`` layout exactly:
     ``[node_id, alias, alias.node_id, alias.<col>...]`` in source column order.
+    ``alias_prefilters`` narrow the matched frame natively — never dropped.
     Anything else (multi-op, edge ops, unnamed, node query=) declines (None -> NIE)."""
     import polars as pl
     from graphistry.compute.ast import ASTNode as _ASTNode
     from .predicates import filter_by_dict_polars
+    from .row_pipeline import _apply_alias_prefilters_polars
     ops = _binding_ast_ops(binding_ops)
     if ops is None or len(ops) != 1 or not isinstance(ops[0], _ASTNode):
         return None
@@ -78,6 +85,8 @@ def rows_binding_ops_polars(g: Plottable, binding_ops: Sequence[Dict[str, JSONVa
         return None
     if matched is None:
         return None
+    # L4 pushdown twin of pandas' cartesian prefilter: NEVER silently dropped
+    matched = _apply_alias_prefilters_polars(matched, alias, alias_prefilters)  # honoured, never dropped (#1804)
     if alias == node_id:
         # pandas' named-op flag column OVERWRITES the id column in this corner —
         # neither engine has sane semantics; decline honestly (wave-1 I1).

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     import polars as pl
     from graphistry.compute.gfql.expr_parser import ExprNode, FunctionCall
     from graphistry.compute.ast import ASTObject
+    from graphistry.compute.gfql.row.prefilter import AliasPrefilters
 
     # Within ONE call the path bag and its per-alias frames are the same polars
     # flavour — the generic builder works in LazyFrames, the indexed one in eager
@@ -1089,13 +1090,123 @@ def _lower_with_schema(table: "pl.DataFrame", fn: Callable[[], _LowerT],
     """Run a lowering callable with the table schema published to ``_SCHEMA`` (float-operand
     inference for the NaN guard) and the graph node-id column published to ``_NODE_ID`` (bare
     ``__gfql_node_id__`` identity-sentinel resolution)."""
-    schema_token = _SCHEMA.set(dict(table.schema))
+    return _lower_with_schema_map(dict(table.schema), fn, node_id=node_id)
+
+
+def _lower_with_schema_map(schema: "Mapping[str, pl.DataType]", fn: Callable[[], _LowerT],
+                           node_id: Optional[str] = None) -> _LowerT:
+    """`_lower_with_schema` for callers holding a schema mapping rather than an eager frame
+    (LazyFrame call sites resolve via ``collect_schema`` — no ``.schema`` warning/collect)."""
+    schema_token = _SCHEMA.set(dict(schema))
     node_id_token = _NODE_ID.set(node_id)
     try:
         return fn()
     finally:
         _SCHEMA.reset(schema_token)
         _NODE_ID.reset(node_id_token)
+
+
+def _apply_alias_prefilters_polars(
+    frame: "PolarsFrameT",
+    alias: Optional[str],
+    alias_prefilters: "Optional[AliasPrefilters]",
+    *,
+    reserved: Sequence[str] = (),
+) -> "PolarsFrameT":
+    """Native twin of the pandas ``_gfql_apply_alias_prefilter`` (L4 single-alias predicate
+    pushdown): pre-filter ONE alias's frame before the binding join. Same evaluator
+    family as the post-join ops (``lower_expr_str`` / ``search_match_expr``), same validation
+    errors as the pandas prefilter, and a TYPED NotImplementedError naming ``alias_prefilters``
+    for any spec the polars lowering cannot serve — a dropped prefilter returns rows the
+    caller filtered out, the worst silent-wrong class. ``frame`` is eager-or-lazy polars;
+    returns the same flavour. ``reserved`` = edge endpoint columns excluded from the
+    searchAny pool (join keys, never searched — pandas twin's ``is_edge`` arm)."""
+    import polars as pl
+    from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
+
+    if not alias or not alias_prefilters or frame is None:
+        return frame
+    specs = alias_prefilters.get(alias)
+    if not specs:
+        return frame
+
+    def _decline(detail: str) -> NotImplementedError:
+        return NotImplementedError(
+            f"polars engine cannot natively honour rows(alias_prefilters=...) for alias "
+            f"{alias!r}: {detail}; use engine='pandas' or engine='cudf' for this query "
+            f"(no silent fallback; a dropped prefilter would return filtered-out rows)"
+        )
+
+    schema = dict(frame.collect_schema()) if isinstance(frame, pl.LazyFrame) else dict(frame.schema)
+    names = list(schema.keys())
+    for spec in specs:
+        kind = spec.get("kind")
+        if kind == "expr":
+            # Same rename-to-qualified trick as the pandas twin: evaluate ``alias.prop``
+            # against a view whose columns carry the alias-qualified names.
+            mapping = {c: f"{alias}.{c}" for c in names}
+            inverse = {v: k for k, v in mapping.items()}
+            renamed_schema = {mapping[c]: dt for c, dt in schema.items()}
+            text = spec.get("text")
+            if not isinstance(text, str):
+                raise _decline("expr prefilter without string text")
+            lowered = _lower_with_schema_map(
+                renamed_schema,
+                lambda: lower_expr_str(text, list(renamed_schema.keys())),
+            )
+            if lowered is None:
+                raise _decline(f"expr prefilter not natively lowerable: {text!r}")
+            frame = frame.rename(mapping).filter(lowered).rename(inverse)
+        elif kind == "search_any":
+            from .search import auto_search_columns, search_match_expr
+            term = spec.get("term")
+            if not isinstance(term, str):
+                raise GFQLValidationError(
+                    ErrorCode.E108,
+                    "searchAny pushdown requires a string term",
+                    field="term",
+                    value=term,
+                    language="cypher",
+                )
+            columns = spec.get("columns")
+            if columns is not None and not all(isinstance(col, str) for col in columns):
+                raise GFQLValidationError(
+                    ErrorCode.E108,
+                    "searchAny pushdown columns= must be a list of strings",
+                    field="columns",
+                    value=columns,
+                    language="cypher",
+                )
+            # Same pool as the pandas twin: alias property columns only (join keys and
+            # internal ``__gfql_`` columns excluded).
+            pool = [c for c in names if c not in reserved and not c.startswith("__gfql_")]
+            if columns is not None:
+                if any(c not in pool for c in columns):
+                    raise GFQLValidationError(
+                        ErrorCode.E108,
+                        "searchAny pushdown columns= includes a column absent from the alias frame",
+                        field="columns",
+                        value=list(columns),
+                        language="cypher",
+                    )
+                chosen = list(columns)
+            else:
+                chosen = auto_search_columns(schema, pool, term)
+            if not chosen:
+                # No searchable column ⇒ no row matches (pandas kernel: all-False mask).
+                frame = frame.filter(pl.lit(False))
+                continue
+            match = search_match_expr(
+                schema, chosen, term,
+                case_sensitive=bool(spec.get("case_sensitive", False)),
+                regex=bool(spec.get("regex", False)),
+            )
+            if match is None:
+                raise _decline(f"searchAny prefilter not natively lowerable: {term!r}")
+            frame = frame.filter(match.fill_null(False))
+        else:
+            raise _decline(f"unknown prefilter kind {kind!r}")
+    return frame
 
 
 def _project_preserving_height(table: Any, exprs: List[Any]) -> Any:
@@ -1456,6 +1567,7 @@ def _cartesian_node_bindings_polars(
     g: Plottable,
     ops: "Sequence[ASTObject]",
     node_id: Optional[str],
+    alias_prefilters: "Optional[AliasPrefilters]" = None,
 ) -> Optional[Plottable]:
     """Native polars cross-product for disconnected MATCH aliases (#1273).
 
@@ -1520,6 +1632,8 @@ def _cartesian_node_bindings_polars(
             raise
         except Exception:  # pragma: no cover - defensive: unexpected filter failure declines
             return None
+        # L4 pushdown twin of pandas `_gfql_cartesian_node_bindings_row_table`
+        matched = _apply_alias_prefilters_polars(matched, alias, alias_prefilters)  # honoured, never dropped (#1804)
         cols = matched.collect_schema().names()
         # prop_cols excludes node_id and any real column named == alias: the pandas
         # node execute() leaks a boolean FLAG into a column named ``alias``
@@ -1551,6 +1665,7 @@ def binding_rows_polars(
     g: Plottable,
     binding_ops: Sequence[Dict[str, JSONVal]],
     attach_prop_aliases: Optional[Sequence[str]] = None,
+    alias_prefilters: "Optional[AliasPrefilters]" = None,
 ) -> Optional[Plottable]:
     """Native polars bindings-row table for connected alias patterns (#1709).
 
@@ -1561,6 +1676,12 @@ def binding_rows_polars(
     columns per node alias. (The pandas frame additionally carries join-residue
     columns — raw ``node_id``, ``a__a_join__``, leaked ``__gfql_edge_index__`` —
     that no lowered query references; those are intentionally not replicated.)
+
+    ``alias_prefilters`` are honoured natively via
+    ``_apply_alias_prefilters_polars`` at the same per-alias points as the pandas
+    builder (seed / per-hop edge / endpoint frames); a spec the polars lowering
+    cannot serve raises a typed NotImplementedError naming the feature — NEVER a
+    silent drop (rows the caller filtered out coming back is the worst class).
 
     Covers fixed-length hops, bounded variable-length (directed ``-[*i..k]->`` and
     undirected ``-[*1..k]-``), unbounded DIRECTED fixed point (``-[*]->`` /
@@ -1650,7 +1771,7 @@ def binding_rows_polars(
             # applied at seed_nodes; node-cartesian re-entry stays pandas-only).
             return None
         # MATCH (a), (b), ... disconnected node aliases: native cross-product.
-        return _cartesian_node_bindings_polars(g, ops, node_id)
+        return _cartesian_node_bindings_polars(g, ops, node_id, alias_prefilters)
     if RowPipelineMixin._gfql_is_shortest_path_scalar_binding_ops(ops):
         return None  # shortestPath scalar contract: BFS/native backends, pandas-only
 
@@ -1669,9 +1790,10 @@ def binding_rows_polars(
 
     handoff = read_handoff(g)
     plan = list(binding_ops)
+    # a prefiltered plan never reuses a prefilter-blind handoff state (pandas twin gate)
     indexed_state = (
         handoff.state
-        if handoff is not None and handoff.serves(plan, engine_concrete)
+        if handoff is not None and handoff.serves(plan, engine_concrete) and not alias_prefilters
         else None
     )
     if indexed_state is None and not (handoff is not None and handoff.declined(plan)):
@@ -1680,6 +1802,7 @@ def binding_rows_polars(
             ops,
             engine=engine_concrete,
             start_nodes=start_nodes,
+            alias_prefilters=alias_prefilters,
         )
     if indexed_state is not None:
         return _finish_binding_rows_polars(
@@ -1814,6 +1937,8 @@ def binding_rows_polars(
         if seed_ids_lf is not None:
             # WITH->MATCH re-entry seed: constrain the first alias to the carried ids.
             seed_nodes = seed_nodes.join(seed_ids_lf, on=node_id, how="semi")
+        # L4 pushdown twin of pandas `_gfql_connected_bindings_state`'s seed prefilter
+        seed_nodes = _apply_alias_prefilters_polars(seed_nodes, first_op._name, alias_prefilters)  # honoured, never dropped (#1804)
         # The whole generic builder works in LazyFrames (`nodes_lf` / `edges_lf` above);
         # `filter_by_dict_polars` is frame-polymorphic at runtime but declares the eager
         # type, so pin the path bag lazy here instead of leaving every downstream lazy
@@ -1834,6 +1959,11 @@ def binding_rows_polars(
             sem = EdgeSemantics.from_edge(edge_op)
             edges_f = filter_by_dict_polars(edges_lf, edge_op.edge_match)
             edge_alias = edge_op._name
+            if not sem.is_multihop and isinstance(edge_alias, str):
+                # pandas' per-hop edge prefilter twin; src/dst = join keys, never searched
+                edges_f = _apply_alias_prefilters_polars(
+                    edges_f, edge_alias, alias_prefilters, reserved=(src, dst),
+                )
             if isinstance(edge_alias, str):
                 payload_renames = {
                     col: f"{edge_alias}.{col}"
@@ -1866,6 +1996,8 @@ def binding_rows_polars(
             if not isinstance(next_op, ASTNode):
                 return None
             next_nodes = filter_by_dict_polars(nodes_lf, next_op.filter_dict)
+            # pandas' endpoint prefilter twin: before the id set, so membership + alias frame agree
+            next_nodes = _apply_alias_prefilters_polars(next_nodes, next_op._name, alias_prefilters)
             next_node_ids = next_nodes.select(node_id).unique()
             if not sem.is_multihop:
                 # Filter endpoint candidates before joining from the current state.

--- a/graphistry/compute/gfql/lazy/engine/polars/search.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/search.py
@@ -3,70 +3,42 @@
 row_pipeline.py (the expression/projection lowering core) — degrees.py precedent."""
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
 
 from graphistry.Plottable import Plottable
 
 from .row_pipeline import _active_table, _rewrap
 
+if TYPE_CHECKING:
+    import polars as pl
 
-def search_any_polars(
-    g: Plottable,
-    alias: str,
-    term: str,
-    out_col: str,
-    case_sensitive: bool = False,
-    regex: bool = False,
-    columns: Optional[Sequence[str]] = None,
-) -> Optional[Plottable]:
-    """Native polars ``search_any`` (viz-filter L2): OR-across-columns marker, same
-    dtype gate as the pandas kernel (string cols always; int cols iff numeric-literal
-    term; float/date/bool auto-gated out). Regex path applies the same Rust-regex
-    decline gate as Contains; literal default folds via lowercase (never regex).
-    None declines (honest NIE)."""
+
+def auto_search_columns(schema: "Mapping[str, pl.DataType]", pool_cols: Sequence[str], term: str) -> List[str]:
+    """The pandas kernel's dtype auto-gate: string columns always, int columns iff the
+    term is a numeric literal; float/date/bool/nested never (see search_any_polars)."""
     import polars as pl
     from graphistry.compute.gfql.search_any import is_numeric_term
+    numeric_ok = is_numeric_term(term)
+    chosen = []
+    for real in pool_cols:
+        dt = schema[real]
+        if dt == pl.String:
+            chosen.append(real)
+        elif numeric_ok and dt in (pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+                                   pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64):
+            chosen.append(real)
+    return chosen
+
+
+def search_match_expr(schema: "Mapping[str, pl.DataType]", chosen: Sequence[str], term: str,
+                      *, case_sensitive: bool, regex: bool) -> "Optional[pl.Expr]":
+    """OR-across-columns match expr over already-chosen columns; None declines (NIE).
+
+    Single lowering shared by the ``search_any`` row op and the ``search_any`` alias
+    prefilter so the dtype/regex decline gates cannot drift between them.
+    """
+    import polars as pl
     from .predicates import _regex_rust_incompatible
-    left = _active_table(g)
-    if left is None:
-        return None
-    prefix = f"{alias}."
-    prefixed = [c for c in left.columns if c.startswith(prefix)]
-    if prefixed:
-        pool = {c[len(prefix):]: c for c in prefixed}
-    else:
-        pool = {c: c for c in left.columns
-                if not c.startswith("__gfql_") and c != alias}
-    schema = dict(left.schema)
-    if columns is not None:
-        if any(c not in pool for c in columns):
-            # same validation error as the pandas row pipeline (there is no pandas
-            # fallback behind this dispatch — a generic NIE here would misreport a
-            # user input error as an engine gap; wave-1 I2)
-            from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
-            raise GFQLValidationError(
-                ErrorCode.E108,
-                "searchAny columns= includes a column absent from the searched table",
-                field="columns",
-                value=list(columns),
-                suggestion="List only columns present on the searched entity.",
-                language="cypher",
-            )
-        chosen = [pool[c] for c in columns]
-    else:
-        numeric_ok = is_numeric_term(term)
-        chosen = []
-        for real in pool.values():
-            dt = schema[real]
-            if dt == pl.String:
-                chosen.append(real)
-            elif numeric_ok and dt in (pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-                                       pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64):
-                chosen.append(real)
-    if len(left) == 0 or not chosen:
-        marked = left.with_columns(
-            pl.lit(False).alias(out_col) if len(left) else pl.lit(None).cast(pl.Boolean).alias(out_col))
-        return _rewrap(g, marked)
     if regex and _regex_rust_incompatible(term):
         return None
     # Explicit columns= reaches beyond the auto gate: only dtypes whose canonical
@@ -105,5 +77,58 @@ def search_any_polars(
             exprs.append(base.str.contains(term, literal=True))
         else:
             exprs.append(base.str.to_lowercase().str.contains(term.lower(), literal=True))
-    marked = left.with_columns(pl.any_horizontal(exprs).fill_null(False).alias(out_col))
+    return pl.any_horizontal(exprs)
+
+
+def search_any_polars(
+    g: Plottable,
+    alias: str,
+    term: str,
+    out_col: str,
+    case_sensitive: bool = False,
+    regex: bool = False,
+    columns: Optional[Sequence[str]] = None,
+) -> Optional[Plottable]:
+    """Native polars ``search_any`` (viz-filter L2): OR-across-columns marker, same
+    dtype gate as the pandas kernel (string cols always; int cols iff numeric-literal
+    term; float/date/bool auto-gated out). Regex path applies the same Rust-regex
+    decline gate as Contains; literal default folds via lowercase (never regex).
+    None declines (honest NIE)."""
+    import polars as pl
+    left = _active_table(g)
+    if left is None:
+        return None
+    prefix = f"{alias}."
+    prefixed = [c for c in left.columns if c.startswith(prefix)]
+    if prefixed:
+        pool = {c[len(prefix):]: c for c in prefixed}
+    else:
+        pool = {c: c for c in left.columns
+                if not c.startswith("__gfql_") and c != alias}
+    schema = dict(left.schema)
+    if columns is not None:
+        if any(c not in pool for c in columns):
+            # same validation error as the pandas row pipeline (there is no pandas
+            # fallback behind this dispatch — a generic NIE here would misreport a
+            # user input error as an engine gap; wave-1 I2)
+            from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
+            raise GFQLValidationError(
+                ErrorCode.E108,
+                "searchAny columns= includes a column absent from the searched table",
+                field="columns",
+                value=list(columns),
+                suggestion="List only columns present on the searched entity.",
+                language="cypher",
+            )
+        chosen = [pool[c] for c in columns]
+    else:
+        chosen = auto_search_columns(schema, list(pool.values()), term)
+    if len(left) == 0 or not chosen:
+        marked = left.with_columns(
+            pl.lit(False).alias(out_col) if len(left) else pl.lit(None).cast(pl.Boolean).alias(out_col))
+        return _rewrap(g, marked)
+    match = search_match_expr(schema, chosen, term, case_sensitive=case_sensitive, regex=regex)
+    if match is None:
+        return None
+    marked = left.with_columns(match.fill_null(False).alias(out_col))
     return _rewrap(g, marked)

--- a/graphistry/compute/gfql_fast_paths.py
+++ b/graphistry/compute/gfql_fast_paths.py
@@ -2198,6 +2198,58 @@ def _single_hop_grouped_aggregate_fused_polars(
     return cast(DataFrameT, _lazy_collect(out_lf))
 
 
+def _has_edge_destination_disambiguated_nodes(
+    nodes: DataFrameT,
+    start_nodes: DataFrameT,
+    edges: DataFrameT,
+    *,
+    node_col: str,
+    src_col: str,
+    dst_col: str,
+    label_col: str,
+    engine: Engine,
+) -> Optional[DataFrameT]:
+    """HAS_<Label> destination disambiguation for the single-hop fast path.
+
+    Twin of pandas ``RowPipelineMixin._gfql_disambiguate_has_edge_destination_nodes`` at
+    its pipeline position: the candidate destination set is the base node rows whose id is
+    a dst of a (filtered) edge leaving a (filtered) start node; iff those candidate ids
+    COLLIDE, the destination domain narrows to the ``label__<Label>``-true rows of the
+    full node table. Returns the narrowed node frame, or None for "no narrowing" (unique
+    candidates — pandas does not narrow there either, even on a duplicate-id table)."""
+    if engine in POLARS_ENGINES:
+        import polars as pl
+        tbl_dup = bool(_lazy_collect(
+            nodes.lazy()  # type: ignore[union-attr]
+            .select(pl.col(node_col).is_duplicated().any())
+        ).item())
+        if not tbl_dup:
+            return None
+        start_ids = start_nodes.lazy().select(node_col).unique()  # type: ignore[union-attr]
+        cand_ids = (
+            edges.lazy()  # type: ignore[union-attr]
+            .join(start_ids, left_on=src_col, right_on=node_col, how="semi")
+            .select(pl.col(dst_col).alias(node_col))
+            .unique()
+        )
+        cand_dup = bool(_lazy_collect(
+            nodes.lazy()  # type: ignore[union-attr]
+            .join(cand_ids, on=node_col, how="semi")
+            .select(pl.col(node_col).is_duplicated().any())
+        ).item())
+        if not cand_dup:
+            return None
+        return nodes.filter(pl.col(label_col).fill_null(False).cast(pl.Boolean))  # type: ignore[union-attr]
+    if not bool(nodes[node_col].duplicated(keep=False).any()):
+        return None
+    start_ids = start_nodes[node_col].drop_duplicates()
+    cand_ids = edges.loc[edges[src_col].isin(start_ids), dst_col].drop_duplicates()
+    cand = nodes[nodes[node_col].isin(cand_ids)]
+    if not bool(cand[node_col].duplicated(keep=False).any()):
+        return None
+    return nodes[nodes[label_col].fillna(False).astype(bool)]
+
+
 def _execute_single_hop_grouped_aggregate_fast_path(
     base_graph: Plottable,
     chain: Chain,
@@ -2348,6 +2400,26 @@ def _execute_single_hop_grouped_aggregate_fast_path(
     start_nodes = _connected_join_cached_node_filter(base_graph, nodes, cast(Optional[dict], start_op.filter_dict), engine=requested_engine, project=start_proj)
     end_nodes = _connected_join_cached_node_filter(base_graph, nodes, cast(Optional[dict], end_op.filter_dict), engine=requested_engine, project=end_proj)
     edges = _connected_join_cached_edge_filter(base_graph, cast(DataFrameT, edges_obj), cast(Optional[dict], edge_op.edge_match), engine=requested_engine, project=edge_proj)
+
+    # Unlabeled HAS_<Label> destinations on a duplicate-id table must narrow BEFORE the
+    # property joins (they join by node id, so a colliding id attaches every same-id row);
+    # same conditional as pandas' `_gfql_disambiguate_has_edge_destination_nodes` oracle.
+    from graphistry.compute.gfql.row.pipeline import RowPipelineMixin  # narrowing oracle (#1739)
+    dis_label_col = RowPipelineMixin._gfql_has_edge_destination_label_col(edge_op, nodes.columns)
+    if (
+        dis_label_col is not None
+        and not RowPipelineMixin._gfql_node_filter_has_label(end_op.filter_dict)
+    ):
+        narrowed = _has_edge_destination_disambiguated_nodes(
+            nodes, start_nodes, edges,
+            node_col=node_col, src_col=src_col, dst_col=dst_col,
+            label_col=dis_label_col, engine=requested_engine,
+        )
+        if narrowed is not None:
+            end_nodes = _filter_project(
+                narrowed, cast(Optional[dict], end_op.filter_dict), end_proj,
+                engine=requested_engine,
+            )
 
     fused_out: Optional[DataFrameT] = None
     if requested_engine in POLARS_ENGINES:

--- a/graphistry/tests/compute/gfql/test_engine_polars_alias_prefilters.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_alias_prefilters.py
@@ -1,0 +1,166 @@
+"""#1804: the native polars bindings builder must HONOUR ``rows(alias_prefilters=...)``.
+
+At master e6625ed28 the polars boundary called ``binding_rows_polars`` with
+``binding_ops`` and ``attach_prop_aliases`` only, so a caller-set ``alias_prefilters``
+was silently DISCARDED and the filtered-out rows came back (12 rows / max(a.id)=8 where
+pandas and cuDF answer 5 / 2) — the worst silent-wrong class. The builder now applies
+the specs natively per alias (``_apply_alias_prefilters_polars``) at the same points as
+the pandas builder: seed alias, per-hop edge alias, endpoint alias, the node-cartesian
+mode, and the single-entity pattern-apply shape. The flipped strict xfail lives in
+``test_rewrite_param_discard.py``; this file pins per-surface VALUE parity against the
+pandas oracle plus the typed decline.
+
+DECLINE CONTRACT: a spec the polars lowering cannot serve raises a NotImplementedError
+NAMING ``alias_prefilters`` — never a silent drop, never a pandas bridge. (On the Cypher
+surface the lowering that emits these prefilters always keeps the equivalent post-join
+filter, and that post-join op declines on the same shapes, so the earlier typed NIE does
+not retire any previously-served Cypher query.)
+
+Anti-vacuity: every filtered pin also asserts the UNFILTERED count, so a prefilter that
+stops narrowing (the master defect) fails on the number, not on schema noise.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, List, Optional
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import ASTObject, e_forward, n, rows, serialize_binding_ops
+from graphistry.tests.compute.gfql.polars_test_utils import engine_skip_reason
+
+ENGINES = ("pandas", "cudf", "polars")
+
+NODES = pd.DataFrame({
+    "id": np.arange(1, 13, dtype=np.int64),
+    "kind": ["seed", "mid", "mid", "end", "end", "tail",
+             "tail", "reverse", "seed", "noise", "noise", "noise"],
+    # float column: the polars searchAny lowering declines float stringification
+    # (repr diverges from pandas in the exponent regime), giving the typed-NIE pin below.
+    "score": np.linspace(0.0, 1.1, 12),
+})
+EDGES = pd.DataFrame({
+    "src": [1, 1, 1, 2, 2, 3, 4, 5, 6, 8, 4, 5],
+    "dst": [2, 2, 3, 4, 5, 5, 6, 6, 7, 1, 2, 3],
+    "type": ["A", "A", "A", "B", "B", "B", "C", "C", "D", "REV", "B", "B"],
+    "weight": np.arange(10, 22, dtype=np.int64),
+})
+ALL_EDGES = len(EDGES)
+
+MIDDLE: List[ASTObject] = [n(name="a"), e_forward(name="r"), n(name="b")]
+BOPS = serialize_binding_ops(MIDDLE)
+
+
+def _graph(engine: str) -> Any:
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        return graphistry.nodes(pl.from_pandas(NODES), "id").edges(
+            pl.from_pandas(EDGES), "src", "dst")
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        return graphistry.nodes(cudf.from_pandas(NODES), "id").edges(
+            cudf.from_pandas(EDGES), "src", "dst")
+    return graphistry.nodes(NODES, "id").edges(EDGES, "src", "dst")
+
+
+@lru_cache(maxsize=None)
+def _engine_skip_reason(engine: str) -> Optional[str]:
+    def smoke() -> None:
+        # NOT the shape under test: no alias_prefilters anywhere in the smoke.
+        _graph(engine).gfql([n({"id": 1}), e_forward(), n()], engine=engine)
+
+    return engine_skip_reason(engine, smoke)
+
+
+def _require(engine: str) -> None:
+    reason = _engine_skip_reason(engine)
+    if reason is not None:
+        pytest.skip(f"engine {engine!r} unavailable here ({reason}) — NOT evidence of passing")
+
+
+def _run(engine: str, ops: List[ASTObject]) -> pd.DataFrame:
+    out = _graph(engine).gfql(list(ops), engine=engine)._nodes
+    assert out is not None
+    return out.to_pandas() if hasattr(out, "to_pandas") else out
+
+
+def _pairs(frame: pd.DataFrame, cols: List[str]) -> List[tuple]:
+    return sorted(map(tuple, frame[cols].values.tolist()))
+
+
+# Each case: (prefilters, hand-computed filtered row count, columns whose values must
+# match pandas). Counts are hand-derived from the 12-edge fixture, so a prefilter that
+# silently stops narrowing (master's polars defect: 12 rows back) fails on the number.
+PREFILTER_CASES = {
+    "seed_expr": ({"a": [{"kind": "expr", "text": "a.id < 3"}]}, 5, ["a.id", "b"]),
+    "endpoint_expr": ({"b": [{"kind": "expr", "text": "b.kind = 'end'"}]}, 3, ["a.id", "b"]),
+    "edge_expr": ({"r": [{"kind": "expr", "text": "r.weight >= 20"}]}, 2, ["a.id", "b", "r.weight"]),
+    "seed_search_any": ({"a": [{"kind": "search_any", "term": "seed"}]}, 3, ["a.id", "b"]),
+}
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("case", sorted(PREFILTER_CASES))
+def test_connected_prefilter_narrows_and_matches_pandas(engine: str, case: str) -> None:
+    _require(engine)
+    prefilters, expected_rows, value_cols = PREFILTER_CASES[case]
+    unfiltered = _run(engine, [rows(binding_ops=BOPS)])
+    filtered = _run(engine, [rows(binding_ops=BOPS, alias_prefilters=prefilters)])
+    assert len(unfiltered) == ALL_EDGES  # anti-vacuity: the unnarrowed bag is the full bag
+    assert len(filtered) == expected_rows, (
+        f"[{engine}/{case}] prefilter narrowed to {len(filtered)} rows, expected "
+        f"{expected_rows} (a discarded prefilter returns {ALL_EDGES})"
+    )
+    if engine != "pandas":
+        oracle = _run("pandas", [rows(binding_ops=BOPS, alias_prefilters=prefilters)])
+        assert _pairs(filtered, value_cols) == _pairs(oracle, value_cols), (
+            f"[{engine}/{case}] filtered VALUES diverge from the pandas oracle"
+        )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_cartesian_prefilter_narrows_and_matches_pandas(engine: str) -> None:
+    """Disconnected MATCH (a), (b): the node-cartesian mode must honour prefilters too.
+
+    12x12 cross-product; ``a.id < 3`` keeps 2x12 = 24 rows.
+    """
+    _require(engine)
+    cart = serialize_binding_ops([n(name="a"), n(name="b")])
+    pref = {"a": [{"kind": "expr", "text": "a.id < 3"}]}
+    unfiltered = _run(engine, [rows(binding_ops=cart)])
+    filtered = _run(engine, [rows(binding_ops=cart, alias_prefilters=pref)])
+    assert len(unfiltered) == 144
+    assert len(filtered) == 24
+    assert sorted(filtered["a"].unique().tolist()) == [1, 2]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_single_entity_prefilter_narrows_and_keeps_the_layout(engine: str) -> None:
+    """The single named-Node shape (the EXISTS-pipeline left table) honours prefilters
+    WITHOUT changing its column layout between the filtered and unfiltered spellings."""
+    _require(engine)
+    single = serialize_binding_ops([n(name="a")])
+    pref = {"a": [{"kind": "expr", "text": "a.id < 3"}]}
+    unfiltered = _run(engine, [rows(binding_ops=single)])
+    filtered = _run(engine, [rows(binding_ops=single, alias_prefilters=pref)])
+    assert len(unfiltered) == len(NODES)
+    assert len(filtered) == 2
+    assert sorted(filtered["a"].tolist()) == [1, 2]
+    assert sorted(map(str, filtered.columns)) == sorted(map(str, unfiltered.columns))
+
+
+def test_polars_unlowerable_prefilter_declines_typed_naming_the_feature() -> None:
+    """A spec polars cannot lower raises a typed NIE NAMING alias_prefilters.
+
+    searchAny over an explicit FLOAT column is the deterministic decline (float
+    stringification diverges from the pandas kernel, same gate as the post-join
+    ``search_any`` op). The error must name the feature and the alias — never a
+    silent drop, never a raw polars exception.
+    """
+    _require("polars")
+    pref = {"a": [{"kind": "search_any", "term": "1", "columns": ["score"]}]}
+    with pytest.raises(NotImplementedError, match=r"alias_prefilters.*'a'"):
+        _run("polars", [rows(binding_ops=BOPS, alias_prefilters=pref)])

--- a/graphistry/tests/compute/gfql/test_has_label_dup_id_fast_path.py
+++ b/graphistry/tests/compute/gfql/test_has_label_dup_id_fast_path.py
@@ -1,0 +1,181 @@
+"""#1739: HAS_<Label> destination disambiguation on DUPLICATE-id node tables must hold
+on the single-hop grouped-aggregate fast path, on every engine.
+
+THE DEFECT (red at master e6625ed28). The Cypher lowering of an LDBC-style multi-label
+graph collides node ids across label tables (the same id carries a Tag row and a Forum
+row). ``MATCH (post:Post {id})-[:HAS_TAG]->(tag) RETURN tag.title, count(post)`` serves via
+``_execute_single_hop_grouped_aggregate_fast_path``, whose lanes join the ``tag`` property
+lookup by node id:
+
+* the polars lanes joined WITHOUT any dedup or label narrowing, so the colliding id
+  attached BOTH rows' properties and the aggregate emitted an extra group
+  (``[{f4,1},{t4,1}]`` where the oracle says ``[{t4,1}]``);
+* the pandas/cuDF lane deduped ``keep='first'`` — the oracle answer only when the
+  label-true row happens to come first in the frame (order-dependent, not narrowing).
+
+THE ORACLE is hand-computed and matches the pandas ROW PIPELINE
+(``_gfql_disambiguate_has_edge_destination_nodes``): when the candidate destination ids of
+a forward ``HAS_<Label>``-typed hop COLLIDE and the destination alias carries no label
+filter, the destination domain narrows to the ``label__<Label>``-true rows. Unique
+candidate ids (even on a duplicate-id table) do NOT narrow, and a labeled destination
+filter disables narrowing — both sides pinned below so the fix cannot over-narrow.
+
+ENGINES: pandas + polars run everywhere this lane runs; cudf skips with a stated reason
+where the GPU stack is absent (never silently green). polars-gpu is exercised out of band
+(see test_rewrite_param_discard's COVERAGE BOUNDARY note).
+
+The grouped property column is ``title``, not ``name``: a node property literally named
+``name`` trips a PRE-EXISTING, unrelated cuDF crash in the fast path's pandas-API lane
+(``grouped.size().reset_index(name=...)`` collides with the column; ValueError at master
+e6625ed28 too) — do not rename it back, or the cudf params test that quirk instead of
+the #1739 narrowing.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.tests.compute.gfql.polars_test_utils import engine_skip_reason
+
+ENGINES = ("pandas", "cudf", "polars")
+
+# Node id 400 collides (Tag row 't4' + Forum row 'f4'); 500 collides too but is never a
+# destination, so it proves the CANDIDATE-scoped probe (a full-table probe alone must not
+# narrow the 500 rows' queries). Edge 601-HAS_TAG->400 is the colliding hop.
+_BASE: Dict[str, List[Any]] = {
+    "id": [600, 601, 201, 300, 400, 400, 500, 500],
+    "label__Post": [True, True, False, False, False, False, False, False],
+    "label__Tag": [False, False, True, False, True, False, True, False],
+    "label__Forum": [False, False, False, True, False, True, False, True],
+    "title": [None, None, "t1", "f-node", "t4", "f4", "t5", "f5"],
+}
+EDGES = pd.DataFrame({
+    "src": [600, 600, 601],
+    "dst": [201, 300, 400],
+    "type": ["HAS_TAG", "HAS_TAG", "HAS_TAG"],
+})
+
+Q_COLLIDING = (
+    "MATCH (post:Post {id: 601})-[:HAS_TAG]->(tag) "
+    "RETURN tag.title AS tagName, count(post) AS c ORDER BY tagName"
+)
+Q_UNIQUE_CANDIDATES = (
+    "MATCH (post:Post {id: 600})-[:HAS_TAG]->(tag) "
+    "RETURN tag.title AS tagName, count(post) AS c ORDER BY tagName"
+)
+Q_LABELED_DEST = (
+    "MATCH (post:Post {id: 601})-[:HAS_TAG]->(tag:Forum) "
+    "RETURN tag.title AS tagName, count(post) AS c ORDER BY tagName"
+)
+
+
+def _nodes(order: str) -> pd.DataFrame:
+    """``tag_first`` = the fixture as written (label-true row first for id 400);
+    ``forum_first`` swaps the two id-400 rows — the order that unmasked the pandas
+    lane's keep='first' accident at master."""
+    df = pd.DataFrame(_BASE)
+    if order == "forum_first":
+        idx = list(range(len(df)))
+        idx[4], idx[5] = idx[5], idx[4]
+        df = df.iloc[idx].reset_index(drop=True)
+    return df
+
+
+def _graph(engine: str, nodes: pd.DataFrame) -> Any:
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        return graphistry.nodes(pl.from_pandas(nodes), "id").edges(
+            pl.from_pandas(EDGES), "src", "dst")
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        return graphistry.nodes(cudf.from_pandas(nodes), "id").edges(
+            cudf.from_pandas(EDGES), "src", "dst")
+    return graphistry.nodes(nodes, "id").edges(EDGES, "src", "dst")
+
+
+@lru_cache(maxsize=None)
+def _engine_skip_reason(engine: str) -> Optional[str]:
+    def smoke() -> None:
+        # NOT the shape under test (no HAS_ type, no duplicate destination).
+        _graph(engine, _nodes("tag_first")).gfql(
+            "MATCH (a:Post {id: 600}) RETURN a.id AS i", engine=engine)
+
+    return engine_skip_reason(engine, smoke)
+
+
+def _require(engine: str) -> None:
+    reason = _engine_skip_reason(engine)
+    if reason is not None:
+        pytest.skip(f"engine {engine!r} unavailable here ({reason}) — NOT evidence of passing")
+
+
+def _records(engine: str, nodes: pd.DataFrame, query: str) -> List[Dict[str, Any]]:
+    out = _graph(engine, nodes).gfql(query, engine=engine)._nodes
+    if hasattr(out, "collect"):
+        out = out.collect()
+    if hasattr(out, "to_pandas"):
+        out = out.to_pandas()
+    return out.to_dict("records")
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("order", ["tag_first", "forum_first"])
+def test_colliding_destination_narrows_to_the_label_row(engine: str, order: str) -> None:
+    """The colliding hop answers the label-narrowed row set — in BOTH frame orders.
+
+    Red at master: polars emitted ``[{f4,1},{t4,1}]`` in both orders; pandas emitted
+    ``[{f4,1}]`` in ``forum_first`` (keep='first' kept the Forum row). One group, the
+    Tag row, is the only answer the disambiguation contract allows.
+    """
+    _require(engine)
+    assert _records(engine, _nodes(order), Q_COLLIDING) == [{"tagName": "t4", "c": 1}]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_unique_candidate_ids_do_not_narrow(engine: str) -> None:
+    """ANTI-OVER-NARROWING: unique candidate ids keep every destination row.
+
+    Seeded from post 600 the candidate destinations are {201, 300} — unique, even though
+    the TABLE has colliding ids (400, 500). The pandas oracle does not narrow here, so
+    the non-Tag destination ``f-node`` must survive; a mutant that narrows on the
+    full-table probe (or unconditionally by label) drops it and fails this test.
+    """
+    _require(engine)
+    assert _records(engine, _nodes("tag_first"), Q_UNIQUE_CANDIDATES) == [
+        {"tagName": "f-node", "c": 1},
+        {"tagName": "t1", "c": 1},
+    ]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_labeled_destination_filter_disables_narrowing(engine: str) -> None:
+    """An explicit destination label wins over the edge type's implied label.
+
+    ``->(tag:Forum)`` filters the destination itself, so the HAS_TAG narrowing must NOT
+    apply (pandas oracle: ``_gfql_node_filter_has_label`` short-circuits) and the Forum
+    row is the answer.
+    """
+    _require(engine)
+    assert _records(engine, _nodes("tag_first"), Q_LABELED_DEST) == [{"tagName": "f4", "c": 1}]
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_fast_path_still_serves_the_colliding_shape(engine: str) -> None:
+    """ANTI-VACUITY: the fix narrows INSIDE the fast path rather than declining it.
+
+    Every value test above passes equally if the fast path silently retires and the
+    query re-serves on the canonical route (or, on polars, would NIE) — so pin the
+    engagement itself, via the public trace rather than a monkeypatch (see
+    engagement.py on why patching private names fails open).
+    """
+    _require(engine)
+    from graphistry.tests.compute.gfql.engagement import assert_fast_path
+
+    assert_fast_path(
+        _graph(engine, _nodes("tag_first")), Q_COLLIDING,
+        "single_hop_grouped_aggregate", served=True, engine=engine,
+    )

--- a/graphistry/tests/compute/gfql/test_known_cross_engine_divergences.py
+++ b/graphistry/tests/compute/gfql/test_known_cross_engine_divergences.py
@@ -40,15 +40,16 @@ def test_1808_dangling_destination_pandas_matches_polars():
 
 
 @polars_only
-@pytest.mark.xfail(strict=True, reason="#1739: HAS_<Label> narrowing missing on polars; pandas fast-path answer is order-dependent")
 def test_1739_has_label_aggregate_on_duplicate_ids_converges():
-    """#1739: duplicate node id across Tag/Forum rows; the aggregating
+    """#1739 (fixed): duplicate node id across Tag/Forum rows; the aggregating
     single-MATCH shape serves BOTH engines via the grouped-aggregate fast path,
-    where pandas keeps one row per id by frame order (an accident, not the row
-    pipeline's label narrowing) and polars keeps both. The converged answer is
-    the label-narrowed one. Flipping this xfail = porting the
-    _gfql_disambiguate_has_edge_destination_nodes gate (or the #1737 decline)
-    to the shared fast path and the generic polars route."""
+    where pandas kept one row per id by frame order (an accident, not the row
+    pipeline's label narrowing) and polars kept both. The fast path now applies
+    the `_gfql_disambiguate_has_edge_destination_nodes` conditional to the
+    destination domain before its property joins
+    (`_has_edge_destination_disambiguated_nodes`), so every engine answers the
+    label-narrowed row set — see test_has_label_dup_id_fast_path.py for the
+    order-flip and no-narrowing pins."""
     nodes = pd.DataFrame({
         "id": [601, 400, 400],
         "label__Post": [True, False, False],

--- a/graphistry/tests/compute/gfql/test_rewrite_param_discard.py
+++ b/graphistry/tests/compute/gfql/test_rewrite_param_discard.py
@@ -28,7 +28,7 @@ around the same two functions, and neither is caught by the table= cases.
 ENGINE LIST IS FIXED, NOT PROBED-INTO-EXISTENCE. ``polars-gpu`` joins the three engines this
 file already carried: it is the GPU collect target of the SAME native polars chain, so it
 runs the same rewrite and the same indexed bypass, and it must therefore land on the same
-side of every gate polars does — including the strict xfail at the bottom. An engine that
+side of every gate polars does. An engine that
 cannot run in the current environment reports SKIPPED with a reason; it never vanishes from
 the report (the trap in ``polars_test_utils.available_nonpandas_engines()``, which silently
 shrinks). The probe RUNS a query rather than importing a module, because a box where
@@ -297,7 +297,7 @@ def test_named_middle_rewrite_keeps_attach_prop_aliases_values(engine: str) -> N
 
 
 # ---------------------------------------------------------------------------
-# 3. an UNFIXED third instance of the class, pinned rather than left to be rediscovered
+# 3. the third instance of the class: rows(alias_prefilters=...) — fixed (#1804)
 # ---------------------------------------------------------------------------
 
 # Unseeded so the prefilter is the ONLY thing that can narrow the result.
@@ -305,34 +305,17 @@ OPEN_MIDDLE: List[ASTObject] = [n(name="a"), e_forward(name="r"), n(name="b")]
 ALIAS_PREFILTER = {"a": [{"kind": "expr", "text": "a.id < 3"}]}
 
 
-@pytest.mark.parametrize("engine", [
-    "pandas",
-    "cudf",
-    pytest.param("polars", marks=pytest.mark.xfail(
-        strict=True,
-        reason="#1804: native polars bindings builder never receives alias_prefilters",
-    )),
-    pytest.param("polars-gpu", marks=pytest.mark.xfail(
-        strict=True,
-        reason="#1804: polars-gpu is the same native builder as polars, same missing param",
-    )),
-])
+@pytest.mark.parametrize("engine", ENGINES)
 def test_alias_prefilters_are_honoured_by_the_bindings_builder(engine: str) -> None:
-    """`alias_prefilters` narrows the bindings on pandas/cuDF — and is IGNORED on polars.
+    """`alias_prefilters` narrows the bindings on EVERY engine (#1804, fixed).
 
-    The native polars row op calls its bindings builder with `binding_ops` and
-    `attach_prop_aliases` only, so the param never reaches it; the generic path threads it
-    into `_gfql_binding_ops_row_table`. Same query, 5 rows vs 12.
-
-    Filed as #1804. Not fixed here: the hint is documented as ADVISORY (the cypher lowering that emits it
-    always keeps the equivalent post-join filter, so Cypher answers agree across engines
-    and only the pushdown is lost), and honouring it natively means porting the whole
-    prefilter evaluator — a feature, not this fix. Hand-written GFQL that passes
-    `alias_prefilters` without a matching post-filter DOES get engine-dependent answers.
-
-    A STRICT xfail on the polars case, not a skip and not an inverted assertion: when
-    polars learns the param this turns into a failure, so whoever fixes it is told to
-    delete the marker instead of leaving a stale "known gap" behind.
+    The native polars row op used to call its bindings builder with `binding_ops` and
+    `attach_prop_aliases` only, so the param never reached it and the filtered-out rows
+    came back: same query, 12 rows instead of 5. The builder now applies the specs
+    natively per alias (`_apply_alias_prefilters_polars`) at the same points the pandas
+    builder does, and a spec the polars lowering cannot serve raises a typed
+    NotImplementedError naming `alias_prefilters` instead of dropping the filter
+    (see test_engine_polars_alias_prefilters.py).
     """
     _require(engine)
     binding_ops = serialize_binding_ops(OPEN_MIDDLE)


### PR DESCRIPTION
Fixes #1804
Fixes #1739

Two verified polars silent-wrong defects, both reproduced on master `e6625ed28` before fixing.

## #1804 — polars silently discarded `rows(alias_prefilters=...)`

**Before** (master): `binding_rows_polars` had no `alias_prefilters` parameter and the polars boundary never passed it — the param was thrown away, so rows the caller filtered out came back. Repro fixture: unfiltered=12 / filtered **should** be 5 with `max(a.id)=2`; polars returned **12 / max=8** where pandas and cuDF return 5 / 2. `polars-gpu` shares the builder.

**After**: the specs are applied natively per alias (`_apply_alias_prefilters_polars` in `lazy/engine/polars/row_pipeline.py`) at the same points as the pandas builder:
- seed alias / per-hop edge alias (src/dst excluded from the searchAny pool, like pandas' `is_edge` arm) / endpoint alias in the generic builder,
- the node-cartesian mode (`_cartesian_node_bindings_polars`),
- the single-entity pattern-apply shape (`rows_binding_ops_polars`) — keeping its column layout identical between filtered and unfiltered spellings,
- the indexed handoff/bypass now declines prefiltered plans exactly like the pandas twin gate.

`expr` specs lower through the same `lower_expr_str` evaluator as the post-join `where_rows`; `search_any` specs share a lowering (`search_match_expr`, factored out of `search_any_polars`) so the dtype/regex decline gates cannot drift. A spec polars cannot lower raises a **typed `NotImplementedError` naming `alias_prefilters` and the alias** — never a silent drop, never a pandas bridge. (Those same shapes already NIE at the post-join op, so no previously-served Cypher query is retired.)

## #1739 — polars `HAS_<Label>` aggregation on duplicate-id graphs emitted an extra row

**Root cause**: the query serves via `_execute_single_hop_grouped_aggregate_fast_path`, whose lanes join the destination property lookup **by node id with no disambiguation** — the polars lanes attached BOTH colliding rows' properties (`[{f4,1},{t4,1}]` where the hand oracle — and the pandas row pipeline, and cuDF — say `[{t4,1}]`), i.e. it joins before any dedup/narrowing. The pandas/cuDF lane deduped `keep='first'`, which matches the oracle **only by frame order** (flipping the two id-400 rows made pandas/cuDF wrong too — also red at master, also fixed here).

**After**: the fast path narrows the destination domain with the same conditional as the pandas row-pipeline oracle (`_gfql_disambiguate_has_edge_destination_nodes`): iff the **candidate** destination ids (dsts of filtered edges leaving matched starts) collide and the destination alias carries no label filter, the domain narrows to the `label__<Label>`-true rows. Pinned on both sides: unique candidates on a duplicate-id table do NOT narrow, and an explicit destination label disables narrowing. Probes route through `_lazy_collect` (execution-target contract) and the fast path still **serves** (engagement pinned via the public trace).

## Verification

- **Red at master**: the new/flipped pins fail 13 ways at `e6625ed28` (all polars prefilter pins incl. the typed decline; #1739 polars both frame orders + pandas/cuDF in the flipped order); the negative-side pins (unique-candidates, labeled-dest, engagement, pandas/cuDF prefilter params) are green at master — red exactly where the defects are.
- **Mutation-checked**: 5 mutants killed (drop the param pass-through; no-op the prefilter helper; disable the narrowing; narrow unconditionally / skip the candidate probe; remove the labeled-destination gate).
- **Flipped strict xfails**: `test_rewrite_param_discard.py` (#1804, polars + polars-gpu params) and `test_known_cross_engine_divergences.py::test_1739_...` — markers deleted, now positive pins.
- **Engines**: pandas / polars / cuDF all asserted (cuDF runs green locally on cudf 25.10); polars-gpu shares the fixed builder and its params are in the lane files (out-of-band GPU coverage per the file docstrings). One unrelated pre-existing cuDF quirk documented: a node property literally named `name` crashes the fast path's cudf lane at master too (`reset_index(name=...)` clash) — the new fixture uses `title` and the test docstring warns.
- **Gates**: ruff clean; comment-density / cypher-surface / type-hygiene guards rc=0; mypy error set identical to master (4 pre-existing, 0 new); full `graphistry/tests/compute` failure set compared against the master baseline (no new failures); new polars-mentioning test files registered in `bin/test-polars.sh` (lane completeness guard green); no new source files (no coverage-baseline registration needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
