### PR TITLE
fix(gfql): post-aggregate WHERE sees the identity row (#1939); cross-alias min/max lowering + sum(bool) dtype (#1821)

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -80,6 +80,8 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_polars_dtype_classifier_contracts.py
     graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_fused_polars.py
     graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_lowcard_count.py
+    # engine-parametrized (pandas/polars); the polars params only ever run here
+    graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_cross_alias.py
     # module-level `importorskip("polars")` files that previously ran in no lane at all
     graphistry/tests/compute/gfql/test_engine_polars_narrow_combine.py
     graphistry/tests/compute/gfql/test_engine_polars_semi_key_dedup.py

--- a/graphistry/compute/gfql/agg_types.py
+++ b/graphistry/compute/gfql/agg_types.py
@@ -167,6 +167,25 @@ def pandas_non_numeric_agg_dtype(series: "SeriesT") -> Optional[str]:
     return None
 
 
+def pandas_object_series_is_bool_like(series: "SeriesT") -> bool:
+    """Object-dtype column whose sampled non-null values are all booleans.
+
+    ``sum()`` over BOOLEAN is the documented GFQL extension above, but pandas'
+    OBJECT-dtype groupby reduction hands a single-row group back as the raw bool,
+    mixing ``2`` and ``False`` in one output column. Callers use this probe to
+    retype that aggregate to a numeric column. Bounded head sample, same tradeoff
+    as :func:`_object_series_is_str_like`; cuDF cannot hold an object-of-bools
+    column (its object dtype is strings), so this never fires there.
+    """
+    if str(getattr(series, "dtype", "")).lower() != "object" or not hasattr(series, "dropna"):
+        return False
+    import numpy as np
+
+    from graphistry.Engine import series_to_pylist
+    values = series_to_pylist(series.dropna().head(128))
+    return len(values) > 0 and all(isinstance(v, (bool, np.bool_)) for v in values)
+
+
 def _object_series_is_str_like(series: "SeriesT") -> bool:
     """Every non-null value in a bounded head sample is a ``str`` (and there is at least one).
 

--- a/graphistry/compute/gfql/call/validation.py
+++ b/graphistry/compute/gfql/call/validation.py
@@ -502,6 +502,18 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
         ),
     ),
 
+    'fill_empty_row': _safelist_entry(
+        {'row'},
+        required_params={'row'},
+        param_validators={
+            'row': lambda v: isinstance(v, dict) and all(isinstance(k, str) for k in v),
+        },
+        description='Replace an EMPTY active row table with the single given row (ungrouped-aggregate identity, #1939)',
+        schema_effects=_schema_effects(
+            adds_node_cols=lambda p: list(p.get('row') or {}),
+        ),
+    ),
+
     'drop_cols': _safelist_entry(
         {'cols'},
         required_params={'cols'},

--- a/graphistry/compute/gfql/cypher/aggregate_bindings.py
+++ b/graphistry/compute/gfql/cypher/aggregate_bindings.py
@@ -1,0 +1,92 @@
+"""Bindings-row routing gates for Cypher aggregates over relationship patterns.
+
+A relationship MATCH can bind the same node into many rows; the per-alias node
+table collapses that multiplicity, so an aggregate whose value depends on row
+multiplicity (sum/avg/collect/plain count) must run on binding rows instead.
+``requires_aggregate_bindings`` is the one gate the lowering asks: it covers the
+multiplicity-sensitive family AND the cross-alias shape -- a sole
+multiplicity-INSENSITIVE aggregate (min/max/count DISTINCT) whose clause spans
+two MATCH aliases has no single source table to lower onto at all, and binding
+rows are sound for it because its value is multiplicity-invariant. The lowering's
+force-bindings block still vets each spec before actually engaging.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Set
+
+from graphistry.compute.ast import ASTObject
+from graphistry.compute.exceptions import GFQLValidationError
+
+if TYPE_CHECKING:
+    from graphistry.compute.gfql.cypher.ast import ReturnClause
+    from graphistry.compute.gfql.cypher.lowering import _AggregateSpec
+
+
+def is_multiplicity_sensitive_aggregate(agg_spec: "_AggregateSpec") -> bool:
+    if agg_spec.func in {"sum", "avg"}:
+        return True
+    if agg_spec.func == "collect":
+        return True
+    if agg_spec.func == "count":
+        return not agg_spec.distinct
+    return False
+
+
+def requires_relationship_multiplicity_bindings(
+    *,
+    aggregate_specs: Sequence["_AggregateSpec"],
+    relationship_count: int,
+) -> bool:
+    return relationship_count > 0 and any(
+        is_multiplicity_sensitive_aggregate(spec)
+        for spec in aggregate_specs
+    )
+
+
+def _clause_spans_multiple_match_aliases(
+    clause: "ReturnClause",
+    *,
+    alias_targets: Mapping[str, ASTObject],
+    params: Optional[Mapping[str, Any]],  # hygiene-ok: explicit-any -- untyped Cypher query-params mapping
+) -> bool:
+    from graphistry.compute.gfql.cypher.lowering import _expr_match_aliases
+
+    referenced: Set[str] = set()
+    for item in clause.items:
+        try:
+            referenced |= _expr_match_aliases(
+                item.expression.text,
+                alias_targets=alias_targets,
+                params=params,
+                field=clause.kind,
+                line=item.span.line,
+                column=item.span.column,
+            )
+        except GFQLValidationError:
+            return False  # unanalyzable expression -> keep the conservative path
+        if len(referenced) >= 2:
+            return True
+    return False
+
+
+def requires_aggregate_bindings(
+    *,
+    aggregate_specs: Sequence["_AggregateSpec"],
+    relationship_count: int,
+    clause: "ReturnClause",
+    alias_targets: Mapping[str, ASTObject],
+    params: Optional[Mapping[str, Any]],  # hygiene-ok: explicit-any -- untyped Cypher query-params mapping
+) -> bool:
+    """True when this clause's aggregates must route to the binding-rows table."""
+    if requires_relationship_multiplicity_bindings(
+        aggregate_specs=aggregate_specs,
+        relationship_count=relationship_count,
+    ):
+        return True
+    if relationship_count <= 0 or not aggregate_specs or len(alias_targets) < 2:
+        return False
+    return _clause_spans_multiple_match_aliases(
+        clause,
+        alias_targets=alias_targets,
+        params=params,
+    )

--- a/graphistry/compute/gfql/cypher/aggregate_identity.py
+++ b/graphistry/compute/gfql/cypher/aggregate_identity.py
@@ -4,8 +4,10 @@ An aggregate with NO grouping keys always yields exactly one row, so a stage tha
 empties the row stream must still return the aggregate identities (count/sum -> 0,
 collect -> [], min/max/avg -> null) rather than an empty frame. Every lowering path
 that can end in an ungrouped aggregate feeds its compiled row steps through
-``ungrouped_aggregate_identity_row`` here; the result becomes the compiled query's
-``empty_result_row``, applied at runtime only when the real result is empty.
+``apply_ungrouped_aggregate_identity`` here. Replayable suffixes compile the row
+into ``empty_result_row``, applied at runtime only when the real result is empty;
+a post-aggregate ``where_rows`` suffix instead gets in-chain ``fill_empty_row``
+steps, because its outcome depends on the runtime aggregate value.
 """
 from __future__ import annotations
 

--- a/graphistry/compute/gfql/cypher/aggregate_identity.py
+++ b/graphistry/compute/gfql/cypher/aggregate_identity.py
@@ -10,7 +10,7 @@ that can end in an ungrouped aggregate feeds its compiled row steps through
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Mapping, Optional, Sequence, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 import pandas as pd
 
@@ -202,5 +202,66 @@ def _identity_row_without_temps(row: Optional[Dict[str, Any]]) -> Optional[Dict[
         if not key.startswith(("__cypher_group__", "__cypher_agg__", "__cypher_postagg__"))
     }
     return out or None
+
+
+_IDENTITY_FILL_SUFFIX_CALLS = _IDENTITY_ROW_REPLAY_CALLS | {"where_rows"}
+
+
+def _identity_fill_insertion_plan(
+    row_steps: Sequence[ASTObject],
+) -> Optional[List[Tuple[int, Dict[str, Any]]]]:  # hygiene-ok: explicit-any -- heterogeneous Cypher identity values (0 / [] / None)
+    """``(pivot index, identity seed)`` pairs for runtime fill injection, or None.
+
+    Engages ONLY for the shape the compile-time replay cannot serve: a
+    ``where_rows`` after an ungrouped aggregate. The WHERE's outcome depends on
+    the aggregate VALUE, which at runtime is either real (stream non-empty) or
+    the identity (stream empty) -- a terminal fill applied at "result is empty"
+    cannot tell those apart (a WHERE that passes the identity but drops the real
+    value would be wrongly overwritten). So the identity row is injected
+    mid-chain, at the aggregate itself, and the suffix -- WHERE included --
+    runs over it with ordinary runtime semantics on every engine.
+    """
+    first_pivot: Optional[int] = None
+    saw_where = False
+    plan: List[Tuple[int, Dict[str, Any]]] = []
+    for idx, step in enumerate(row_steps):
+        seed = _ungrouped_aggregate_identity_seed(step)
+        if seed is not None and isinstance(step, ASTCall) and step.function == "group_by":
+            if first_pivot is None:
+                first_pivot = idx
+            plan.append((idx, seed))
+            continue
+        if first_pivot is None:
+            continue
+        if not isinstance(step, ASTCall) or step.function not in _IDENTITY_FILL_SUFFIX_CALLS:
+            return None
+        if step.function == "where_rows":
+            saw_where = True
+        elif step.function == "group_by":
+            # Post-pivot group_by without a computable identity seed -- decline.
+            return None
+    if first_pivot is None or not saw_where:
+        return None
+    return plan
+
+
+def apply_ungrouped_aggregate_identity(
+    row_steps: List[ASTObject],
+) -> Optional[Dict[str, Any]]:  # hygiene-ok: explicit-any -- heterogeneous Cypher identity values (0 / [] / None)
+    """Compile the ungrouped-aggregate identity contract for this row program.
+
+    Replayable suffixes keep the compile-time terminal row (returned as
+    ``empty_result_row``, unchanged). A post-aggregate ``where_rows`` suffix
+    instead gets ``fill_empty_row`` steps inserted in place after each ungrouped
+    aggregate and compiles NO terminal row -- runtime owns the outcome.
+    """
+    terminal = ungrouped_aggregate_identity_row(row_steps)
+    if terminal is not None:
+        return terminal
+    plan = _identity_fill_insertion_plan(row_steps)
+    if plan is not None:
+        for offset, (index, seed) in enumerate(plan):
+            row_steps.insert(index + 1 + offset, ASTCall("fill_empty_row", {"row": seed}))
+    return None
 
 

--- a/graphistry/compute/gfql/cypher/lowering.py
+++ b/graphistry/compute/gfql/cypher/lowering.py
@@ -63,10 +63,14 @@ from graphistry.compute.predicates.is_in import is_in
 from graphistry.compute.predicates.logical import all_of
 from graphistry.compute.predicates.str import contains as str_contains, endswith, fullmatch, never_match, startswith
 from graphistry.compute.gfql.cypher.parser import _mask_quoted_backticked_and_commented_for_scan
+from graphistry.compute.gfql.cypher.aggregate_bindings import (
+    is_multiplicity_sensitive_aggregate as _is_multiplicity_sensitive_aggregate,
+    requires_aggregate_bindings as _requires_aggregate_bindings,
+)
 from graphistry.compute.gfql.cypher.aggregate_identity import (
     aggregate_identity_value,
+    apply_ungrouped_aggregate_identity,
     identity_row_after_paging,
-    ungrouped_aggregate_identity_row,
 )
 from graphistry.compute.gfql.language_defs import GFQL_AGGREGATION_FUNCTIONS
 from graphistry.compute.gfql.expr_parser import (
@@ -2544,16 +2548,6 @@ def _validate_aggregate_expr_scope(
     )
 
 
-def _is_multiplicity_sensitive_aggregate(agg_spec: _AggregateSpec) -> bool:
-    if agg_spec.func in {"sum", "avg"}:
-        return True
-    if agg_spec.func == "collect":
-        return True
-    if agg_spec.func == "count":
-        return not agg_spec.distinct
-    return False
-
-
 def _collect_aggregate_specs_for_clause(
     clause: ReturnClause,
     *,
@@ -2577,17 +2571,6 @@ def _collect_aggregate_specs_for_clause(
             nested_aggregate_specs, _ = post_agg_plan
             aggregate_specs.extend(nested_aggregate_specs)
     return aggregate_specs
-
-
-def _requires_relationship_multiplicity_bindings(
-    *,
-    aggregate_specs: Sequence[_AggregateSpec],
-    relationship_count: int,
-) -> bool:
-    return relationship_count > 0 and any(
-        _is_multiplicity_sensitive_aggregate(spec)
-        for spec in aggregate_specs
-    )
 
 
 def _match_relationship_count(clause: MatchClause) -> int:
@@ -4717,9 +4700,12 @@ def _build_initial_row_scope(
         )
     ):
         binding_row_aliases = set(alias_targets.keys())
-    if _requires_relationship_multiplicity_bindings(
+    if _requires_aggregate_bindings(
         aggregate_specs=stage_aggregate_specs,
         relationship_count=relationship_count,
+        clause=stage_clause,
+        alias_targets=alias_targets,
+        params=params,
     ):
         return_has_whole_row_alias = any(
             item.expression.text in alias_targets
@@ -5683,13 +5669,14 @@ def _lower_row_only_sequence_with_scope(
         stage_steps, scope = _lower_row_column_stage(item, scope=scope, params=params)
         row_steps.extend(stage_steps)
 
+    empty_result_row = apply_ungrouped_aggregate_identity(row_steps)
     return CompiledCypherQuery(
         Chain(row_steps),
         seed_rows=seed_rows,
         procedure_call=procedure_call,
         post_processing=_normalize_post_processing(
             CompiledCypherPostProcessing(
-                empty_result_row=ungrouped_aggregate_identity_row(row_steps),
+                empty_result_row=empty_result_row,
             )
         ),
     )
@@ -7106,9 +7093,12 @@ def _lower_general_row_projection(
 
     binding_row_aliases = _binding_row_aliases_for_match(query.match, alias_targets=alias_targets)
     forced_binding_row_aliases = False
-    if _requires_relationship_multiplicity_bindings(
+    if _requires_aggregate_bindings(
         aggregate_specs=aggregate_specs,
         relationship_count=relationship_count,
+        clause=query.return_,
+        alias_targets=alias_targets,
+        params=params,
     ):
         base_active_alias: Optional[str] = None
         can_force_bindings = True
@@ -9654,7 +9644,7 @@ def compile_cypher_query(
                 alias_targets=alias_targets,
             )
         if empty_result_row is None and result_projection is None:
-            empty_result_row = ungrouped_aggregate_identity_row(row_steps)
+            empty_result_row = apply_ungrouped_aggregate_identity(row_steps)
 
         return _attach_graph_context(CompiledCypherQuery(
             Chain(row_steps if binding_row_aliases else lowered.query + row_steps, where=lowered.where),

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -679,6 +679,9 @@ def _try_native_row_op(g_cur, op):
         return select_polars(g_cur, op.params.get("items", []))
     if fn == "where_rows":
         return where_rows_polars(g_cur, op.params.get("filter_dict"), op.params.get("expr"))
+    if fn == "fill_empty_row":
+        from .row_pipeline import fill_empty_row_polars
+        return fill_empty_row_polars(g_cur, op.params["row"])
     if fn == "order_by":
         return order_by_polars(g_cur, op.params.get("keys", []))
     if fn == "group_by":

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1259,6 +1259,20 @@ def with_columns_polars(g: Plottable, items: Sequence[SelectItem]) -> Optional[P
     return _project_polars(g, items, extend=True)
 
 
+def fill_empty_row_polars(g: Plottable, row: Dict[str, Any]) -> Plottable:  # hygiene-ok: explicit-any -- heterogeneous Cypher identity values (0 / [] / None)
+    """Native twin of ``RowPipelineMixin.fill_empty_row``: an ungrouped aggregate
+    yields exactly one row, so an EMPTY aggregate output becomes the compiled
+    identity row and the suffix (post-aggregate WHERE, paging) runs on it."""
+    import polars as pl
+    from .dtypes import is_lazy
+    table = _active_table(g)
+    if is_lazy(table):
+        table = table.collect()
+    if table.height > 0:
+        return g
+    return _rewrap(g, pl.DataFrame({key: [value] for key, value in row.items()}))
+
+
 def where_rows_polars(
     g: Plottable,
     filter_dict: Optional[dict] = None,

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -34,6 +34,7 @@ from graphistry.compute.gfql.agg_types import (
     numeric_agg_all_null_value,
     pandas_dtype_is_numeric_for_agg,
     pandas_non_numeric_agg_dtype,
+    pandas_object_series_is_bool_like,
     raise_non_numeric_aggregation,
 )
 from graphistry.compute.gfql.language_defs import (
@@ -221,6 +222,7 @@ ROW_PIPELINE_CALLS = frozenset(
         "distinct",
         "unwind",
         "group_by",
+        "fill_empty_row",
         "drop_cols",
         "count_table",
     }
@@ -5571,6 +5573,9 @@ class RowPipelineMixin:
                         grouped = _make_grouped(table_df, [expr_col])
                     agg_series = grouped[expr_col]
                     agg_df = getattr(agg_series, method_name)().reset_index(name=alias)
+                    if func == "sum" and pandas_object_series_is_bool_like(table_df[expr_col]):
+                        # The object-dtype kernel returns a lone-row group as the raw bool.
+                        agg_df = agg_df.assign(**{alias: pd.to_numeric(agg_df[alias])})  # bool sums as int (#1821)
 
             out_df = out_df.merge(agg_df, on=key_cols, how="left", sort=False)
             if func in {"collect", "collect_distinct"}:
@@ -5595,6 +5600,17 @@ class RowPipelineMixin:
         out_df = out_df.sort_values(by=[group_order_col]).reset_index(drop=True)
         out_df = out_df.drop(columns=[group_order_col])
         return self._gfql_row_table(out_df)
+
+    def fill_empty_row(self, row: Dict[str, Any]) -> "Plottable":  # hygiene-ok: explicit-any -- heterogeneous Cypher identity values (0 / [] / None)
+        """openCypher ungrouped-aggregate identity: an aggregate with no grouping
+        keys yields exactly one row, so an EMPTY aggregate output becomes the given
+        identity row here -- where the compiled suffix (post-aggregate WHERE,
+        projections, paging) still sees it with runtime semantics."""
+        table_df = self._gfql_get_active_table()
+        if len(table_df) > 0:
+            return self._gfql_row_table(table_df)
+        filled = type(table_df)({key: [value] for key, value in row.items()})
+        return self._gfql_row_table(filled)
 
 
 class _RowPipelineAdapter(RowPipelineMixin):
@@ -5636,6 +5652,7 @@ _ROW_PIPELINE_DISPATCH: Dict[str, Callable[..., "Plottable"]] = {
     "distinct": RowPipelineMixin.distinct,
     "unwind": RowPipelineMixin.unwind,
     "group_by": RowPipelineMixin.group_by,
+    "fill_empty_row": RowPipelineMixin.fill_empty_row,
     "drop_cols": RowPipelineMixin.drop_cols,
     "count_table": RowPipelineMixin.count_table,
 }

--- a/graphistry/compute/gfql_fast_paths.py
+++ b/graphistry/compute/gfql_fast_paths.py
@@ -47,6 +47,7 @@ from graphistry.compute.gfql.agg_types import (
     numeric_agg_all_null_value,
     pandas_dtype_is_numeric_for_agg,
     pandas_non_numeric_agg_dtype,
+    pandas_object_series_is_bool_like,
     polars_non_numeric_agg_dtype,
     raise_non_numeric_aggregation,
 )
@@ -2595,6 +2596,9 @@ def _execute_single_hop_grouped_aggregate_fast_path(
                 agg_df = grouped[expr_alias].mean().reset_index(name=alias)
             elif func == "sum" and expr_alias is not None:
                 agg_df = grouped[expr_alias].sum().reset_index(name=alias)
+                if pandas_object_series_is_bool_like(work[expr_alias]):
+                    # Twin of the row-pipeline group_by sum(bool) numeric retype.
+                    agg_df = agg_df.assign(**{alias: pd.to_numeric(agg_df[alias])})  # bool sums as int (#1821)
             elif func == "min" and expr_alias is not None:
                 agg_df = grouped[expr_alias].min().reset_index(name=alias)
             elif func == "max" and expr_alias is not None:

--- a/graphistry/tests/compute/gfql/coverage_baselines/ci-pandas-py3.12.json
+++ b/graphistry/tests/compute/gfql/coverage_baselines/ci-pandas-py3.12.json
@@ -21,6 +21,7 @@
     "graphistry/compute/chain_let.py": 69.5,
     "graphistry/compute/gfql/cypher/__init__.py": 100.0,
     "graphistry/compute/gfql/cypher/_boolean_expr_text.py": 97.06,
+    "graphistry/compute/gfql/cypher/aggregate_bindings.py": 100.0,
     "graphistry/compute/gfql/cypher/aggregate_identity.py": 100.0,
     "graphistry/compute/gfql/cypher/api.py": 89.29,
     "graphistry/compute/gfql/cypher/ast.py": 99.02,

--- a/graphistry/tests/compute/gfql/cypher/test_aggregate_identity_branches.py
+++ b/graphistry/tests/compute/gfql/cypher/test_aggregate_identity_branches.py
@@ -36,12 +36,14 @@ from graphistry.compute.ast import (
     with_,
 )
 from graphistry.compute.gfql.cypher.aggregate_identity import (
+    _identity_fill_insertion_plan,
     _identity_row_passthrough_projection,
     _identity_row_scalar,
     _identity_row_without_temps,
     _replay_identity_row,
     _ungrouped_aggregate_identity_seed,
     aggregate_identity_value,
+    apply_ungrouped_aggregate_identity,
     identity_row_after_paging,
     ungrouped_aggregate_identity_row,
 )
@@ -478,9 +480,9 @@ def test_declines_a_non_call_suffix_step() -> None:
 
 
 def test_declines_a_post_aggregate_filter() -> None:
-    """#1909 residual: whether the identity row survives a post-aggregate WHERE
-    depends on the real aggregate value, so the synthesis declines. Pinned as a
-    strict xfail end-to-end in test_aggregate_identity_row_semantics.py."""
+    """Whether the identity row survives a post-aggregate WHERE depends on the
+    real aggregate value, so the compile-time synthesis declines; the runtime
+    fill-injection plan (section 9) serves the shape instead."""
     assert ungrouped_aggregate_identity_row(
         SEED_STEPS + [select([("c", "c")]), where_rows(expr="(c = 0)")]
     ) is None
@@ -501,3 +503,88 @@ def test_replay_fallback_still_pages_and_strips_temps() -> None:
     assert ungrouped_aggregate_identity_row(
         SEED_STEPS + [select([("c1", "(c + 1)")]), limit(1)]
     ) == {"c1": 1}
+
+
+# ===========================================================================
+# 9. Post-aggregate WHERE: runtime fill-injection plan (test_..._semantics
+#    pins the observable behavior; these pin the admit/decline branches)
+# ===========================================================================
+
+WHERE_STEPS = SEED_STEPS + [with_([("c", "c")]), where_rows(expr="(c = 0)"), select([("c", "c")])]
+
+
+def test_where_suffix_plans_a_fill_at_the_pivot() -> None:
+    assert _identity_fill_insertion_plan(WHERE_STEPS) == [(2, {GROUP_KEY: 1, "c": 0})]
+
+
+def test_apply_inserts_the_fill_step_and_compiles_no_terminal_row() -> None:
+    steps = list(WHERE_STEPS)
+    assert apply_ungrouped_aggregate_identity(steps) is None
+    assert len(steps) == len(WHERE_STEPS) + 1
+    fill = steps[3]
+    assert isinstance(fill, ASTCall)
+    assert fill.function == "fill_empty_row"
+    assert fill.params == {"row": {GROUP_KEY: 1, "c": 0}}
+    assert steps[:3] == WHERE_STEPS[:3] and steps[4:] == WHERE_STEPS[3:]
+
+
+def test_apply_keeps_replayable_suffixes_on_the_terminal_row() -> None:
+    """Anti-vacuity: the compile-time path is byte-for-byte untouched when no
+    where_rows follows the pivot -- terminal row returned, NO insertion."""
+    steps = list(SEED_STEPS)
+    assert apply_ungrouped_aggregate_identity(steps) == {"c": 0}
+    assert steps == SEED_STEPS
+
+
+def test_apply_returns_none_when_neither_path_serves() -> None:
+    original = [ROWS, select([("n", "m.name")])]
+    steps = list(original)
+    assert apply_ungrouped_aggregate_identity(steps) is None
+    assert steps == original
+
+
+def test_fill_plan_declines_without_a_where() -> None:
+    assert _identity_fill_insertion_plan(SEED_STEPS) is None
+    assert _identity_fill_insertion_plan(SEED_STEPS + [select([("c", "c")])]) is None
+
+
+def test_fill_plan_declines_without_a_pivot() -> None:
+    assert _identity_fill_insertion_plan([]) is None
+    assert _identity_fill_insertion_plan([ROWS, where_rows(expr="(x = 0)")]) is None
+    # count_table always emits its one row, so no fill is needed (or planned)
+    assert _identity_fill_insertion_plan(
+        [count_table(alias="c"), where_rows(expr="(c = 0)")]
+    ) is None
+
+
+def test_fill_plan_declines_non_replayable_suffix_steps() -> None:
+    assert _identity_fill_insertion_plan(WHERE_STEPS + [n()]) is None
+    assert _identity_fill_insertion_plan(
+        WHERE_STEPS + [ASTCall("unwind", {"expr": "[]", "as_": "x"})]
+    ) is None
+
+
+def test_fill_plan_declines_a_post_pivot_group_by_without_a_seed() -> None:
+    """A real-keyed (grouped) aggregate after the pivot has no identity contract."""
+    assert _identity_fill_insertion_plan(
+        WHERE_STEPS + [group_by(["c"], [("n", "count")]), select([("n", "n")])]
+    ) is None
+
+
+def test_fill_plan_covers_every_pivot() -> None:
+    steps = (
+        SEED_STEPS
+        + [with_([("c", "c")]), where_rows(expr="(c = 0)")]
+        + [with_([(GROUP_KEY, 1)]), _group_by(("n", "count")),
+           where_rows(expr="(n = 1)"), select([("n", "n")])]
+    )
+    assert _identity_fill_insertion_plan(steps) == [
+        (2, {GROUP_KEY: 1, "c": 0}),
+        (6, {GROUP_KEY: 1, "n": 0}),
+    ]
+    mutated = list(steps)
+    assert apply_ungrouped_aggregate_identity(mutated) is None
+    fills = [s for s in mutated if isinstance(s, ASTCall) and s.function == "fill_empty_row"]
+    assert len(fills) == 2
+    assert mutated[3].params == {"row": {GROUP_KEY: 1, "c": 0}}
+    assert mutated[8].params == {"row": {GROUP_KEY: 1, "n": 0}}

--- a/graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_cross_alias.py
+++ b/graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_cross_alias.py
@@ -1,0 +1,205 @@
+"""Cross-alias grouped aggregates: sole min()/max() lowering + sum(bool) dtype (#1821).
+
+Two families, every expected value HAND-COMPUTED on the fixtures below:
+
+1. A grouped aggregate whose argument lives on a DIFFERENT MATCH alias than its
+   group key (``RETURN c.city, min(p.age)``). The multiplicity-sensitive gate
+   already routed sum/avg/collect/count(*) to binding rows; a SOLE
+   multiplicity-INSENSITIVE aggregate (min/max/count DISTINCT) fell through to
+   the one-source path and refused to lower. Binding rows are sound for those
+   (their value is multiplicity-invariant), so the same route now serves them.
+
+2. pandas ``sum()`` over an object-dtype boolean column: the kernel returned a
+   lone-row group as the raw bool, mixing ``2`` and ``False`` in one output
+   column. sum(bool) is the documented GFQL extension (see agg_types), so the
+   accepted result must be a well-typed numeric column.
+
+Fixture A (persons -> cities): persons 0(20), 1(30), 2(40); LIVES_IN edges
+0->NYC, 1->NYC, 2->LA. Groups: NYC={20, 30}, LA={40}.
+  min per city: LA=40, NYC=20;  max: LA=40, NYC=30;  sum: LA=40, NYC=50;
+  count(DISTINCT p.age): LA=1, NYC=2.
+
+Fixture B (path graph): nodes 0..5, grp x={0,1,2} y={3,4,5},
+bool_col=[T,F,T,T,F,F], int_col=[1..6]; edges 0->1,1->2,2->3,3->4.
+``WITH a.grp AS k, b.col AS v``: k=x pairs b in {1,2,3}, k=y pairs b in {4}.
+  sum(int): x=2+3+4=9, y=5;  sum(bool): x=F+T+T=2, y=F=0.
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.exceptions import GFQLValidationError
+
+try:
+    import polars as pl
+    HAS_POLARS = True
+except ImportError:
+    HAS_POLARS = False
+
+polars_only = pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")
+
+ENGINES = ["pandas", pytest.param("polars", marks=polars_only)]
+
+
+NODES_A = pd.DataFrame({
+    "id": [0, 1, 2, 10, 11],
+    "node_type": ["Person", "Person", "Person", "City", "City"],
+    "age": [20.0, 30.0, 40.0, None, None],
+    "city": [None, None, None, "NYC", "LA"],
+})
+EDGES_A = pd.DataFrame({"s": [0, 1, 2], "d": [10, 10, 11], "rel": ["LIVES_IN"] * 3})
+
+MATCH_A = ("MATCH (p {node_type:'Person'})-[{rel:'LIVES_IN'}]->(c {node_type:'City'}) ")
+
+
+def _graph_a(engine: str):
+    if engine == "polars":
+        return graphistry.nodes(pl.from_pandas(NODES_A), "id").edges(pl.from_pandas(EDGES_A), "s", "d")
+    return graphistry.nodes(NODES_A, "id").edges(EDGES_A, "s", "d")
+
+
+def _run(g, query: str, engine: str) -> pd.DataFrame:
+    out = g.gfql(query, engine=engine)._nodes
+    if hasattr(out, "to_pandas"):
+        out = out.to_pandas()
+    return out.reset_index(drop=True)
+
+
+def _records(df: pd.DataFrame):
+    return [
+        {k: (None if pd.isna(v) else (int(v) if isinstance(v, float) and float(v).is_integer() else v))
+         for k, v in row.items()}
+        for row in df.to_dict("records")
+    ]
+
+
+# ===========================================================================
+# 1. Sole multiplicity-insensitive aggregates now lower onto binding rows
+# ===========================================================================
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("returns,expected", [
+    ("RETURN c.city AS city, min(p.age) AS m ORDER BY city",
+     [{"city": "LA", "m": 40}, {"city": "NYC", "m": 20}]),
+    ("RETURN c.city AS city, max(p.age) AS m ORDER BY city",
+     [{"city": "LA", "m": 40}, {"city": "NYC", "m": 30}]),
+    ("RETURN c.city AS city, count(DISTINCT p.age) AS n ORDER BY city",
+     [{"city": "LA", "n": 1}, {"city": "NYC", "n": 2}]),
+    ("RETURN c.city AS city, min(p.age) AS m, max(p.age) AS x ORDER BY city",
+     [{"city": "LA", "m": 40, "x": 40}, {"city": "NYC", "m": 20, "x": 30}]),
+    ("WITH c.city AS city, min(p.age) AS m RETURN city, m ORDER BY city",
+     [{"city": "LA", "m": 40}, {"city": "NYC", "m": 20}]),
+], ids=["sole_min", "sole_max", "sole_count_distinct", "min_and_max", "with_stage_sole_min"])
+def test_sole_insensitive_cross_alias_grouped_aggregate_serves(returns, expected, engine):
+    assert _records(_run(_graph_a(engine), MATCH_A + returns, engine)) == expected
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_multiplicity_sensitive_route_is_value_identical(engine):
+    """Anti-vacuity control: the sum route (already served at base) agrees with
+    the newly served min route on the same binding rows."""
+    out = _records(_run(
+        _graph_a(engine),
+        MATCH_A + "RETURN c.city AS city, sum(p.age) AS s, min(p.age) AS m ORDER BY city",
+        engine))
+    assert out == [{"city": "LA", "s": 40, "m": 40}, {"city": "NYC", "s": 50, "m": 20}]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_single_alias_sole_min_still_uses_the_source_table_path(engine):
+    """Anti-vacuity: one referenced alias never engages the cross-alias gate."""
+    g = _graph_a(engine)
+    assert _records(_run(g, MATCH_A + "RETURN min(p.age) AS m", engine)) == [{"m": 20}]
+    assert _records(_run(g, MATCH_A + "RETURN max(c.city) AS m", engine)) == [{"m": "NYC"}]
+
+
+def test_whole_row_grouped_sole_min_serves_on_pandas():
+    """`RETURN c, min(p.age)` -- whole-row grouping with a sole insensitive
+    aggregate rides the same binding-rows route on pandas."""
+    out = _run(_graph_a("pandas"), MATCH_A + "RETURN c, min(p.age) AS m", "pandas")
+    got = {row["c.city"]: int(row["m"]) for row in out.to_dict("records")}
+    assert got == {"NYC": 20, "LA": 40}
+
+
+@polars_only
+def test_whole_row_grouped_sole_min_declines_typed_on_polars():
+    """polars has no native whole-entity result projection for this shape;
+    parity-or-error by design (NotImplementedError, never a silent wrong)."""
+    with pytest.raises(NotImplementedError):
+        _run(_graph_a("polars"), MATCH_A + "RETURN c, min(p.age) AS m", "polars")
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_mixed_aggregate_compound_item_keeps_the_fail_fast(engine):
+    """The conservative one-source boundary survives the new gate: an item that
+    COMBINES two aggregates in one expression still refuses to lower."""
+    with pytest.raises(GFQLValidationError, match="one MATCH source alias at a time"):
+        _run(_graph_a(engine),
+             MATCH_A + "RETURN c.city AS city, min(p.age) + max(p.age) AS mm ORDER BY city",
+             engine)
+
+
+# ===========================================================================
+# 2. pandas sum(bool) is a well-typed numeric column
+# ===========================================================================
+
+
+NODES_B = pd.DataFrame({
+    "id": list(range(6)),
+    "grp": ["x"] * 3 + ["y"] * 3,
+    "int_col": [1, 2, 3, 4, 5, 6],
+    "bool_col": [True, False, True, True, False, False],
+})
+EDGES_B = pd.DataFrame({"src": [0, 1, 2, 3], "dst": [1, 2, 3, 4]})
+
+Q_B = "MATCH (a)-[e]->(b) WITH a.grp AS k, b.%s AS v RETURN k, sum(v) AS r ORDER BY k"
+
+
+def _graph_b(engine: str):
+    if engine == "polars":
+        return graphistry.nodes(pl.from_pandas(NODES_B), "id").edges(pl.from_pandas(EDGES_B), "src", "dst")
+    return graphistry.nodes(NODES_B, "id").edges(EDGES_B, "src", "dst")
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("col,expected", [
+    ("bool_col", [2, 0]),
+    ("int_col", [9, 5]),
+], ids=["sum_bool", "sum_int_control"])
+def test_grouped_sum_column_is_numeric_not_mixed(col, expected, engine):
+    out = _run(_graph_b(engine), Q_B % col, engine)
+    values = out["r"].tolist()
+    assert [int(v) for v in values] == expected
+    # the defect was one column mixing int 2 and bool False: no bools, no object dtype
+    assert all(not isinstance(v, bool) for v in values)
+    assert str(out["r"].dtype) != "object"
+
+
+def test_fast_path_sum_over_object_bools_is_numeric():
+    """Twin pin for the OLAP single-hop grouped fast path's pandas branch: it
+    must serve this labeled shape (engagement asserted, not assumed) and answer
+    sum(object-of-bools) as ints. Oracle: NYC flags {True, True} -> 2, LA {False} -> 0."""
+    import graphistry.compute.gfql_fast_paths as fast_paths
+    import graphistry.compute.gfql_unified as unified
+
+    nodes = NODES_A.assign(flag=pd.Series([True, True, False, None, None], dtype=object))
+    g = graphistry.nodes(nodes, "id").edges(EDGES_A, "s", "d")
+    served = []
+    original = fast_paths._execute_single_hop_grouped_aggregate_fast_path
+
+    def spy(*args, **kwargs):
+        result = original(*args, **kwargs)
+        served.append(result is not None)
+        return result
+
+    unified._execute_single_hop_grouped_aggregate_fast_path = spy
+    try:
+        out = _run(g, MATCH_A + "RETURN c.city AS city, sum(p.flag) AS s ORDER BY city", "pandas")
+    finally:
+        unified._execute_single_hop_grouped_aggregate_fast_path = original
+    assert served == [True]
+    values = out["s"].tolist()
+    assert [int(v) for v in values] == [0, 2]
+    assert all(not isinstance(v, bool) for v in values)
+    assert str(out["s"].dtype) != "object"

--- a/graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_cross_alias.py
+++ b/graphistry/tests/compute/gfql/cypher/test_grouped_aggregate_cross_alias.py
@@ -140,6 +140,29 @@ def test_mixed_aggregate_compound_item_keeps_the_fail_fast(engine):
              engine)
 
 
+def test_gate_declines_an_unanalyzable_clause_expression():
+    """Unit pin for the gate's conservative branch: an item text the row-expr
+    parser rejects keeps the pre-existing one-source path (False, no raise)."""
+    from graphistry.compute.ast import n
+    from graphistry.compute.gfql.cypher.aggregate_bindings import requires_aggregate_bindings
+    from graphistry.compute.gfql.cypher.ast import ExpressionText, ReturnClause, ReturnItem, SourceSpan
+
+    span = SourceSpan(1, 1, 1, 1, 0, 0)
+    clause = ReturnClause(
+        items=(ReturnItem(ExpressionText("p.age ~~ c.x", span), None, span),),
+        distinct=False, kind="return", span=span,
+    )
+
+    class _Spec:
+        func = "min"
+        distinct = False
+
+    assert requires_aggregate_bindings(
+        aggregate_specs=[_Spec()], relationship_count=1, clause=clause,
+        alias_targets={"p": n(), "c": n()}, params=None,
+    ) is False
+
+
 # ===========================================================================
 # 2. pandas sum(bool) is a well-typed numeric column
 # ===========================================================================

--- a/graphistry/tests/compute/gfql/cypher/test_lowering.py
+++ b/graphistry/tests/compute/gfql/cypher/test_lowering.py
@@ -13717,14 +13717,21 @@ def test_gfql_executes_count_distinct_missing_property_as_zero() -> None:
     )
 
 
-def test_cypher_to_gfql_rejects_multi_source_aggregate_expr() -> None:
-    with pytest.raises(GFQLValidationError) as exc_info:
-        cypher_to_gfql("MATCH (a)-[r]->(b) RETURN a.id AS a_id, max(b.score) AS max_b")
+def test_cypher_to_gfql_serves_cross_alias_sole_insensitive_aggregate() -> None:
+    """Previously an E108 rejection: a sole multiplicity-insensitive aggregate
+    (max) over one alias grouped by another's property now lowers onto binding
+    rows. Oracle: edges 1->{2,3}, 2->{3}; max(b.score) is 30 for both groups."""
+    cypher_to_gfql("MATCH (a)-[r]->(b) RETURN a.id AS a_id, max(b.score) AS max_b")
 
-    assert exc_info.value.code == ErrorCode.E108
-    assert exc_info.value.context["field"] == "return"
-    assert exc_info.value.context["value"] == "b.score"
-    assert "value: 'b.score'" in str(exc_info.value)
+    g = _mk_graph(
+        pd.DataFrame({"id": [1, 2, 3], "score": [10.0, 20.0, 30.0]}),
+        pd.DataFrame({"s": [1, 1, 2], "d": [2, 3, 3]}),
+    )
+    out = g.gfql("MATCH (a)-[r]->(b) RETURN a.id AS a_id, max(b.score) AS max_b ORDER BY a_id")._nodes
+    assert out.to_dict("records") == [
+        {"a_id": 1, "max_b": 30.0},
+        {"a_id": 2, "max_b": 30.0},
+    ]
 
 
 def test_gfql_executes_top_level_quantifier_expression() -> None:

--- a/graphistry/tests/compute/gfql/test_aggregate_identity_row_semantics.py
+++ b/graphistry/tests/compute/gfql/test_aggregate_identity_row_semantics.py
@@ -302,28 +302,57 @@ def test_min_max_over_booleans_is_plain_opencypher(engine):
 
 
 # ===========================================================================
-# 5. Residual: a post-aggregate WHERE is undecidable at compile time (#1909)
+# 5. A truthy post-aggregate WHERE sees the identity row at RUNTIME (#1939)
 # ===========================================================================
+# Whether the identity row survives a post-aggregate WHERE depends on the real
+# aggregate value, which the compiler cannot see -- so the lowering injects a
+# `fill_empty_row` step at the aggregate itself and the WHERE runs over
+# whichever row exists at runtime (real or identity), on every engine.
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_post_aggregate_where_over_empty_stream_is_a_known_residual(engine):
-    """Control for the residual pinned below: with 6 nodes the count is 6, the
-    `c = 0` filter removes it, and 0 rows is CORRECT."""
-    assert _records(_run("MATCH (m) WITH count(*) AS c WHERE c = 0 RETURN c", engine)) == []
+@pytest.mark.parametrize("query,expected", [
+    # empty stream -> identity {c: 0}; `c = 0` KEEPS it
+    ("MATCH (m) WHERE m.name = 'Zed' WITH count(*) AS c WHERE c = 0 RETURN c", [{"c": 0}]),
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c = 0 RETURN c", [{"c": 0}]),
+    # empty stream, `c > 0` DROPS the identity row
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c > 0 RETURN c", []),
+    # post-aggregate expression after the surviving identity row
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c = 0 RETURN c + 1 AS v", [{"v": 1}]),
+    # terminal paging still pages the surviving row
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c = 0 RETURN c SKIP 1", []),
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c = 0 RETURN c LIMIT 0", []),
+    # the other identities survive their own truthy WHEREs
+    ("MATCH (m) WHERE m.name = 'Zed' WITH sum(m.age) AS s WHERE s = 0 RETURN s", [{"s": 0}]),
+    ("MATCH (m) WHERE m.name = 'Zed' WITH min(m.age) AS mn WHERE mn IS NULL RETURN mn",
+     [{"mn": None}]),
+    ("MATCH (m) WHERE m.name = 'Zed' WITH collect(m.name) AS l WHERE size(l) = 0 RETURN l",
+     [{"l": []}]),
+    ("UNWIND [] AS x WITH count(DISTINCT x) AS c WHERE c = 0 RETURN c", [{"c": 0}]),
+    # chained: each ungrouped aggregate gets its own runtime fill.
+    # c=0 survives `c = 0`; count(c) over that one row is 1; `n = 1` keeps it.
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c = 0 WITH count(c) AS n WHERE n = 1 RETURN n",
+     [{"n": 1}]),
+    # c=0 fails `c = 5`; count over the emptied stream refills n=0; `n = 1` drops it.
+    ("UNWIND [] AS x WITH count(*) AS c WHERE c = 5 WITH count(c) AS n WHERE n = 1 RETURN n",
+     []),
+], ids=["match_where_keeps", "unwind_where_keeps", "unwind_where_drops", "post_expr",
+        "skip_pages_out", "limit_pages_out", "sum_identity", "min_is_null", "collect_size",
+        "count_distinct", "chained_double_fill_keeps", "chained_double_fill_drops"])
+def test_post_aggregate_where_sees_the_identity_row(query, expected, engine):
+    assert _records(_run(query, engine)) == expected
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-@pytest.mark.xfail(strict=True, reason="#1909 residual: when a WHERE follows the ungrouped "
-                                       "aggregate, whether the identity row survives depends on "
-                                       "the real aggregate value, which the compiler cannot see; "
-                                       "the synthesis declines rather than guess")
-def test_post_aggregate_where_keeping_the_identity_row_is_unsupported(engine):
-    """openCypher: no node is named 'Zed', so count(*) is 0 and `WHERE c = 0` KEEPS
-    the identity row -> 1 row {c: 0}. We return 0 rows; deciding this needs the
-    emptiness of the pre-aggregate stream at runtime, not compile time."""
-    query = "MATCH (m) WHERE m.name = 'Zed' WITH count(*) AS c WHERE c = 0 RETURN c"
-    assert _records(_run(query, engine)) == [{"c": 0}]
+@pytest.mark.parametrize("query,expected", [
+    # SOUNDNESS: with 6 nodes the count is 6, `c = 0` removes the REAL row and the
+    # identity fill must NOT resurrect it -- a terminal "fill when empty" would.
+    ("MATCH (m) WITH count(*) AS c WHERE c = 0 RETURN c", []),
+    # the real aggregate value flows through the same WHERE unharmed
+    ("MATCH (m) WITH count(*) AS c WHERE c = 6 RETURN c", [{"c": 6}]),
+], ids=["real_row_filtered_stays_filtered", "real_row_kept"])
+def test_post_aggregate_where_over_a_nonempty_stream_uses_the_real_value(query, expected, engine):
+    assert _records(_run(query, engine)) == expected
 
 
 # ===========================================================================

--- a/graphistry/tests/compute/gfql/test_conformance_ledger.py
+++ b/graphistry/tests/compute/gfql/test_conformance_ledger.py
@@ -137,6 +137,7 @@ CALL_KNOWN_UNCOVERED: dict[str, str] = {
     "order_by": "row sort; native on polars chain, NIE via call()/DAG executor; not asserted via call(). TODO.",
     "unwind": "list explode; native on polars chain, NIE via call()/DAG executor; not asserted via call(). TODO.",
     "group_by": "grouped aggregation; native on polars chain, NIE via call()/DAG executor; not asserted via call(). TODO.",
+    "fill_empty_row": "ungrouped-aggregate identity fill; compiler-emitted (cypher lowering), native on all engines, exercised via the post-aggregate WHERE cypher cases; not asserted via call(). TODO.",
     "search_any": "cross-column search marker (viz-filter L2); exercised as a labeled subject via test_search_any_op_all_engines (chain call surface, oracle pins + 4-engine parity-or-NIE), not via a direct call() consistency label.",
     "count_table": "count(*) short-circuit fast path (table height / source-mask sum); native frame op emitted by the cypher lowering, exercised as a labeled subject via _ROW_OP_CASES + the count_all_nodes/edges cypher cases, not via a direct call() consistency label. TODO.",
     "semi_apply_mark": "correlated EXISTS-mark; NATIVE on polars (viz-filter L1), exercised implicitly by the matrix EXISTS cypher cases; no direct labeled subject.",
@@ -194,6 +195,7 @@ CALL_KNOWN_UNCOVERED: dict[str, str] = {
 # they're tracked on the call() axis.) Fails CI if a NEW op lands unasserted and unwaived ----
 
 ROW_OP_KNOWN_UNCOVERED: dict[str, str] = {
+    "fill_empty_row": "ungrouped-aggregate identity fill; native on pandas/cuDF/polars, exercised (and mutation-killed) via the post-aggregate WHERE cypher cases in test_aggregate_identity_row_semantics.py; no labeled rowop subject in this matrix.",
     # honest NIE — correlated-subquery ops with no native polars lowering (_try_native_row_op returns None)
     "semi_apply_mark": "native single-join-alias polars lowering (viz-filter L1); multi-alias correlation still declines NIE; exercised via cypher EXISTS cases, no labeled rowop subject.",
     "anti_semi_apply": "native single-join-alias polars lowering (viz-filter L1); multi-alias correlation still declines NIE; exercised via cypher NOT-EXISTS case, no labeled rowop subject.",


### PR DESCRIPTION
Fixes #1939. Serves #1821 sub-1 and sub-3 (sub-2 was fixed earlier), so closes #1821.

## #1939 — post-aggregate WHERE never saw the ungrouped-aggregate identity row

`UNWIND [] AS x WITH count(*) AS c WHERE c = 0 RETURN c` returned 0 rows on every engine; the openCypher answer is 1 row `{c: 0}`.

Root cause: the #1910 module synthesizes the identity row at compile time and the runtime applies it only when the final result is empty. A post-aggregate `where_rows` made the synthesis decline — and that decline was the *sound* choice for a terminal fill: whether the identity row survives the WHERE depends on the real aggregate value, and a "fill when the final result is empty" applied after a WHERE that passes the identity would wrongly resurrect a WHERE-filtered *real* row (`MATCH (m) WITH count(*) AS c WHERE c = 0` over 6 nodes must stay 0 rows).

Fix — move the decision to runtime: when (and only when) the suffix after an ungrouped aggregate contains `where_rows` and every suffix step is replayable-or-where, the lowering inserts a new `fill_empty_row` row op directly after each ungrouped-aggregate `group_by`. The op replaces an EMPTY aggregate output with the compiled identity row; the WHERE (and any post-expressions, paging, later aggregates) then runs over whichever row exists — real or identity — with ordinary runtime semantics on pandas, polars (native twin), and cuDF. Chained ungrouped aggregates each get their own fill, so `... WHERE c = 5 WITH count(c) AS n ...` re-fills correctly after the WHERE empties the stream.

All previously served identity shapes keep the compile-time terminal row byte-for-byte (pinned); the every-#1909-case battery is green and unchanged. The optional-reentry overlap (where `empty_result_row` is deliberately cleared) is unreachable for this shape — `OPTIONAL MATCH ... WITH <agg> WHERE` is a typed compile decline on base and head alike (A/B verified).

New op surface: safelist entry (`call/validation.py`), pandas/cuDF mixin op + dispatch (`row/pipeline.py`), native polars twin (`lazy/engine/polars/row_pipeline.py`, `chain.py`).

## #1821 sub-1 — sole `min()`/`max()` cross-alias grouped aggregate refused to lower

`MATCH (p ...)-[...]->(c ...) RETURN c.city, min(p.age)` raised `GFQLValidationError` ("one MATCH source alias at a time") while `sum(...)` and `sum(...), min(...)` both served. The force-bindings block already vetted min/max/count as sound on binding rows (case b), but its outer gate keyed only on multiplicity-*sensitive* aggregates, so a sole insensitive aggregate never reached it and fell to the one-source fail-fast.

Fix: the gate (moved to a new `cypher/aggregate_bindings.py`; `lowering.py` stays under its surface-guard line cap, net −10 lines) now also engages when a clause with aggregates over a relationship pattern spans ≥2 MATCH aliases. Binding rows are sound for min/max/count DISTINCT because their values are multiplicity-invariant; the per-spec vetting inside the block and the mixed-item fail-fast (`min(p.age) + max(p.age)` in one item) are unchanged and pinned. Every newly-engaged shape was an ERROR at base — no served query changes route. Serves: sole min, sole max, sole count DISTINCT, min+max, the WITH-stage variant, and whole-row `RETURN c, min(p.age)` on pandas/cuDF (polars declines that result projection with its usual typed NIE, pinned).

## #1821 sub-3 — pandas `sum(bool)` produced one column mixing `2` and `False`

pandas' object-dtype groupby reduction returns a lone-row group as the raw bool. `sum(bool)` is the documented GFQL extension (agg_types module docstring), so the accepted result is now retyped to a numeric column (`[2, 0]`, int64) in the row-pipeline `group_by` and in the OLAP single-hop grouped fast path's pandas branch (twin; engagement asserted in the pin). Acceptance itself is untouched (#1820 stays an owner question). polars/cuDF already answered ints and are unchanged.

## Verification

- Repro'd all three defects at base `07c57a827` on pandas, polars, and cuDF 25.10; all serve after the fix on all three engines (hand-computed oracles).
- Pins red-at-master: 30 e2e failures at base = exactly the fix pins (plus the new-module unit file which cannot import at base); anti-vacuity controls (WHERE-drops, paging, non-empty real-value soundness, single-alias routes, sum(int), mixed-item fail-fast) pass at base AND head.
- Mutation-check: 6 targeted mutants (gate neutered, injection plan removed, pandas fill neutered, polars fill neutered, both sum(bool) retypes dropped) each killed by the pins; unmutated control green.
- Full `graphistry/tests/compute` failure SET identical base vs head (105 pre-existing failures in the local env, no additions, no losses). Two intentional test-side updates from that A/B: the stale E108 pin `test_cypher_to_gfql_rejects_multi_source_aggregate_expr` is now a serving pin with an execution oracle (its query is exactly the fixed #1821 family), and `fill_empty_row` carries conformance-ledger entries on both the rowops and call() axes.
- Gates: ruff/lint rc=0; cypher-surface, comment-density, and type-hygiene guards rc=0; mypy error set identical to base (4 pre-existing).
- Coverage: `aggregate_identity.py` floor kept at 100.0; new `aggregate_bindings.py` at 100% and added to the ci-pandas baseline at 100.0. New test file registered in the polars lane (`bin/test-polars.sh`), lane-completeness guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
