### PR TITLE
fix(gfql): hop-family defects — cuDF NA-mask node drop (#1798), min_hops seed residue (#1918 F2), internal column leak (#1940)

### DIFF
--- a/graphistry/compute/hop.py
+++ b/graphistry/compute/hop.py
@@ -860,17 +860,6 @@ def hop(self: Plottable,
 
             rebuild_node_hops_from_retained_paths = direction in ('forward', 'reverse')
 
-            if direction == 'forward':
-                valid_node_hop_frames.append(
-                    valid_endpoint_edges_with_nodes[[g2._destination, edge_hop_col]]
-                    .rename(columns={g2._destination: node_col})
-                )
-            elif direction == 'reverse':
-                valid_node_hop_frames.append(
-                    valid_endpoint_edges_with_nodes[[g2._source, edge_hop_col]]
-                    .rename(columns={g2._source: node_col})
-                )
-
             max_edge_hop = int(edge_hop_records[edge_hop_col].max()) if len(edge_hop_records) > 0 else max_reached_hop
             for hop_level in range(max_edge_hop, 0, -1):
                 hop_edges = edge_records_with_endpoints[
@@ -913,6 +902,18 @@ def hop(self: Plottable,
             valid_node_series = valid_node_series.drop_duplicates()
             valid_edge_series = concat(valid_edge_list, ignore_index=True, sort=False).drop_duplicates() if valid_edge_list else goal_node_series[:0]
 
+            # Goal labels feed a groupby on node_hop_col: rename, or distinct-name arms read a dead column (all-NULL labels)
+            if rebuild_node_hops_from_retained_paths:
+                goal_endpoint_col = g2._destination if direction == 'forward' else g2._source
+                goal_label_rows = (
+                    valid_endpoint_edges_with_nodes[[goal_endpoint_col, EDGE_ID, edge_hop_col]]
+                    .rename(columns={goal_endpoint_col: node_col, edge_hop_col: node_hop_col}))
+                if node_hop_col != edge_hop_col:
+                    # Goals off the retained walk keep their row but a NULL label (net membership unchanged)
+                    unretained_mask = ~goal_label_rows[EDGE_ID].isin(valid_edge_series)
+                    goal_label_rows.loc[unretained_mask, node_hop_col] = s_na(engine_concrete)
+                valid_node_hop_frames.append(goal_label_rows[[node_col, node_hop_col]])
+
             edge_hop_records = edge_hop_records[edge_hop_records[EDGE_ID].isin(valid_edge_series)]
             if valid_node_hop_frames:
                 node_hop_records = (
@@ -940,14 +941,14 @@ def hop(self: Plottable,
                         retained_edges_with_endpoints[
                             retained_edges_with_endpoints[g2._destination].isin(seed_ids_for_labels)
                         ][[g2._destination, edge_hop_col]]
-                        .rename(columns={g2._destination: node_col})
+                        .rename(columns={g2._destination: node_col, edge_hop_col: node_hop_col})
                     )
                 else:
                     retained_seed_hops = (
                         retained_edges_with_endpoints[
                             retained_edges_with_endpoints[g2._source].isin(seed_ids_for_labels)
                         ][[g2._source, edge_hop_col]]
-                        .rename(columns={g2._source: node_col})
+                        .rename(columns={g2._source: node_col, edge_hop_col: node_hop_col})
                     )
                 if len(retained_seed_hops) > 0:
                     nonzero_seed_mask = (
@@ -1100,6 +1101,11 @@ def hop(self: Plottable,
 
     if g_out._edges is not None and len(g_out._edges) > 0 and g_out._nodes is not None:
         unbacked_endpoints = _endpoint_ids_without_node_rows(g_out, concat)
+        # Unlabeled min_hops>1 excludes pruned seed rows; labeled hops keep the NULL-labeled stub the chain wavefront contract expects
+        if min_hop_prune_applied and label_node_hops is None and not label_seeds \
+                and seeds_provided and node_col in starting_nodes.columns:  # 1918 F2 seed residue
+            unbacked_endpoints = unbacked_endpoints[
+                ~unbacked_endpoints[g_out._node].isin(starting_nodes[node_col])]
         nodes_out = g_out._nodes
         if track_node_hops and node_hop_records is not None and node_hop_col is not None:
             nodes_out = _nodes_with_hop_label_column(nodes_out, node_hop_col)
@@ -1232,10 +1238,11 @@ def hop(self: Plottable,
             SeriesCls = s_series(engine_concrete)
             mask = SeriesCls(True, index=g_out._nodes.index)
             if node_hop_col is not None and node_hop_col in g_out._nodes.columns:
+                # fillna BEFORE combining: cuDF &/| are non-Kleene and NULL-masked rows drop (1798 self-loop seeds)
                 if final_output_min is not None:
-                    mask = mask & (g_out._nodes[node_hop_col] >= final_output_min)
+                    mask = mask & (g_out._nodes[node_hop_col] >= final_output_min).fillna(False)
                 if final_output_max is not None:
-                    mask = mask & (g_out._nodes[node_hop_col] <= final_output_max)
+                    mask = mask & (g_out._nodes[node_hop_col] <= final_output_max).fillna(False)
             endpoint_ids = None
             if g_out._edges is not None:
                 endpoint_ids = concat(
@@ -1295,5 +1302,13 @@ def hop(self: Plottable,
                 ]
             filtered_nodes = g_out._nodes[~g_out._nodes[node_col].isin(column_values(seeds_not_reached_df, node_col))]
         g_out = g_out.nodes(filtered_nodes)
+
+    # Internal tracking columns must never reach user output; backfills above re-add them after the mid-function drops
+    if label_node_hops is None and node_hop_col is not None \
+            and g_out._nodes is not None and node_hop_col in g_out._nodes.columns:
+        g_out = g_out.nodes(g_out._nodes.drop(columns=[node_hop_col]))
+    if label_edge_hops is None and edge_hop_col is not None \
+            and g_out._edges is not None and edge_hop_col in g_out._edges.columns:
+        g_out = g_out.edges(g_out._edges.drop(columns=[edge_hop_col]))
 
     return g_out

--- a/graphistry/tests/compute/gfql/test_endpoint_closure_matrix.py
+++ b/graphistry/tests/compute/gfql/test_endpoint_closure_matrix.py
@@ -460,13 +460,6 @@ def test_to_fixed_point_stops_at_the_closed_frontier(engine, seed, direction, wa
 _MIN_HOPS_SERVED = ["pandas", "cudf"]
 _MIN_HOPS_DECLINED = ["polars", "polars-gpu"]
 
-_MIN_HOPS_CUDF_SEED_XFAIL = pytest.mark.xfail(strict=True, raises=AssertionError, reason=(
-    "PRE-EXISTING cuDF divergence (identical at merge-base 526976e91): under a hop window the "
-    "cuDF epilogue drops the SEED's node row -- its hop label is NULL and cuDF's NULL-valued "
-    "boolean mask is not rescued by the endpoint OR -- so edge (0,1) survives with no node row "
-    "for 0. pandas keeps it. Same family as "
-    "test_output_hop_window_backfills_the_source_node_row_on_cudf."))
-
 _MIN_HOPS_ORACLE = [(2, LADDER_CLOSED), (3, LADDER_CLOSED), (4, set())]
 
 
@@ -482,15 +475,25 @@ def test_min_hops_window_never_lands_on_a_dangling_target(engine, min_hops, want
 
 @pytest.mark.parametrize("engine,min_hops", [
     ("pandas", 2), ("pandas", 3), ("pandas", 4),
-    pytest.param("cudf", 2, marks=_MIN_HOPS_CUDF_SEED_XFAIL),
-    pytest.param("cudf", 3, marks=_MIN_HOPS_CUDF_SEED_XFAIL),
-    ("cudf", 4),  # empty answer, so there is no edge whose endpoint could be unbacked
+    ("cudf", 2), ("cudf", 3), ("cudf", 4),
 ])
-def test_min_hops_window_output_is_endpoint_closed(engine, min_hops):
+def test_min_hops_window_output_excludes_the_seed_and_backs_everything_else(engine, min_hops):
+    """#1918 F2 contract: seeds are hop 0, and hop 0 is labeled only under label_seeds, so a
+    min_hops>=2 window excludes the seed's node ROW entirely (it does not come back as an
+    attribute-less stub, and cuDF no longer diverges by accident). Every NON-seed endpoint of
+    a surviving edge is still backed by its full-attribute node row."""
     _require_engine(engine)
     out = _bind(engine, LADDER_NODES, LADDER_EDGES).hop(
         nodes=_seed(engine, [0]), min_hops=min_hops, hops=4, direction="forward", engine=engine)
-    _assert_output_is_endpoint_closed(out)
+    ids = node_id_set(out)
+    assert 0 not in ids, "min_hops>=2 excludes the unlabeled seed row"
+    edges = to_pandas_any(out._edges)
+    if edges is not None and len(edges) > 0:
+        non_seed_endpoints = (set(edges["s"].tolist()) | set(edges["d"].tolist())) - {0}
+        assert non_seed_endpoints <= ids, "non-seed endpoint with no node row"
+    nodes = to_pandas_any(out._nodes)
+    if len(nodes) > 0:
+        assert not nodes.drop(columns=["id"]).isna().any().any(), "attribute-less stub row"
 
 
 @pytest.mark.parametrize("engine", _MIN_HOPS_DECLINED)

--- a/graphistry/tests/compute/gfql/test_hop_kernel_contracts.py
+++ b/graphistry/tests/compute/gfql/test_hop_kernel_contracts.py
@@ -262,14 +262,6 @@ _SEED_LABEL_ORACLE = [
 ]
 
 
-_SEED_LABEL_CUDF_XFAIL = pytest.mark.xfail(strict=True, raises=AssertionError, reason=(
-    "PRE-EXISTING cuDF divergence (identical at merge-base 526976e91, so #1888/#1895 did not "
-    "cause it): the labelled hop's output-window mask is `(hop <= max) | endpoint`, and on cuDF "
-    "a NULL hop makes the whole mask NULL rather than False-then-rescued, so the SEED's node row "
-    "is dropped -- leaving edges whose endpoint has no node row on a fully closed input graph. "
-    "Same family as test_output_hop_window_backfills_the_source_node_row_on_cudf."))
-
-
 def _labelled_undirected_hop(engine, seeds):
     g = (graphistry
          .nodes(_frame(pd.DataFrame({"id": [0, 1, 2, 3], "v": [10, 20, 30, 40]}), engine), "id")
@@ -278,8 +270,7 @@ def _labelled_undirected_hop(engine, seeds):
                  direction="undirected", label_node_hops="nh", engine=engine)
 
 
-@pytest.mark.parametrize("engine", [
-    "pandas", "polars", pytest.param("cudf", marks=_SEED_LABEL_CUDF_XFAIL)])
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
 @pytest.mark.parametrize("seeds,want", _SEED_LABEL_ORACLE)
 def test_undirected_hop_labels_leave_the_seed_unlabelled(engine, seeds, want):
     _require_engine(engine)
@@ -288,8 +279,7 @@ def test_undirected_hop_labels_leave_the_seed_unlabelled(engine, seeds, want):
     assert labels == want
 
 
-@pytest.mark.parametrize("engine", [
-    "pandas", "polars", pytest.param("cudf", marks=_SEED_LABEL_CUDF_XFAIL)])
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
 def test_labelled_undirected_hop_output_still_backs_every_edge_endpoint(engine):
     """The closure contract read on the OUTPUT: every endpoint of a surviving edge has a node
     row. Input here is fully closed, so nothing may be dropped."""
@@ -369,3 +359,90 @@ def test_nan_free_frame_id_cache_evicts_on_gc_so_a_recycled_id_cannot_hit():
 # No integration pin is added here: removing the chain's re-point call does NOT change any
 # observable result or index trace in the shapes reachable today (measured), so an
 # integration test would assert nothing.
+
+
+# --- #1798: tracked undirected hop must not drop self-loop/seed node rows on cuDF -----------
+#
+# Fixture: nodes 0..3 kind [b,a,a,b]; edges (2,2)x3, (0,3)x2, (3,1), (1,1). Seeded at the
+# 'a' nodes {1,2}, one undirected hop touches 5 edge rows -- (3,1), (1,1), (2,2)x3 -- and
+# nodes {1,2,3}. Any track_hops arm leaves seeds hop-label NULL, and cuDF's non-Kleene
+# NULL | True stayed NULL, so the output-window epilogue dropped BOTH self-loop seeds.
+
+_SELF_LOOP_NODES = pd.DataFrame({"id": [0, 1, 2, 3], "kind": ["b", "a", "a", "b"]})
+_SELF_LOOP_EDGES = pd.DataFrame(
+    [(2, 2), (0, 3), (2, 2), (3, 1), (0, 3), (2, 2), (1, 1)], columns=["s", "d"])
+_SELF_LOOP_EDGE_ORACLE = [(1, 1), (2, 2), (2, 2), (2, 2), (3, 1)]
+
+_TRACKED_UNDIRECTED_ARMS = [
+    ("min1max1_label_nodes", dict(min_hops=1, max_hops=1, label_node_hops="nh")),
+    ("min1max1_label_edges", dict(min_hops=1, max_hops=1, label_edge_hops="eh")),
+    ("output_window", dict(hops=1, output_min_hops=1, output_max_hops=1)),
+]
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize("arm,kwargs", _TRACKED_UNDIRECTED_ARMS, ids=[a for a, _ in _TRACKED_UNDIRECTED_ARMS])
+def test_tracked_undirected_hop_keeps_self_loop_seed_rows(engine, arm, kwargs):
+    _require_engine(engine)
+    g = (graphistry
+         .nodes(_frame(_SELF_LOOP_NODES, engine), "id")
+         .edges(_frame(_SELF_LOOP_EDGES, engine), "s", "d"))
+    out = g.hop(nodes=_frame(pd.DataFrame({"id": [1, 2]}), engine),
+                direction="undirected", engine=engine, **kwargs)
+    edges = to_pandas_any(out._edges)
+    assert sorted(map(tuple, edges[["s", "d"]].itertuples(index=False))) == _SELF_LOOP_EDGE_ORACLE
+    assert node_id_set(out) == {1, 2, 3}, "self-loop seed node rows must survive tracking"
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_seeded_undirected_degenerate_varlen_counts_self_loops(engine):
+    """#1798 end to end: MATCH (a {kind:'a'})-[*1..1]-(b) on the self-loop fixture. Hand
+    enumeration: seed 1 via (3,1) and its self-loop (1,1); seed 2 via (2,2)x3 -- self-loops
+    counted once per edge row (Neo4j relationship semantics) = 5. cuDF returned 1."""
+    _require_engine(engine)
+    g = (graphistry
+         .nodes(_frame(_SELF_LOOP_NODES, engine), "id")
+         .edges(_frame(_SELF_LOOP_EDGES, engine), "s", "d"))
+    out = g.gfql("MATCH (a {kind:'a'})-[*1..1]-(b) RETURN count(*) AS c", engine=engine)
+    assert int(to_pandas_any(out._nodes)["c"].iloc[0]) == 5
+
+
+# --- #1940: internal __gfqlhop__ tracking columns must never reach user output --------------
+
+_LEAK_ARMS = [
+    ("min_hops2", dict(min_hops=2, hops=2)),
+    ("label_nodes_only", dict(label_node_hops="nh", hops=2)),
+    ("label_edges_only", dict(label_edge_hops="eh", hops=2)),
+    ("output_min", dict(output_min_hops=1, hops=2)),
+    ("output_max", dict(output_max_hops=1, hops=2)),
+    ("output_window_both", dict(output_min_hops=1, output_max_hops=2, hops=2)),
+    ("label_seeds", dict(label_node_hops="nh", label_seeds=True, hops=2)),
+    ("wavefront_window", dict(output_min_hops=1, hops=2, return_as_wave_front=True)),
+    ("tfp_label_nodes", dict(to_fixed_point=True, label_node_hops="nh")),
+    ("tfp_output_min", dict(to_fixed_point=True, output_min_hops=1)),
+]
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize("direction", ["forward", "reverse", "undirected"])
+@pytest.mark.parametrize("arm,kwargs", _LEAK_ARMS, ids=[a for a, _ in _LEAK_ARMS])
+def test_no_internal_gfqlhop_column_reaches_user_output(engine, direction, arm, kwargs):
+    """Every track_hops arm allocates internal `__gfqlhop_*__` label columns; several output
+    paths re-added them after the mid-function drop (#1940). Requested label columns stay;
+    internal ones never escape, on any direction x window x label x tfp arm."""
+    _require_engine(engine)
+    ndf = pd.DataFrame({"id": [0, 1, 2], "val": [10, 11, 12]})
+    edf = pd.DataFrame({"s": [0, 1], "d": [1, 2]})
+    g = (graphistry
+         .nodes(_frame(ndf, engine), "id")
+         .edges(_frame(edf, engine), "s", "d"))
+    out = g.hop(nodes=_frame(pd.DataFrame({"id": [0]}), engine),
+                direction=direction, engine=engine, **kwargs)
+    leaked_node_cols = [c for c in out._nodes.columns if str(c).startswith("__gfqlhop_")]
+    leaked_edge_cols = [c for c in out._edges.columns if str(c).startswith("__gfqlhop_")]
+    assert leaked_node_cols == [] and leaked_edge_cols == [], (
+        f"internal tracking columns leaked: nodes={leaked_node_cols} edges={leaked_edge_cols}")
+    if "label_node_hops" in kwargs:
+        assert "nh" in out._nodes.columns, "requested node label column must remain"
+    if "label_edge_hops" in kwargs:
+        assert "eh" in out._edges.columns, "requested edge label column must remain"

--- a/graphistry/tests/compute/gfql/test_hop_semantics_1918.py
+++ b/graphistry/tests/compute/gfql/test_hop_semantics_1918.py
@@ -34,6 +34,14 @@ except ImportError:
 
 polars_only = pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")
 
+try:
+    import cudf  # noqa: F401
+    HAS_CUDF = True
+except ImportError:
+    HAS_CUDF = False
+
+cudf_only = pytest.mark.skipif(not HAS_CUDF, reason="cudf not installed")
+
 ENGINES = ["pandas", pytest.param("polars", marks=polars_only)]
 
 
@@ -334,28 +342,49 @@ def test_f2_tracked_seed_keeps_its_attributes_and_dtype(flag_id, flags, directio
     assert str(nodes["w"].dtype) == "int64", "attr dtype must not upcast via a NaN backfill"
 
 
-def test_f2_min_hops_forward_seed_is_still_attribute_less_residue():
-    """RESIDUE PIN (#1918 F2, deliberately NOT fixed) -- recorded as a value test, not a
-    comment, so it cannot rot and so the day it changes is a loud test failure.
-
-    ``min_hops>=2`` is the one track_hops flag whose seed still returns attribute-less. There
-    the hop-label set is REBUILT from the retained-path backward walk and the node-output
-    restriction to it is load-bearing: it is how a dead-end source-side branch leaves the
-    answer. Widening it admits nodes with no retained incident edge and breaks the 400-case
-    polars chain min_hops parity, whose node output deliberately mirrors this pandas stub
-    (``hop_eager.py:_min_hops_labeled_node_output``). Lifting it is a decision about the
-    CHAIN contract, not a local hop() bug fix.
-
-    The seed's ROW is present (it is a retained-edge endpoint); only its attributes are NaN.
-    Scoped to FORWARD (and reverse): the retained-path label rebuild runs for directed hops
-    only, so UNDIRECTED min_hops takes the plain label-restriction path and is clean -- pinned
-    positively just below, which also fixes the boundary of this residue in place.
-    """
+def test_f2_min_hops_forward_seed_row_is_excluded_entirely():
+    """#1918 F2 CLOSED (this replaced the residue pin that recorded the defect): seeds are
+    hop 0, hop 0 is labeled only under label_seeds, so a ``min_hops>=2`` window excludes the
+    seed's node ROW entirely. Pre-fix pandas re-synthesized it id-only via the endpoint
+    backfill (type/w NaN, w upcast int64->float64) while cuDF omitted it -- divergent. Now
+    both engines return the same seed-less membership with unupcast attributes."""
     g = _attr_graph("pandas")
     r = g.hop(nodes=pd.DataFrame({"id": [0]}), min_hops=2, max_hops=2, engine="pandas")
     nodes = _pd(r._nodes)
-    row = nodes.loc[nodes["id"] == 0].iloc[0]
-    assert pd.isna(row["type"]) and pd.isna(row["w"]), "residue: still id-only backfilled"
+    assert nodes["id"].tolist() == [1, 2], "seed row excluded, traversed rows kept"
+    assert not nodes[["type", "w"]].isna().any().any(), "no attribute-less stub rows"
+    assert str(nodes["w"].dtype) == "int64", "no NaN-backfill upcast"
+
+
+def test_f2_min_hops_node_labels_survive_without_an_edge_label():
+    """min_hops>=2 rebuilds node hop labels from the retained-path walk. Those frames carry
+    the values under edge_hop_col, and the groupby that follows reads node_hop_col -- the two
+    names only coincide when BOTH labels are internal. With a user node label and no edge
+    label (so no edge-endpoint backfill to mask it), the goal node's label came back NULL.
+    The LABELED arm keeps the seed row with a NULL label (chain wavefront contract); only the
+    unlabeled arm excludes it."""
+    g = _attr_graph("pandas")
+    r = g.hop(nodes=pd.DataFrame({"id": [0]}), min_hops=2, max_hops=2,
+              label_node_hops="nh", engine="pandas")
+    nodes = _pd(r._nodes).sort_values("id")
+    labels = {i: (None if pd.isna(v) else int(v)) for i, v in zip(nodes["id"], nodes["nh"])}
+    assert labels == {0: None, 1: 1, 2: 2}
+
+
+@cudf_only
+def test_f2_min_hops_forward_membership_agrees_on_cudf():
+    """The cuDF side of the F2 close-out: same seed-less membership, same intact dtypes."""
+    import cudf
+    ndf = pd.DataFrame({"id": [0, 1, 2], "type": ["a", "b", "a"],
+                        "w": pd.Series([10, 20, 30], dtype="int64")})
+    edf = pd.DataFrame({"s": [0, 1], "d": [1, 2], "rel": ["x", "y"]})
+    g = graphistry.nodes(cudf.from_pandas(ndf), "id").edges(cudf.from_pandas(edf), "s", "d")
+    r = g.hop(nodes=cudf.from_pandas(pd.DataFrame({"id": [0]})), min_hops=2, max_hops=2,
+              engine="cudf")
+    nodes = _pd(r._nodes).sort_values("id")
+    assert nodes["id"].tolist() == [1, 2]
+    assert not nodes[["type", "w"]].isna().any().any()
+    assert str(nodes["w"].dtype) == "int64"
 
 
 def test_f2_min_hops_undirected_seed_keeps_attributes():
@@ -535,7 +564,8 @@ def test_f8_does_not_widen_a_satisfiable_window():
     edf = pd.DataFrame({"s": [0, 1, 2], "d": [1, 2, 3]})
     g = graphistry.nodes(ndf, "id").edges(edf, "s", "d")
     r = g.hop(nodes=pd.DataFrame({"id": [0]}), min_hops=2, max_hops=3, engine="pandas")
-    assert node_ids(r) == [0, 1, 2, 3]
+    # min_hops>=2 excludes the unlabeled hop-0 seed ROW (#1918 F2); paths/edges are intact.
+    assert node_ids(r) == [1, 2, 3]
     assert edge_ids(r) == [(0, 1), (1, 2), (2, 3)]
     r2 = g.hop(nodes=pd.DataFrame({"id": [0]}), min_hops=4, max_hops=5, engine="pandas")
     assert node_ids(r2) == [] and edge_ids(r2) == [], "acyclic: no 4-walk exists, still empty"

--- a/graphistry/tests/compute/gfql/test_known_cross_engine_divergences.py
+++ b/graphistry/tests/compute/gfql/test_known_cross_engine_divergences.py
@@ -287,15 +287,11 @@ def test_optional_match_grouped_aggregate_is_served_on_every_engine(engine, agg,
 
 
 @cudf_only
-@pytest.mark.xfail(strict=True, reason="cuDF drops the sliced edge's source node row under an output hop window; pandas backfills it")
 def test_output_hop_window_backfills_the_source_node_row_on_cudf():
-    """Found by the #1895 hop.py boundary amplification, PRE-EXISTING (reproduces identically
-    at that branch's merge-base, so #1888/#1895 did not cause it).
-
-    With an output hop window, pandas returns edge (0,1) AND both endpoint node rows; cuDF
-    returns the edge with only node 1 -- the source row is never backfilled, leaving an edge
-    whose endpoint has no node row. Every engine should satisfy endpoint closure on its OUTPUT.
-    Flipping this xfail = the cuDF epilogue backfilling like the pandas one.
+    """RESOLVED divergence (#1798 family): the output-window node mask now fills NULL hop
+    labels to False BEFORE combining (cuDF's &/| are not Kleene, so `NULL | endpoint` stayed
+    NULL and cuDF dropped the row that the endpoint OR rescued on pandas). Both engines now
+    keep the sliced edge's source node row: endpoint closure holds on the OUTPUT.
     """
     import cudf
 

--- a/graphistry/tests/compute/gfql/test_varlen_bounded_engine_parity_1787.py
+++ b/graphistry/tests/compute/gfql/test_varlen_bounded_engine_parity_1787.py
@@ -415,34 +415,19 @@ CUDF_DIVERGENCE_EDGES = pd.DataFrame(
 )
 
 
-# The cuDF parameter carries the xfail at COLLECTION time (a marker added inside the test body
-# is applied too late to be reliable), and STRICT so the fix cannot land unnoticed.
-_DEGENERATE_SEED_ENGINES = [
-    pytest.param(
-        engine,
-        marks=pytest.mark.xfail(
-            strict=True,
-            reason="#1798: cuDF answers 1 where the pandas oracle answers 9",
-        ),
-    )
-    if engine == "cudf"
-    else engine
-    for engine in ALL_ENGINES
-]
+# #1798 fixed (non-Kleene NULL masks dropped the self-loop seed node rows on cuDF); the
+# strict xfail this list used to carry XPASSed and was lifted, so cuDF runs plain.
+_DEGENERATE_SEED_ENGINES = ALL_ENGINES
 
 
 @pytest.mark.parametrize("engine", _DEGENERATE_SEED_ENGINES)
 def test_seeded_undirected_degenerate_window_agrees_with_the_oracle(engine: str) -> None:
-    """``(a {..})-[*1..1]-(b)``: a SEPARATE cuDF defect, in the pandas-API family (#1798).
+    """``(a {..})-[*1..1]-(b)``: the seeded degenerate window that flushed out #1798.
 
-    Not the #1787 gap and not fixed by this PR — the polars engines decline this shape (it is
-    the ``undir-degenerate-window`` case above with a seed), so the polars fix cannot mask it.
-    cuDF answers 1 where pandas answers 9, silently: 23 of 40 random graphs diverge on this
-    shape alone, while the UNSEEDED ``-[*1..1]-``, the seeded ``-[]-``, the seeded
-    ``-[*1..2]-`` and the directed ``-[*1..1]->`` are all clean (0/40 each).
-
-    Recorded as a STRICT xfail rather than left out: when #1798 lands, this test fails loudly
-    and must be un-xfailed, whereas a comment or a skip would rot silently.
+    cuDF used to answer 1 where the trail oracle answers 5 (self-loops bind once): the
+    tracked output-window node mask combined NULL seed hop labels with cuDF's non-Kleene
+    boolean ops and dropped the self-loop seed node rows. Fixed in hop.py (fillna(False)
+    before combining); every engine now answers 5.
     """
     _require(engine)
     g = _graph(engine, CUDF_DIVERGENCE_NODES, CUDF_DIVERGENCE_EDGES)

--- a/graphistry/tests/test_compute_hops.py
+++ b/graphistry/tests/test_compute_hops.py
@@ -226,7 +226,8 @@ class TestComputeHopMixin(NoAuthTestCase):
         g = simple_chain_graph()
         seeds = pd.DataFrame({g._node: ['a']})
         g2 = g.hop(seeds, min_hops=2, max_hops=3)
-        assert set(g2._nodes[g2._node].to_list()) == {'a', 'b', 'c', 'd'}
+        # min_hops>=2 excludes the unlabeled hop-0 seed row (#1918 F2); use label_seeds to keep it
+        assert set(g2._nodes[g2._node].to_list()) == {'b', 'c', 'd'}
         assert set(zip(g2._edges['s'], g2._edges['d'])) == {('a', 'b'), ('b', 'c'), ('c', 'd')}
 
     def test_hop_min_not_reached_returns_empty(self):
@@ -247,8 +248,9 @@ class TestComputeHopMixin(NoAuthTestCase):
         g = branching_chain_graph()
         seeds = pd.DataFrame({g._node: ['a']})
         g2 = g.hop(seeds, min_hops=3, max_hops=3)
-        # Only nodes/edges on paths reaching 3 hops; b2/c2 branch excluded
-        assert set(g2._nodes[g._node].to_list()) == {'a', 'b1', 'c1', 'd1'}
+        # Only nodes/edges on paths reaching 3 hops; b2/c2 branch excluded, and the
+        # unlabeled hop-0 seed row is excluded by the min_hops window (#1918 F2)
+        assert set(g2._nodes[g._node].to_list()) == {'b1', 'c1', 'd1'}
         assert set(zip(g2._edges['s'], g2._edges['d'])) == {
             ('a', 'b1'),
             ('b1', 'c1'),
@@ -304,6 +306,8 @@ class TestComputeHopMixin(NoAuthTestCase):
         g = simple_chain_graph()
         seeds = pd.DataFrame({g._node: ['a']})
         g2 = g.hop(seeds, min_hops=2, max_hops=2, label_node_hops='hop', label_edge_hops='edge_hop')
+        # LABELED min_hops keeps the seed row with a NULL label (chain wavefront contract);
+        # only the unlabeled arm excludes it (#1918 F2)
         assert set(g2._nodes[g._node].to_list()) == {'a', 'b', 'c'}
         assert set(g2._nodes['hop'].dropna().to_list()) == {1, 2}
         assert set(zip(g2._edges['s'], g2._edges['d'])) == {('a', 'b'), ('b', 'c')}


### PR DESCRIPTION
Fixes #1798
Fixes #1940

Pre-release fixes for the three outstanding hop-family defects, verified live at `e6625ed28` with hand-computed oracles (cuDF 25.10 lanes really executed). Four surgical changes in `graphistry/compute/hop.py`; the rest is pins.

## #1798 — cuDF drops ALL self-loop matches on seeded undirected `[*1..1]`

**Before:** `MATCH (a {kind:'a'})-[*1..1]-(b) RETURN count(*)` on the self-loop fixture (nodes 0..3 kind `[b,a,a,b]`; edges `(2,2)x3, (0,3)x2, (3,1), (1,1)`): hand-enumerated oracle 5 (self-loops bind once per edge row, Neo4j relationship semantics; the issue text's "9" was the stale double-counting figure); pandas 5, **cuDF 1**.

**Root cause:** the degenerate varlen window engages hop tracking; undirected seeds carry a NULL hop label, and the output-window node mask combined `(hop <= max)` with the endpoint rescue using cuDF's **non-Kleene** boolean ops: `NULL | True = NULL`, and cuDF's boolean indexing silently drops NULL-masked rows. Both self-loop seed node rows vanished from the node output, so the Cypher join found 1 match. pandas survived only via Kleene `NA | True = True`.

**Fix:** `fillna(False)` on each window comparison BEFORE combining, so no NULL ever enters the and/or chain and both engines agree.

**After:** pandas 5, cuDF 5; all 9 tracked/windowed undirected probe arms value-identical across engines. Four strict-xfail pins that recorded exactly this divergence XPASSed and had their markers lifted (`test_hop_kernel_contracts` seed-label pair, `test_endpoint_closure_matrix` min-hops seed cells, `test_known_cross_engine_divergences::test_output_hop_window_backfills_the_source_node_row_on_cudf`, `test_varlen_bounded_engine_parity_1787::test_seeded_undirected_degenerate_window_agrees_with_the_oracle[cudf]`) — all now run green on cuDF.

## #1918 F2 residual — min_hops>=2 seed row: NaN residue on pandas, divergent on cuDF

**Before:** `hop(nodes=[0], min_hops=2, hops=2)` (unlabeled) on the attributed path `0->1->2`: pandas emitted the seed row id-only (attrs NaN, `int64 -> float64` upcast) via the endpoint backfill; cuDF omitted the seed row (by accident, through the same NULL-mask bug above).

**Contract decision (from the `hop()` docstring):** seeds are hop 0, and hop 0 is labeled only under `label_seeds`, so an UNLABELED `min_hops>=2` hop excludes the seed row entirely. Scope: **labeled** hops keep the NULL-labeled seed stub — the chain wavefront contract (mirrored verbatim by the polars lane's `_min_hops_labeled_node_output`) depends on that stub, and this PR deliberately leaves the chain contract untouched, so the 400-case polars chain min_hops parity stays green. `label_seeds=True` keeps the seed labeled 0; a seed re-reached at `hop >= min_hops` keeps its real row (cycle pin unchanged).

**Fix:** the endpoint backfill no longer resurrects min-hop-pruned seed rows on the unlabeled arm (gated `min_hop_prune_applied and label_node_hops is None and not label_seeds`).

**After:** pandas == cuDF == nodes `[1,2]`, attrs intact, no upcast; on the labeled arm both engines now agree too (seed stub NULL-labeled — previously cuDF dropped it AND the goal node).

Bonus fix in the same family: the min-hop prune's goal-label rebuild carried hop values under `edge_hop_col` while the groupby read `node_hop_col` (the names only coincide when both labels are internal), so `min_hops=2 + label_node_hops` returned NULL labels for every goal node on pandas and cuDF. Now renamed; goals the backward walk retains carry their real hop, and net node membership is unchanged in every arm (verified against the polars parity fuzz, 400 seeds x 2 suites).

**#1918 status: F2 was the last open residual and this closes it — #1918 can be CLOSED.** F1/F3–F8 were fixed in the earlier rounds and their pins stay green here; the deliberate residue pin `test_f2_min_hops_forward_seed_is_still_attribute_less_residue` is replaced by pins of the fixed contract.

**Known residual kept out of scope (chain contract, cross-lane):** the min-hop prune's backward walk still drops qualifying branches that end below `max_hops` (e.g. seed `c`, `min=2,max=3`, branch `c->d->e` ends at hop 2 and vanishes). Fixing it flips ~29 polars chain-parity cells because the polars mirror reproduces the same behavior, so it needs a paired change in the polars lane; follow-up issue #1944 filed with the verified fix shape (retain every edge traversed at a level `>= min_hops` outright).

## #1940 — internal `__gfqlhop__hop_0__` column leaks into user output

**Before (both pandas and cuDF):** `min_hops>=2`, `label_edge_hops`-only, and `output_min/max_hops` arms leaked the internal tracking column into user node and/or edge frames — the mid-function drops ran before backfill blocks that re-add the column.

**Fix:** a final sweep just before return drops internally-generated label columns (only when the corresponding `label_*_hops` was not requested; requested labels, including collision-suffixed ones, are untouched).

**After:** all 20 engine x arm sweep cells clean.

## Pins + anti-vacuity

- `test_hop_kernel_contracts.py`: **#1798** hop-level pins (tracked undirected self-loop arms keep seed rows; edges + membership hand-oracled) and end-to-end Cypher `count(*) == 5`; **#1940** matrix pin — no `__gfqlhop_`-prefixed column ever reaches user node/edge output across 2 engines x 3 directions x 10 arms (windows x labels x label_seeds x wavefront x tfp), requested labels asserted to remain.
- `test_hop_semantics_1918.py`: F2 fixed-contract pins (pandas + cuDF membership/dtype agreement on the unlabeled arm; NULL-labeled stub + correct goal labels on the labeled arm).
- `test_endpoint_closure_matrix.py`: min_hops cells rewritten to the new contract (unlabeled seed row excluded; every non-seed endpoint backed by its full-attribute row; no stub rows), cuDF xfails lifted.
- Intended flips of legacy pins (`test_compute_hops.py`: `test_hop_min_max_range`, `test_hop_exact_three_branch` drop the seed from unlabeled memberships; `test_hop_output_slice` keeps it — labeled arm).
- **Red-at-master: 55 failing cells** for the final pin set against `e6625ed28` (38 leak-matrix, 10 #1798-family incl. 5 lifted strict xfails, 7 F2-family), all green at head.
- **Mutation-checked:** individually reverting each of the four hop.py changes re-reddens its own pin group (8 / 6 / 38 / 1 cells).

## Gates

- ruff clean; comment-density / cypher-surface / type-hygiene guards rc=0 from the worktree.
- mypy: identical 4 pre-existing errors (polars-lane files) at base and head — no new.
- Full `graphistry/tests/compute`: failure set vs master baseline is identical (105 pre-existing cells, none hop-related) — zero unintended flips; the hop battery (boundary matrix 581 cells, semantics pins, kernel contracts, 1918 pins, endpoint-closure matrix, varlen parity, legacy hops) is 100% green.
- No new source files; both touched pin files already registered in `bin/test-polars.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
