### PR TITLE
fix(gfql): WITH->MATCH carry restricts every route (#1712 residual); alias-shadowed property reads (#1911 defect-4)

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -55,6 +55,10 @@ POLARS_TEST_FILES=(
     # #1911 alias-scoping pins: every case is parametrized pandas AND polars, and the
     # polars params (WITH-rebind decline parity, edge-identity collision crash) only run here
     graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+    # #1712 reentry-carry seed pins: no module-level importorskip (pandas params run in
+    # test-gfql-core), but the polars params — native carry restriction + the typed
+    # scalar-carry declines — only ever run here
+    graphistry/tests/compute/gfql/test_reentry_carry_seed_restriction.py
     graphistry/tests/compute/gfql/test_count_and_param_semantics.py
     graphistry/tests/compute/gfql/row/test_row_pipeline_boundaries.py
     graphistry/tests/compute/gfql/test_unary_op_surface.py

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -538,9 +538,7 @@ def combine_steps(
             base = c[:-2]
             c_x = base + '_x'
             if c_x in out_df.columns:
-                if base in alias_marker_names:
-                    out_df[base] = out_df[c_x].fillna(False).astype(bool)
-                elif len(out_df) > 0:
+                if len(out_df) > 0:
                     out_df[base] = out_df[c_x].where(out_df[c_x].notna(), out_df[c])
                 out_df = out_df.drop(columns=[c, c_x])
 

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -531,7 +531,9 @@ def combine_steps(
             if c_y in out_df.columns:
                 if base in alias_marker_names:
                     out_df[base] = out_df[c].fillna(False).astype(bool)
-                elif len(out_df) > 0:
+                    out_df = out_df.drop(columns=[c, c_y])
+                    continue
+                if len(out_df) > 0:
                     out_df[base] = out_df[c].where(out_df[c].notna(), out_df[c_y])
                 out_df = out_df.drop(columns=[c, c_y])
         elif c.endswith('_y'):

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -516,10 +516,10 @@ def combine_steps(
                 out_df[op._name] = label_mask
 
     cols = list(out_df.columns)
-    # #1911: an alias named like a user column collides here (marker `_x` from the step
-    # frames vs user values `_y` from the base frame). The marker is authoritative
-    # (null = unbound row); user values are restored from the base frame at property-read
-    # time, never coalesced into the marker (mixed bool/user dtypes also crash cuDF).
+    # An alias named like a user column collides here (marker `_x` from the step frames
+    # vs user values `_y` from the base frame). The marker is authoritative (null =
+    # unbound row); user values are restored from the base frame at property-read time,
+    # never coalesced into the marker (mixed bool/user dtypes also crash cuDF).
     alias_marker_names = {
         op._name for op, _ in steps
         if isinstance(op, op_type) and isinstance(getattr(op, '_name', None), str)

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -516,19 +516,31 @@ def combine_steps(
                 out_df[op._name] = label_mask
 
     cols = list(out_df.columns)
+    # #1911: an alias named like a user column collides here (marker `_x` from the step
+    # frames vs user values `_y` from the base frame). The marker is authoritative
+    # (null = unbound row); user values are restored from the base frame at property-read
+    # time, never coalesced into the marker (mixed bool/user dtypes also crash cuDF).
+    alias_marker_names = {
+        op._name for op, _ in steps
+        if isinstance(op, op_type) and isinstance(getattr(op, '_name', None), str)
+    }
     for c in cols:
         if c.endswith('_x'):
             base = c[:-2]
             c_y = base + '_y'
             if c_y in out_df.columns:
-                if len(out_df) > 0:
+                if base in alias_marker_names:
+                    out_df[base] = out_df[c].fillna(False).astype(bool)
+                elif len(out_df) > 0:
                     out_df[base] = out_df[c].where(out_df[c].notna(), out_df[c_y])
                 out_df = out_df.drop(columns=[c, c_y])
         elif c.endswith('_y'):
             base = c[:-2]
             c_x = base + '_x'
             if c_x in out_df.columns:
-                if len(out_df) > 0:
+                if base in alias_marker_names:
+                    out_df[base] = out_df[c_x].fillna(False).astype(bool)
+                elif len(out_df) > 0:
                     out_df[base] = out_df[c_x].where(out_df[c_x].notna(), out_df[c])
                 out_df = out_df.drop(columns=[c, c_x])
 

--- a/graphistry/compute/gfql/cypher/reentry/execution.py
+++ b/graphistry/compute/gfql/cypher/reentry/execution.py
@@ -310,6 +310,46 @@ def _optional_reentry_key_value(value: CypherFillValue) -> CypherFillValue:
     return value
 
 
+def restrict_connected_join_rows_to_reentry_seed(
+    joined_rows: DataFrameT,
+    *,
+    start_nodes: DataFrameT,
+    reentry_alias: Optional[str],
+    node_col: str,
+) -> DataFrameT:
+    """#1712: keep only comma-pattern join rows whose reentry alias is a carried seed id.
+
+    The connected comma-pattern join re-matches every arm from the whole graph, so a
+    ``WITH p MATCH (p)-..., (p)-...`` suffix must be narrowed back to the carried ``p``
+    rows here; seeds are non-null by construction (``aligned_reentry_rows``)."""
+    if reentry_alias is None or node_col not in start_nodes.columns:
+        raise reentry_validation_error(
+            "Cypher MATCH after WITH could not recover the carried seed ids for the connected comma-pattern join",
+            value=reentry_alias,
+            suggestion=REENTRY_WHOLE_ROW_SUGGESTION,
+        )
+    alias_col = next(
+        (
+            col
+            for col in (reentry_alias, f"{reentry_alias}.{node_col}")
+            if col in joined_rows.columns
+        ),
+        None,
+    )
+    if alias_col is None:
+        raise reentry_validation_error(
+            "Cypher MATCH after WITH could not recover the carried alias binding column from the connected comma-pattern join",
+            value=reentry_alias,
+            suggestion=REENTRY_WHOLE_ROW_SUGGESTION,
+        )
+    seed_ids = cast(SeriesT, start_nodes[node_col])
+    if _is_polars_df(joined_rows):
+        import polars as pl
+        seed_values = seed_ids.to_list() if hasattr(seed_ids, "to_list") else list(seed_ids)
+        return cast(DataFrameT, joined_rows.filter(pl.col(alias_col).is_in(seed_values)))
+    return cast(DataFrameT, joined_rows[joined_rows[alias_col].isin(seed_ids)])
+
+
 def compiled_query_reentry_state(
     base_graph: Plottable,
     plan: ReentryPlan,

--- a/graphistry/compute/gfql/cypher/reentry/execution.py
+++ b/graphistry/compute/gfql/cypher/reentry/execution.py
@@ -317,7 +317,7 @@ def restrict_connected_join_rows_to_reentry_seed(
     reentry_alias: Optional[str],
     node_col: str,
 ) -> DataFrameT:
-    """#1712: keep only comma-pattern join rows whose reentry alias is a carried seed id.
+    """Keep only comma-pattern join rows whose reentry alias is a carried seed id.
 
     The connected comma-pattern join re-matches every arm from the whole graph, so a
     ``WITH p MATCH (p)-..., (p)-...`` suffix must be narrowed back to the carried ``p``
@@ -342,12 +342,12 @@ def restrict_connected_join_rows_to_reentry_seed(
             value=reentry_alias,
             suggestion=REENTRY_WHOLE_ROW_SUGGESTION,
         )
-    seed_ids = cast(SeriesT, start_nodes[node_col])
+    seed_ids = start_nodes[node_col]
     if _is_polars_df(joined_rows):
         import polars as pl
         seed_values = seed_ids.to_list() if hasattr(seed_ids, "to_list") else list(seed_ids)
-        return cast(DataFrameT, joined_rows.filter(pl.col(alias_col).is_in(seed_values)))
-    return cast(DataFrameT, joined_rows[joined_rows[alias_col].isin(seed_ids)])
+        return joined_rows.filter(pl.col(alias_col).is_in(seed_values))  # type: ignore[attr-defined]
+    return joined_rows[joined_rows[alias_col].isin(seed_ids)]
 
 
 def compiled_query_reentry_state(

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -8,6 +8,7 @@ import pandas as pd
 from graphistry.Plottable import Plottable
 from graphistry.compute.typing import DataFrameT, SeriesT
 from graphistry.Engine import is_polars_df
+from graphistry.compute.gfql.identifiers import shadow_restore_column
 from graphistry.compute.gfql.series_str_compat import is_non_textual_scalar_dtype
 
 from .lowering import ResultProjectionColumn, ResultProjectionPlan
@@ -265,13 +266,6 @@ def _projection_alias_rows(
 ) -> Optional[DataFrameT]:
     prefix = f"{alias}."
     alias_columns = [column for column in rows_df.columns if str(column).startswith(prefix)]
-    if (
-        alias_columns == [f"{alias}.{alias}"]
-        and alias in rows_df.columns
-        and str(getattr(rows_df[alias], "dtype", "")).startswith("bool")
-    ):
-        # a lone dotted self-column beside the boolean marker is the rows() shadow restore, not a pre-flattened entity frame
-        return rows_df.drop(columns=[f"{alias}.{alias}"])
     if alias_columns:
         alias_rows = cast(
             DataFrameT,
@@ -377,9 +371,9 @@ def _apply_result_projection_pandas(
             output_columns.append(column.output_name)
             if column.kind == "property":
                 property_rows_df = alias_rows_df
-                self_shadow_col = f"{projection.alias}.{projection.alias}"
+                self_shadow_col = shadow_restore_column(projection.alias)
                 if column.source_name == projection.alias and self_shadow_col in rows_df.columns:
-                    # 'alias.alias': the plain column is the marker; user values live under the dotted self-name
+                    # 'alias.alias': the plain column is the marker; rows() re-keyed the user values
                     column = replace(column, source_name=self_shadow_col)
                     property_rows_df = rows_df
                 elif (

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -265,6 +265,15 @@ def _projection_alias_rows(
 ) -> Optional[DataFrameT]:
     prefix = f"{alias}."
     alias_columns = [column for column in rows_df.columns if str(column).startswith(prefix)]
+    if (
+        alias_columns == [f"{alias}.{alias}"]
+        and alias in rows_df.columns
+        and str(getattr(rows_df[alias], "dtype", "")).startswith("bool")
+    ):
+        # #1911 defect-4: rows() re-exposes a marker-shadowed user column under its dotted
+        # self-name for property reads; a lone self-column beside the boolean marker is that
+        # restore, not a pre-flattened entity frame — whole-entity reads the plain frame.
+        return cast(DataFrameT, rows_df.drop(columns=[f"{alias}.{alias}"]))
     if alias_columns:
         alias_rows = cast(
             DataFrameT,
@@ -370,7 +379,13 @@ def _apply_result_projection_pandas(
             output_columns.append(column.output_name)
             if column.kind == "property":
                 property_rows_df = alias_rows_df
-                if (
+                self_shadow_col = f"{projection.alias}.{projection.alias}"
+                if column.source_name == projection.alias and self_shadow_col in rows_df.columns:
+                    # #1911 defect-4: 'alias.alias' — the plain column is the boolean
+                    # marker; the restored user values live under the dotted self-name.
+                    column = replace(column, source_name=self_shadow_col)
+                    property_rows_df = rows_df
+                elif (
                     column.source_name is not None
                     and column.source_name not in alias_rows_df.columns
                     and column.source_name in rows_df.columns

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -270,10 +270,8 @@ def _projection_alias_rows(
         and alias in rows_df.columns
         and str(getattr(rows_df[alias], "dtype", "")).startswith("bool")
     ):
-        # #1911 defect-4: rows() re-exposes a marker-shadowed user column under its dotted
-        # self-name for property reads; a lone self-column beside the boolean marker is that
-        # restore, not a pre-flattened entity frame — whole-entity reads the plain frame.
-        return cast(DataFrameT, rows_df.drop(columns=[f"{alias}.{alias}"]))
+        # a lone dotted self-column beside the boolean marker is the rows() shadow restore, not a pre-flattened entity frame
+        return rows_df.drop(columns=[f"{alias}.{alias}"])
     if alias_columns:
         alias_rows = cast(
             DataFrameT,
@@ -381,8 +379,7 @@ def _apply_result_projection_pandas(
                 property_rows_df = alias_rows_df
                 self_shadow_col = f"{projection.alias}.{projection.alias}"
                 if column.source_name == projection.alias and self_shadow_col in rows_df.columns:
-                    # #1911 defect-4: 'alias.alias' — the plain column is the boolean
-                    # marker; the restored user values live under the dotted self-name.
+                    # 'alias.alias': the plain column is the marker; user values live under the dotted self-name
                     column = replace(column, source_name=self_shadow_col)
                     property_rows_df = rows_df
                 elif (

--- a/graphistry/compute/gfql/identifiers.py
+++ b/graphistry/compute/gfql/identifiers.py
@@ -55,6 +55,11 @@ WALK_PREV_COL: Final[str] = '__gfql_prev__'
 #: Stable per-edge identity: openCypher TRAIL semantics bind a relationship at most once per path.
 TRAIL_EDGE_IDENT_COL: Final[str] = '__gfql_edge_ident__'
 
+
+def shadow_restore_column(alias: str) -> str:
+    """Row-table column carrying user values of a column the alias marker overwrote."""
+    return f'__gfql_shadow_restore__{alias}__'
+
 #: Prefix of the per-hop column recording WHICH relationship that hop bound.
 TRAIL_COLUMN_PREFIX: Final[str] = '__gfql_trail_'
 

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1649,15 +1649,14 @@ def _cartesian_node_bindings_polars(
         # L4 pushdown twin of pandas `_gfql_cartesian_node_bindings_row_table`
         matched = _apply_alias_prefilters_polars(matched, alias, alias_prefilters)  # honoured, never dropped (#1804)
         cols = matched.collect_schema().names()
-        # prop_cols excludes node_id and any real column named == alias: the pandas
-        # node execute() leaks a boolean FLAG into a column named ``alias``
-        # (shadowing a same-named real property), which the lookup frame surfaces
-        # as ``alias.alias = True``. Reproduce that exactly.
+        # prop_cols excludes node_id and any real column named == alias; that column is
+        # emitted once below as ``alias.alias``: the real user values when the column
+        # exists (#1911 defect-4 parity with pandas' unshadow), else the flag ``True``.
         prop_cols = [c for c in cols if c != node_id and c != alias]
         exprs = [
             pl.col(node_id).alias(alias),
             pl.col(node_id).alias(f"{alias}.{node_id}"),
-            pl.lit(True).alias(f"{alias}.{alias}"),
+            (pl.col(alias) if alias in cols else pl.lit(True)).alias(f"{alias}.{alias}"),
         ]
         exprs.extend(pl.col(c).alias(f"{alias}.{c}") for c in prop_cols)
         per_alias.append(matched.select(exprs))

--- a/graphistry/compute/gfql/row/entity_props.py
+++ b/graphistry/compute/gfql/row/entity_props.py
@@ -143,8 +143,7 @@ def _nullify_missing_alias_rows(df: DataFrameT, alias_col: str, rendered: Series
 def _all_non_null_match(mask: SeriesT, non_null: SeriesT) -> bool:
     if not hasattr(mask, "where"):
         return False
-    # all-null: nothing matches the shape being probed — vacuous truth here rendered
-    # NULL carried scalars as constructor zero-values (e.g. '0000-00-00'; #1712 family).
+    # all-null proves nothing; vacuous truth rendered NULLs as constructor zero-values
     if hasattr(non_null, "any") and not bool(non_null.any()):
         return False
     return bool(mask.where(non_null, True).all())

--- a/graphistry/compute/gfql/row/entity_props.py
+++ b/graphistry/compute/gfql/row/entity_props.py
@@ -143,6 +143,10 @@ def _nullify_missing_alias_rows(df: DataFrameT, alias_col: str, rendered: Series
 def _all_non_null_match(mask: SeriesT, non_null: SeriesT) -> bool:
     if not hasattr(mask, "where"):
         return False
+    # all-null: nothing matches the shape being probed — vacuous truth here rendered
+    # NULL carried scalars as constructor zero-values (e.g. '0000-00-00'; #1712 family).
+    if hasattr(non_null, "any") and not bool(non_null.any()):
+        return False
     return bool(mask.where(non_null, True).all())
 
 

--- a/graphistry/compute/gfql/row/frame_ops.py
+++ b/graphistry/compute/gfql/row/frame_ops.py
@@ -66,15 +66,24 @@ def _restore_alias_shadowed_user_column(
 ) -> "DataFrameT":
     """An alias named like a user column (``MATCH (name:P) RETURN name.name``) has that
     column overwritten by the alias marker upstream, so ``source.source`` read back the
-    marker. Re-key the user's values from the base frame and expose them under the
-    dotted name the projection resolves first, keeping the boolean marker intact for
-    every other property read. No-op when the alias shadows nothing or rows cannot be
-    re-keyed (marker stays, as before)."""
+    marker. Re-key the user's values from the base frame under an internal restore
+    column the projection resolves, keeping the boolean marker intact for every other
+    read. No-op when the alias shadows nothing, the base column is itself a boolean
+    marker (an intermediate dispatch graph), or rows cannot be re-keyed."""
+    from graphistry.compute.gfql.identifiers import shadow_restore_column
+
     base_graph = ctx._gfql_rows_base_graph if ctx._gfql_rows_base_graph is not None else ctx._g
     base_frame = None if base_graph is None else (
         base_graph._nodes if table == "nodes" else base_graph._edges
     )
     if base_frame is None or source not in base_frame.columns:
+        return table_df
+    if _is_polars(table_df):
+        import polars as pl
+        base_is_marker = base_frame.schema.get(source) == pl.Boolean
+    else:
+        base_is_marker = str(getattr(base_frame[source], "dtype", "")).startswith("bool")
+    if base_is_marker:
         return table_df
     key = base_graph._node if table == "nodes" else base_graph._edge  # type: ignore[union-attr]
     if _is_polars(table_df):
@@ -88,7 +97,7 @@ def _restore_alias_shadowed_user_column(
                 base_frame.select([key, source]), on=key, how="left"
             ).select(orig_cols)
         return table_df
-    dotted = f"{source}.{source}"
+    restore_col = shadow_restore_column(source)
     base_index = getattr(base_frame, "index", None)
     if base_index is not None and bool(base_index.is_unique):
         # guarded .loc proves index-subset alignment (cuDF Index.isin disagrees with pandas)
@@ -98,14 +107,14 @@ def _restore_alias_shadowed_user_column(
             restored = None
         if restored is not None and len(restored) == len(table_df):
             out = table_df.copy()
-            out[dotted] = restored
+            out[restore_col] = restored
             return out
     if (
         key is not None and key != source
         and key in table_df.columns and key in base_frame.columns
         and bool(base_frame[key].is_unique)
     ):
-        renamed = base_frame[[key, source]].rename(columns={source: dotted})
+        renamed = base_frame[[key, source]].rename(columns={source: restore_col})
         return table_df.merge(renamed, on=key, how="left")
     return table_df
 

--- a/graphistry/compute/gfql/row/frame_ops.py
+++ b/graphistry/compute/gfql/row/frame_ops.py
@@ -61,6 +61,56 @@ def _alias_true_mask(table_df: Any, source: str) -> Any:
     return mask.astype(bool)
 
 
+def _restore_alias_shadowed_user_column(
+    ctx: RowPipelineCtx, table_df: Any, table: Optional[str], source: str
+) -> Any:
+    """#1911 defect-4: an alias named like a user column (``MATCH (name:P) RETURN name.name``)
+    has that column overwritten by the alias marker upstream, so ``source.source`` read back
+    the marker. Re-key the user's values from the base frame and expose them under the
+    dotted name the projection resolves first, keeping the boolean marker intact for every
+    other property read. No-op when the alias shadows nothing or rows cannot be re-keyed
+    (marker stays, as before)."""
+    base_graph = ctx._gfql_rows_base_graph if ctx._gfql_rows_base_graph is not None else ctx._g
+    base_frame = None if base_graph is None else (
+        base_graph._nodes if table == "nodes" else base_graph._edges
+    )
+    if base_frame is None or source not in base_frame.columns:
+        return table_df
+    key = base_graph._node if table == "nodes" else base_graph._edge  # type: ignore[union-attr]
+    if _is_polars(table_df):
+        if (
+            key is not None and key != source
+            and key in table_df.columns and key in base_frame.columns
+            and base_frame[key].n_unique() == len(base_frame)
+        ):
+            orig_cols = list(table_df.columns)
+            return table_df.drop(source).join(
+                base_frame.select([key, source]), on=key, how="left"
+            ).select(orig_cols)
+        return table_df
+    dotted = f"{source}.{source}"
+    base_index = getattr(base_frame, "index", None)
+    if base_index is not None and bool(base_index.is_unique):
+        # the chain result is a row-subset of the base frame with its index preserved;
+        # a guarded .loc (not Index.isin — cuDF's disagrees with pandas') proves it.
+        try:
+            restored = base_frame[source].loc[table_df.index]
+        except (KeyError, IndexError, TypeError):
+            restored = None
+        if restored is not None and len(restored) == len(table_df):
+            out = table_df.copy()
+            out[dotted] = restored
+            return out
+    if (
+        key is not None and key != source
+        and key in table_df.columns and key in base_frame.columns
+        and bool(base_frame[key].is_unique)
+    ):
+        renamed = base_frame[[key, source]].rename(columns={source: dotted})
+        return table_df.merge(renamed, on=key, how="left")
+    return table_df
+
+
 def row_table(ctx: RowPipelineCtx, table_df: Any) -> "Plottable":
     """Return a plottable that treats ``table_df`` as the active row table."""
     from graphistry.compute.gfql.index.handoff import clear_handoff, read_handoff
@@ -228,11 +278,13 @@ def rows(
             # the polars frame would otherwise widen the variable's type and break the pandas
             # ``.loc`` branch below (``is_polars_df`` is a TypeGuard, so it does not narrow the
             # negative branch back to pandas). Same call, same argument, same result.
-            return row_table(ctx, table_df.filter(pl.col(source).fill_null(False).cast(pl.Boolean)))
+            return row_table(ctx, _restore_alias_shadowed_user_column(
+                ctx, table_df.filter(pl.col(source).fill_null(False).cast(pl.Boolean)), table, source))
         # unreachable for polars (returned above), but the guard on the ``.copy()`` branch
         # further up leaves the polars arm in this variable's type: TypeGuard narrows only
         # the positive branch, so ``not _is_polars(...)`` cannot narrow back to pandas.
         table_df = table_df.loc[_alias_true_mask(table_df, source)]  # type: ignore[union-attr]
+        table_df = _restore_alias_shadowed_user_column(ctx, table_df, table, source)
 
     return row_table(ctx, table_df)
 

--- a/graphistry/compute/gfql/row/frame_ops.py
+++ b/graphistry/compute/gfql/row/frame_ops.py
@@ -62,14 +62,14 @@ def _alias_true_mask(table_df: Any, source: str) -> Any:
 
 
 def _restore_alias_shadowed_user_column(
-    ctx: RowPipelineCtx, table_df: Any, table: Optional[str], source: str
-) -> Any:
-    """#1911 defect-4: an alias named like a user column (``MATCH (name:P) RETURN name.name``)
-    has that column overwritten by the alias marker upstream, so ``source.source`` read back
-    the marker. Re-key the user's values from the base frame and expose them under the
-    dotted name the projection resolves first, keeping the boolean marker intact for every
-    other property read. No-op when the alias shadows nothing or rows cannot be re-keyed
-    (marker stays, as before)."""
+    ctx: RowPipelineCtx, table_df: "DataFrameT", table: Optional[str], source: str
+) -> "DataFrameT":
+    """An alias named like a user column (``MATCH (name:P) RETURN name.name``) has that
+    column overwritten by the alias marker upstream, so ``source.source`` read back the
+    marker. Re-key the user's values from the base frame and expose them under the
+    dotted name the projection resolves first, keeping the boolean marker intact for
+    every other property read. No-op when the alias shadows nothing or rows cannot be
+    re-keyed (marker stays, as before)."""
     base_graph = ctx._gfql_rows_base_graph if ctx._gfql_rows_base_graph is not None else ctx._g
     base_frame = None if base_graph is None else (
         base_graph._nodes if table == "nodes" else base_graph._edges
@@ -91,8 +91,7 @@ def _restore_alias_shadowed_user_column(
     dotted = f"{source}.{source}"
     base_index = getattr(base_frame, "index", None)
     if base_index is not None and bool(base_index.is_unique):
-        # the chain result is a row-subset of the base frame with its index preserved;
-        # a guarded .loc (not Index.isin — cuDF's disagrees with pandas') proves it.
+        # guarded .loc proves index-subset alignment (cuDF Index.isin disagrees with pandas)
         try:
             restored = base_frame[source].loc[table_df.index]
         except (KeyError, IndexError, TypeError):

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -81,6 +81,7 @@ from graphistry.compute.gfql.identifiers import (
     WALK_PREV_COL,
     WALK_TO_COL,
     is_shortest_path_hops_column,
+    shadow_restore_column,
     trail_column_name,
 )
 from graphistry.compute.util import generate_safe_column_name
@@ -1081,6 +1082,11 @@ class RowPipelineMixin:
         if isinstance(node, PropertyAccessExpr):
             if isinstance(node.value, Identifier):
                 alias_name = node.value.name
+                if alias_name == node.property:
+                    restore_col = shadow_restore_column(alias_name)
+                    if restore_col in table_df.columns:
+                        # the alias marker overwrote this same-named user column; rows() re-keyed it
+                        return True, table_df[restore_col]
                 if "." not in alias_name and RowPipelineMixin._gfql_has_bindings_alias_prefix(table_df, alias_name):
                     if node.property == NODE_IDENTITY_COLUMN:
                         node_id = self._gfql_node_id_column()
@@ -2907,6 +2913,11 @@ class RowPipelineMixin:
         if prop_match is not None:
             alias = prop_match.group("alias")
             prop = prop_match.group("prop")
+            if alias == prop:
+                restore_col = shadow_restore_column(alias)
+                if restore_col in table_df.columns:
+                    # the alias marker overwrote this same-named user column; rows() re-keyed it
+                    return table_df[restore_col]
             if RowPipelineMixin._gfql_has_bindings_alias_prefix(table_df, alias):
                 if prop == NODE_IDENTITY_COLUMN:
                     node_id = self._gfql_node_id_column()

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -4606,7 +4606,12 @@ class RowPipelineMixin:
             )
 
             if isinstance(alias, str):
-                frame = self._gfql_node_alias_lookup_frame(matched_nodes, str(node_id), alias)
+                # Same marker shadowing as the connected path (#1911 defect-4).
+                lookup_source = self._gfql_unshadow_alias_marker_column(
+                    matched_nodes, alias, base_nodes, str(node_id)
+                )
+                assert lookup_source is not None  # non-None in, non-None out
+                frame = self._gfql_node_alias_lookup_frame(lookup_source, str(node_id), alias)
             else:
                 anon_col = RowPipelineMixin._gfql_fresh_col_name(matched_nodes.columns, f"__gfql_binding_node_{idx}__")
                 frame = matched_nodes[[node_id]].copy().rename(columns={node_id: anon_col})

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -2913,11 +2913,6 @@ class RowPipelineMixin:
         if prop_match is not None:
             alias = prop_match.group("alias")
             prop = prop_match.group("prop")
-            if alias == prop:
-                restore_col = shadow_restore_column(alias)
-                if restore_col in table_df.columns:
-                    # the alias marker overwrote this same-named user column; rows() re-keyed it
-                    return table_df[restore_col]
             if RowPipelineMixin._gfql_has_bindings_alias_prefix(table_df, alias):
                 if prop == NODE_IDENTITY_COLUMN:
                     node_id = self._gfql_node_id_column()

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -4606,7 +4606,7 @@ class RowPipelineMixin:
             )
 
             if isinstance(alias, str):
-                # Same marker shadowing as the connected path (#1911 defect-4).
+                # Same marker shadowing as the connected path, keyed on the node id.
                 lookup_source = self._gfql_unshadow_alias_marker_column(
                     matched_nodes, alias, base_nodes, str(node_id)
                 )

--- a/graphistry/compute/gfql_fast_paths.py
+++ b/graphistry/compute/gfql_fast_paths.py
@@ -2259,9 +2259,7 @@ def _execute_single_hop_grouped_aggregate_fast_path(
     reentry_start_nodes: Optional[DataFrameT] = None,
 ) -> Optional[Plottable]:
     if reentry_start_nodes is not None:
-        # #1712: a carried WITH..MATCH seed restricts the first alias to those rows; this
-        # path derives its seed from the ops' filter_dicts alone, so engaging would
-        # silently widen the aggregate back to the whole graph. Decline.
+        # seed comes from filter_dicts alone; engaging would widen a carried WITH..MATCH seed
         return None
     ops = list(chain.chain)
     if len(ops) not in (3, 4, 5) or not all(isinstance(op, ASTCall) for op in ops):
@@ -3028,7 +3026,7 @@ def _execute_two_hop_count_fast_path(
     reentry_start_nodes: Optional[DataFrameT] = None,
 ) -> Optional[Plottable]:
     if reentry_start_nodes is not None:
-        # #1712: same seed-blindness as the grouped-aggregate path above — decline.
+        # same seed-blindness as the grouped-aggregate path above
         return None
     alias = _two_hop_count_alias(chain)
     if alias is None:

--- a/graphistry/compute/gfql_fast_paths.py
+++ b/graphistry/compute/gfql_fast_paths.py
@@ -2256,7 +2256,13 @@ def _execute_single_hop_grouped_aggregate_fast_path(
     chain: Chain,
     *,
     engine: Union[EngineAbstract, str],
+    reentry_start_nodes: Optional[DataFrameT] = None,
 ) -> Optional[Plottable]:
+    if reentry_start_nodes is not None:
+        # #1712: a carried WITH..MATCH seed restricts the first alias to those rows; this
+        # path derives its seed from the ops' filter_dicts alone, so engaging would
+        # silently widen the aggregate back to the whole graph. Decline.
+        return None
     ops = list(chain.chain)
     if len(ops) not in (3, 4, 5) or not all(isinstance(op, ASTCall) for op in ops):
         return None
@@ -3019,7 +3025,11 @@ def _execute_two_hop_count_fast_path(
     chain: Chain,
     *,
     engine: Union[EngineAbstract, str],
+    reentry_start_nodes: Optional[DataFrameT] = None,
 ) -> Optional[Plottable]:
+    if reentry_start_nodes is not None:
+        # #1712: same seed-blindness as the grouped-aggregate path above — decline.
+        return None
     alias = _two_hop_count_alias(chain)
     if alias is None:
         return None

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -759,6 +759,11 @@ def _apply_connected_match_join(
     # recomputes instead of returning a stale cached answer (BLOCKER 1).
     cache_store: Dict[str, Any] = {}
 
+    for pattern_chain in plan.pattern_chains:
+        _reject_node_alias_shadowing_id_binding(
+            base_graph, pattern_chain, include_edge_endpoint_aliases=True
+        )
+
     trail_identity_col = _trail_edge_identity_col(base_graph)
     trail_arms = _connected_join_trail_arms(plan, identity_col=trail_identity_col)
     arms_may_share_an_edge = trail_arms is not None
@@ -1531,6 +1536,9 @@ def _execute_compiled_query_chain_non_union(
             compiled_query=compiled_query,
             engine=engine,
         )
+    _reject_node_alias_shadowing_id_binding(
+        base_graph, compiled_query.chain, include_edge_endpoint_aliases=True
+    )
 
     # #1712: a bounded-reentry main chain that is a binding-ops row pipeline
     # (rows(binding_ops) -> group_by -> ...) must seed its first alias from the
@@ -2672,7 +2680,9 @@ def gfql(self: Plottable,
             context.policy_depth = policy_depth
 
 
-def _reject_node_alias_shadowing_id_binding(g: Plottable, chain_obj: Chain) -> None:
+def _reject_node_alias_shadowing_id_binding(
+    g: Plottable, chain_obj: Chain, *, include_edge_endpoint_aliases: bool = False
+) -> None:
     """Typed decline for a node alias named after the node-ID binding column.
 
     The alias marker is stamped as ``<alias> = True``, so an alias equal to the node-id
@@ -2697,8 +2707,13 @@ def _reject_node_alias_shadowing_id_binding(g: Plottable, chain_obj: Chain) -> N
                     f"overwrite the node-ID binding. Rename the alias."
                 ),
             )
-        # an edge alias equal to an endpoint binding overwrites the endpoints
-        if isinstance(op, ASTEdge) and getattr(op, "_name", None) in endpoint_cols:
+        # Cypher-only: an endpoint-named edge alias overwrites the endpoints downstream;
+        # raw GFQL chains keep their documented full-path overwrite parity instead.
+        if (
+            include_edge_endpoint_aliases
+            and isinstance(op, ASTEdge)
+            and getattr(op, "_name", None) in endpoint_cols
+        ):
             raise GFQLValidationError(
                 ErrorCode.E108,
                 "An edge alias cannot be named after an edge endpoint binding column",

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -2707,8 +2707,7 @@ def _reject_node_alias_shadowing_id_binding(
                     f"overwrite the node-ID binding. Rename the alias."
                 ),
             )
-        # Cypher-only: an endpoint-named edge alias overwrites the endpoints downstream;
-        # raw GFQL chains keep their documented full-path overwrite parity instead.
+        # Cypher-only decline; raw GFQL chains keep their documented overwrite parity.
         if (
             include_edge_endpoint_aliases
             and isinstance(op, ASTEdge)

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -60,6 +60,7 @@ from graphistry.compute.gfql.cypher.reentry.execution import (
     compiled_query_scalar_reentry_state as _compiled_query_scalar_reentry_state,
     freeform_broadcast_row_to_nodes as _freeform_broadcast_row_to_nodes,
     reentry_validation_error as _reentry_validation_error,
+    restrict_connected_join_rows_to_reentry_seed as _restrict_connected_join_rows_to_reentry_seed,
     union_scalar_reentry_results as _union_scalar_reentry_results,
 )
 from graphistry.compute.gfql.cypher.call_procedures import execute_cypher_call
@@ -743,6 +744,8 @@ def _apply_connected_match_join(
     engine: Union[EngineAbstract, str],
     policy: Optional[PolicyDict],
     context: ExecutionContext,
+    start_nodes: Optional[DataFrameT] = None,
+    reentry_alias: Optional[str] = None,
 ) -> Plottable:
     from graphistry.compute.ast import ASTCall, ASTNode as _ASTNode, serialize_binding_ops
 
@@ -769,8 +772,10 @@ def _apply_connected_match_join(
         )
 
     # Both two-star fast paths emit the raw arm product, so they serve disjoint arms only.
+    # A carried WITH..MATCH seed (#1712) also declines them: they re-derive every arm from
+    # filter_dicts alone, silently widening the seed back to the whole graph.
     fast_grouped_count = (
-        None if arms_may_share_an_edge
+        None if arms_may_share_an_edge or start_nodes is not None
         else _connected_join_two_star_fast_grouped_count(base_graph, plan, engine=requested_engine, cache_store=cache_store)
     )
     if fast_grouped_count is not None:
@@ -780,7 +785,7 @@ def _apply_connected_match_join(
         return out
 
     fast_rows = (
-        None if arms_may_share_an_edge
+        None if arms_may_share_an_edge or start_nodes is not None
         else _connected_join_two_star_fast_rows(base_graph, plan, engine=requested_engine, cache_store=cache_store)
     )
     if fast_rows is not None:
@@ -887,6 +892,15 @@ def _apply_connected_match_join(
                            else joined_rows.drop(columns=drop_columns))
     joined_rows = _joined_hidden_scalar_columns(joined_rows)
     joined_rows = _joined_alias_columns(joined_rows)
+    if start_nodes is not None:
+        # #1712: the arms above re-matched from the whole graph; narrow the joined rows
+        # back to the carried reentry-alias seeds before the aggregate/projection runs.
+        joined_rows = _restrict_connected_join_rows_to_reentry_seed(
+            cast(DataFrameT, joined_rows),
+            start_nodes=start_nodes,
+            reentry_alias=reentry_alias,
+            node_col=node_col,
+        )
     joined_plottable = base_graph.bind()
     joined_plottable._nodes = joined_rows
     joined_plottable._edges = df_ctor()
@@ -1378,6 +1392,11 @@ def _execute_compiled_query_via_physical_plan(
             engine=engine,
             policy=policy,
             context=context,
+            start_nodes=start_nodes,
+            reentry_alias=(
+                None if compiled_query.reentry_plan is None
+                else compiled_query.reentry_plan.reentry_alias_name
+            ),
         )
 
     if connected_optional_match is not None:
@@ -1415,12 +1434,14 @@ def _execute_compiled_query_via_physical_plan(
 
         fast_grouped = _try_fast(
             "single_hop_grouped_aggregate",
-            lambda: _execute_single_hop_grouped_aggregate_fast_path(base_graph, compiled_query.chain, engine=engine))
+            lambda: _execute_single_hop_grouped_aggregate_fast_path(
+                base_graph, compiled_query.chain, engine=engine, reentry_start_nodes=start_nodes))
         if fast_grouped is not None:
             return fast_grouped
         fast_count = _try_fast(
             "two_hop_count",
-            lambda: _execute_two_hop_count_fast_path(base_graph, compiled_query.chain, engine=engine))
+            lambda: _execute_two_hop_count_fast_path(
+                base_graph, compiled_query.chain, engine=engine, reentry_start_nodes=start_nodes))
         if fast_count is not None:
             return fast_count
         fast_hop = _try_fast(
@@ -2663,10 +2684,12 @@ def _reject_node_alias_shadowing_id_binding(g: Plottable, chain_obj: Chain) -> N
     polars answered ``True``. Neither is a usable result; decline the same way on both.
     """
     node_id = getattr(g, "_node", None)
-    if not isinstance(node_id, str):
-        return
+    endpoint_cols = {
+        col for col in (getattr(g, "_source", None), getattr(g, "_destination", None))
+        if isinstance(col, str)
+    }
     for op in chain_obj.chain:
-        if isinstance(op, ASTNode) and getattr(op, "_name", None) == node_id:
+        if isinstance(node_id, str) and isinstance(op, ASTNode) and getattr(op, "_name", None) == node_id:
             raise GFQLValidationError(
                 ErrorCode.E108,
                 "A node alias cannot be named after the node-ID binding column",
@@ -2675,6 +2698,20 @@ def _reject_node_alias_shadowing_id_binding(g: Plottable, chain_obj: Chain) -> N
                 suggestion=(
                     f"The alias flag is materialized as a column named '{node_id}', which would "
                     f"overwrite the node-ID binding. Rename the alias."
+                ),
+            )
+        # #1911 defect-4 sibling: an edge alias equal to an endpoint binding column
+        # overwrites the endpoints themselves (silent empty result). Same decline shape.
+        if isinstance(op, ASTEdge) and getattr(op, "_name", None) in endpoint_cols:
+            raise GFQLValidationError(
+                ErrorCode.E108,
+                "An edge alias cannot be named after an edge endpoint binding column",
+                field="chain.name",
+                value=getattr(op, "_name", None),
+                suggestion=(
+                    "The alias flag is materialized as a column named like the edge "
+                    "source/destination binding, which would overwrite the endpoints. "
+                    "Rename the alias."
                 ),
             )
 

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -771,9 +771,7 @@ def _apply_connected_match_join(
             base_graph, engine=requested_engine, identity_col=trail_identity_col
         )
 
-    # Both two-star fast paths emit the raw arm product, so they serve disjoint arms only.
-    # A carried WITH..MATCH seed (#1712) also declines them: they re-derive every arm from
-    # filter_dicts alone, silently widening the seed back to the whole graph.
+    # Both two-star fast paths serve only disjoint, unseeded arms (their seeds are filter_dicts-only)
     fast_grouped_count = (
         None if arms_may_share_an_edge or start_nodes is not None
         else _connected_join_two_star_fast_grouped_count(base_graph, plan, engine=requested_engine, cache_store=cache_store)
@@ -893,10 +891,9 @@ def _apply_connected_match_join(
     joined_rows = _joined_hidden_scalar_columns(joined_rows)
     joined_rows = _joined_alias_columns(joined_rows)
     if start_nodes is not None:
-        # #1712: the arms above re-matched from the whole graph; narrow the joined rows
-        # back to the carried reentry-alias seeds before the aggregate/projection runs.
+        # the arms above re-matched from the whole graph; narrow to the carried seeds
         joined_rows = _restrict_connected_join_rows_to_reentry_seed(
-            cast(DataFrameT, joined_rows),
+            joined_rows,
             start_nodes=start_nodes,
             reentry_alias=reentry_alias,
             node_col=node_col,
@@ -2700,8 +2697,7 @@ def _reject_node_alias_shadowing_id_binding(g: Plottable, chain_obj: Chain) -> N
                     f"overwrite the node-ID binding. Rename the alias."
                 ),
             )
-        # #1911 defect-4 sibling: an edge alias equal to an endpoint binding column
-        # overwrites the endpoints themselves (silent empty result). Same decline shape.
+        # an edge alias equal to an endpoint binding overwrites the endpoints
         if isinstance(op, ASTEdge) and getattr(op, "_name", None) in endpoint_cols:
             raise GFQLValidationError(
                 ErrorCode.E108,

--- a/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+++ b/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
@@ -568,6 +568,46 @@ def test_mixed_whole_entity_and_self_named_property_projection(engine: str) -> N
     assert [r["name.id"] for r in rows] == ["a1", "a2", "b1", "b2"]
 
 
+def test_restore_alias_shadowed_user_column_branches() -> None:
+    """Helper-level pins for the rows-route restore: no-op without a base or a shadowed
+    column; index-keyed restore; key-merge fallback when the base index cannot re-key."""
+    from types import SimpleNamespace
+
+    from graphistry.compute.gfql.row.frame_ops import _restore_alias_shadowed_user_column
+
+    def ctx_for(base_graph):
+        return SimpleNamespace(_gfql_rows_base_graph=base_graph, _g=None)
+
+    marked = pd.DataFrame({"id": ["a", "b"], "kind": [True, True]})
+    # no base graph / alias shadows nothing: unchanged
+    assert _restore_alias_shadowed_user_column(ctx_for(None), marked, "nodes", "kind") is marked
+    base_no_col = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"]}), _edges=None, _node="id", _edge=None)
+    assert _restore_alias_shadowed_user_column(ctx_for(base_no_col), marked, "nodes", "kind") is marked
+    # index-keyed restore adds the dotted self-column and keeps the marker boolean
+    base = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}), _edges=None, _node="id", _edge=None)
+    out = _restore_alias_shadowed_user_column(ctx_for(base), marked, "nodes", "kind")
+    assert list(out["kind.kind"]) == ["K1", "K2"] and list(out["kind"]) == [True, True]
+    # base index cannot re-key (duplicate labels): fall back to the id-key merge
+    dup_index_nodes = pd.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}, index=[0, 0])
+    base_dup = SimpleNamespace(_nodes=dup_index_nodes, _edges=None, _node="id", _edge=None)
+    out = _restore_alias_shadowed_user_column(ctx_for(base_dup), marked, "nodes", "kind")
+    assert list(out["kind.kind"]) == ["K1", "K2"]
+    # neither index nor key can re-key: unchanged (marker stays, as before)
+    base_no_key = SimpleNamespace(_nodes=dup_index_nodes, _edges=None, _node=None, _edge=None)
+    assert _restore_alias_shadowed_user_column(ctx_for(base_no_key), marked, "nodes", "kind") is marked
+    # row-table labels absent from a unique base index: guarded .loc declines to the key merge
+    shifted = pd.DataFrame({"id": ["a", "b"], "kind": [True, True]}, index=[10, 11])
+    out = _restore_alias_shadowed_user_column(ctx_for(base), shifted, "nodes", "kind")
+    assert list(out["kind.kind"]) == ["K1", "K2"]
+    # polars: id-keyed join replaces the marker column in place; no key -> unchanged
+    marked_pl = pl.DataFrame({"id": ["a", "b"], "kind": [True, True]})
+    base_pl = SimpleNamespace(_nodes=pl.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}), _edges=None, _node="id", _edge=None)
+    out_pl = _restore_alias_shadowed_user_column(ctx_for(base_pl), marked_pl, "nodes", "kind")
+    assert out_pl["kind"].to_list() == ["K1", "K2"]
+    base_pl_no_key = SimpleNamespace(_nodes=base_pl._nodes, _edges=None, _node=None, _edge=None)
+    assert _restore_alias_shadowed_user_column(ctx_for(base_pl_no_key), marked_pl, "nodes", "kind") is marked_pl
+
+
 def test_cudf_rows_route_self_named_alias_parity() -> None:
     """cuDF (dataframe ops only): the node shape crashed with a raw mixed-types
     TypeError from the marker/user-column coalesce; both shapes now match pandas."""

--- a/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+++ b/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
@@ -558,6 +558,28 @@ def test_rows_route_edge_alias_colliding_with_its_own_type_filter() -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
+def test_rows_route_self_named_plus_other_property(engine: str) -> None:
+    """The restore must not turn OTHER property reads of the same alias into NA: the
+    row table is not a bindings table just because the shadowed value was re-keyed
+    (an early restore design leaked exactly that, NA-ing ``name.id``)."""
+    rows = _run(SELF_NAMED_NODES, SELF_NAMED_EDGES,
+                "MATCH (name:P) RETURN name.name AS n, name.id AS i", engine)
+    assert [(r["n"], r["i"]) for r in rows] == [
+        ("Sa", "a1"), ("Sb", "a2"), (None, "b1"), ("Tb", "b2")]
+
+
+def test_connected_join_carried_relationship_projection_unaffected() -> None:
+    """CONTROL (regression found in-flight): a comma-pattern whose base graph is an
+    intermediate dispatch frame must not have the restore misread the arm's marker as
+    user data — ``r.weight`` stays 7, never NA."""
+    nodes = pd.DataFrame({"id": ["a1", "b1"], "label__A": [True, False], "label__B": [False, True]})
+    edges = pd.DataFrame({"s": ["a1", "b1"], "d": ["b1", "a1"], "type": ["R", "S"], "w": [7, 9]})
+    rows = _run(nodes, edges,
+                "MATCH (a:A {id: 'a1'})-[r:R]->(b:B), (b)-[:S]->(a) RETURN r.w AS w", "pandas")
+    assert rows == [{"w": 7}]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
 def test_mixed_whole_entity_and_self_named_property_projection(engine: str) -> None:
     """``RETURN name, name.name AS n``: the whole-entity flatten keeps omitting the
     shadowed column (pinned above) while the explicit property column must read the
@@ -569,11 +591,15 @@ def test_mixed_whole_entity_and_self_named_property_projection(engine: str) -> N
 
 
 def test_restore_alias_shadowed_user_column_branches() -> None:
-    """Helper-level pins for the rows-route restore: no-op without a base or a shadowed
-    column; index-keyed restore; key-merge fallback when the base index cannot re-key."""
+    """Helper-level pins for the rows-route restore: no-op without a base, a shadowed
+    column, or when the base column is itself a boolean marker (intermediate dispatch
+    graph); index-keyed restore; key-merge fallback when the index cannot re-key."""
     from types import SimpleNamespace
 
+    from graphistry.compute.gfql.identifiers import shadow_restore_column
     from graphistry.compute.gfql.row.frame_ops import _restore_alias_shadowed_user_column
+
+    restore_col = shadow_restore_column("kind")
 
     def ctx_for(base_graph):
         return SimpleNamespace(_gfql_rows_base_graph=base_graph, _g=None)
@@ -583,22 +609,25 @@ def test_restore_alias_shadowed_user_column_branches() -> None:
     assert _restore_alias_shadowed_user_column(ctx_for(None), marked, "nodes", "kind") is marked
     base_no_col = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"]}), _edges=None, _node="id", _edge=None)
     assert _restore_alias_shadowed_user_column(ctx_for(base_no_col), marked, "nodes", "kind") is marked
-    # index-keyed restore adds the dotted self-column and keeps the marker boolean
+    # base column is itself a boolean marker (an intermediate dispatch graph): unchanged
+    base_marker = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"], "kind": [True, False]}), _edges=None, _node="id", _edge=None)
+    assert _restore_alias_shadowed_user_column(ctx_for(base_marker), marked, "nodes", "kind") is marked
+    # index-keyed restore adds the internal restore column and keeps the marker boolean
     base = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}), _edges=None, _node="id", _edge=None)
     out = _restore_alias_shadowed_user_column(ctx_for(base), marked, "nodes", "kind")
-    assert list(out["kind.kind"]) == ["K1", "K2"] and list(out["kind"]) == [True, True]
+    assert list(out[restore_col]) == ["K1", "K2"] and list(out["kind"]) == [True, True]
     # base index cannot re-key (duplicate labels): fall back to the id-key merge
     dup_index_nodes = pd.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}, index=[0, 0])
     base_dup = SimpleNamespace(_nodes=dup_index_nodes, _edges=None, _node="id", _edge=None)
     out = _restore_alias_shadowed_user_column(ctx_for(base_dup), marked, "nodes", "kind")
-    assert list(out["kind.kind"]) == ["K1", "K2"]
+    assert list(out[restore_col]) == ["K1", "K2"]
     # neither index nor key can re-key: unchanged (marker stays, as before)
     base_no_key = SimpleNamespace(_nodes=dup_index_nodes, _edges=None, _node=None, _edge=None)
     assert _restore_alias_shadowed_user_column(ctx_for(base_no_key), marked, "nodes", "kind") is marked
     # row-table labels absent from a unique base index: guarded .loc declines to the key merge
     shifted = pd.DataFrame({"id": ["a", "b"], "kind": [True, True]}, index=[10, 11])
     out = _restore_alias_shadowed_user_column(ctx_for(base), shifted, "nodes", "kind")
-    assert list(out["kind.kind"]) == ["K1", "K2"]
+    assert list(out[restore_col]) == ["K1", "K2"]
     # polars: id-keyed join replaces the marker column in place; no key -> unchanged
     marked_pl = pl.DataFrame({"id": ["a", "b"], "kind": [True, True]})
     base_pl = SimpleNamespace(_nodes=pl.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}), _edges=None, _node="id", _edge=None)
@@ -606,6 +635,9 @@ def test_restore_alias_shadowed_user_column_branches() -> None:
     assert out_pl["kind"].to_list() == ["K1", "K2"]
     base_pl_no_key = SimpleNamespace(_nodes=base_pl._nodes, _edges=None, _node=None, _edge=None)
     assert _restore_alias_shadowed_user_column(ctx_for(base_pl_no_key), marked_pl, "nodes", "kind") is marked_pl
+    # polars marker-carrying base: unchanged
+    base_pl_marker = SimpleNamespace(_nodes=pl.DataFrame({"id": ["a", "b"], "kind": [True, False]}), _edges=None, _node="id", _edge=None)
+    assert _restore_alias_shadowed_user_column(ctx_for(base_pl_marker), marked_pl, "nodes", "kind") is marked_pl
 
 
 def test_cudf_rows_route_self_named_alias_parity() -> None:

--- a/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+++ b/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
@@ -88,13 +88,16 @@ def _graph(nodes: pd.DataFrame, edges: pd.DataFrame, engine: str):
     return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
 
 
+def _null(v):
+    return None if isinstance(v, float) and v != v else v
+
+
 def _rows(g, query: str, engine: str):
     frame = g.gfql(query, engine=engine)._nodes
     if frame is None:
         return []
-    if isinstance(frame, pl.DataFrame):
-        return frame.to_dicts()
-    return frame.to_dict("records")
+    records = frame.to_dicts() if isinstance(frame, pl.DataFrame) else frame.to_dict("records")
+    return [{k: _null(v) for k, v in r.items()} for r in records]
 
 
 def _run(nodes, edges, query: str, engine: str):

--- a/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+++ b/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
@@ -318,46 +318,43 @@ def test_whole_entity_projection_of_shadowing_alias_omits_the_column(engine: str
     assert sorted(r["kind.name"] for r in rows) == ["One", "Three", "Two"]
 
 
-# ------------------------------------------------------------------ residuals
+# ---------------------------------------- defect-4 remaining shapes (fixed)
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_single_alias_and_cartesian_alias_marker_still_leaks(engine: str) -> None:  # noqa: ARG001
-    """RESIDUAL (#1911 defect 4, not fixed this cycle): the single-alias
-    `rows(table='nodes', source=...)` and the cartesian binding paths read properties off
-    the chain output frame, where the alias marker has ALREADY overwritten the user
-    column -- the pre-marker values are gone by then, so the fix needs the marker itself
-    to move to a safe internal name (which chain.py's own labeling machinery reads back).
-    Pinned CONSISTENT across engines so the divergence cannot reappear silently."""
-    for query in ["MATCH (kind:P) RETURN kind.kind AS k",
-                  "MATCH (kind:P), (b:P) RETURN kind.kind AS k, b.id AS bi",
-                  # a bare relationship-property projection also skips the connected-
-                  # bindings property attach that the fix hooks.
-                  "MATCH (a:P)-[w:K]->(b:P) RETURN w.w AS k"]:
-        rows = _run(SHADOW_NODES, SHADOW_EDGES, query, "pandas")
-        assert {r["k"] for r in rows} == {True}, f"{query} -> {rows}"
+def test_single_alias_and_cartesian_shadowed_alias_reads_the_user_value(engine: str) -> None:
+    """#1911 defect 4 (was RESIDUAL): the single-alias ``rows(table=..., source=...)``
+    route and the cartesian binding path read properties off the chain output frame,
+    where the alias marker had overwritten the user column. The rows route now restores
+    the user values from the base frame (dotted self-column, marker kept boolean); the
+    cartesian paths unshadow like the connected one. Anti-vacuity: 3 node rows / 9
+    cartesian rows / 2 relationship rows, distinct values -- an all-``True`` marker
+    leak or an empty frame cannot pass."""
+    rows = _run(SHADOW_NODES, SHADOW_EDGES, "MATCH (kind:P) RETURN kind.kind AS k", engine)
+    assert sorted(r["k"] for r in rows) == ["K1", "K2", "K3"]
+    rows = _run(SHADOW_NODES, SHADOW_EDGES,
+                "MATCH (kind:P), (b:P) RETURN kind.kind AS k, b.id AS bi", engine)
+    assert len(rows) == 9 and sorted({r["k"] for r in rows}) == ["K1", "K2", "K3"]
+    # bare relationship-property projection (rows(table='edges', source=alias) route)
+    rows = _run(SHADOW_NODES, SHADOW_EDGES, "MATCH (a:P)-[w:K]->(b:P) RETURN w.w AS k", engine)
+    assert sorted(r["k"] for r in rows) == [7, 8]
 
 
-def test_residual_multihop_relationship_alias_marker_divergence() -> None:
-    """RESIDUAL (#1911 defect 4): a relationship alias in a MULTI-hop pattern still takes
-    a different path than the single-hop one fixed above -- pandas reads the marker,
-    polars reads the value (and also over-multiplies the rows, a separate pre-existing
-    polars defect independent of the alias name). Pinned so the state is explicit."""
+def test_multihop_relationship_shadowed_alias_pandas_fixed_polars_multiplicity_residual() -> None:
+    """#1911 defect 4: pandas now reads the user value in the MULTI-hop shape too
+    (was the marker ``True``). polars still over-multiplies the rows -- a separate
+    pre-existing multiplicity defect independent of the alias name -- pinned as-is."""
     query = "MATCH (a:P)-[w:K]->(b:P)-[:K]->(c:P) RETURN w.w AS x"
-    assert [r["x"] for r in _run(SHADOW_NODES, SHADOW_EDGES, query, "pandas")] == [True]
+    assert [r["x"] for r in _run(SHADOW_NODES, SHADOW_EDGES, query, "pandas")] == [7]
     assert sorted(r["x"] for r in _run(SHADOW_NODES, SHADOW_EDGES, query, "polars")) == [7, 8]
 
 
-def test_residual_empty_result_drops_a_shadowed_alias_column_on_pandas() -> None:
-    """RESIDUAL (#1911 defect 4): when an alias is named after ANY existing node column
-    and the match is EMPTY, pandas' chain output loses that column outright, so the
-    downstream `rows` op fails its schema check; polars returns the correct empty result.
-    Reproduces with a non-colliding property too (`kind.name`), so it is a chain
-    empty-frame column-preservation bug rather than a property-resolution one."""
-    from graphistry.compute.exceptions import GFQLSchemaError
-
+def test_empty_result_keeps_a_shadowed_alias_column_on_both_engines() -> None:
+    """#1911 defect 4 (was RESIDUAL): an EMPTY match on an alias named after an existing
+    node column used to lose that column on pandas (chain empty-frame column drop), so the
+    downstream ``rows`` op raised a schema error; the marker-aware coalesce now keeps the
+    column even at zero rows and both engines return the correct empty result."""
     query = "MATCH (kind:P) WHERE kind.name = 'ZZ' RETURN kind.name AS n"
-    with pytest.raises(GFQLSchemaError):
-        _run(SHADOW_NODES, SHADOW_EDGES, query, "pandas")
+    assert _run(SHADOW_NODES, SHADOW_EDGES, query, "pandas") == []
     assert _run(SHADOW_NODES, SHADOW_EDGES, query, "polars") == []
 
 
@@ -489,16 +486,100 @@ def test_unwind_alias_collision_still_declines_before_the_rebind_guard(engine: s
     assert "UNWIND alias collides" in str(exc_info.value)
 
 
-def test_edge_alias_named_like_source_column_is_a_schema_error_residual() -> None:
-    """RESIDUAL: an edge alias named after the edge SOURCE column has its marker
-    destroy that column -- surfaced as a typed GFQLSchemaError (column-not-found),
-    not a silent answer. Pinned so a change here is deliberate; a typed decline
-    naming the alias collision (like the node-ID one) would be the upgrade."""
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("alias", ["s", "d"])
+def test_edge_alias_named_like_an_endpoint_binding_is_a_typed_decline(alias: str, engine: str) -> None:
+    """#1911 defect-4 sibling (was RESIDUAL): an edge alias named after the edge
+    SOURCE/DESTINATION binding column has its marker destroy the endpoints. It used to
+    surface as an incidental GFQLSchemaError on pandas; the marker-aware coalesce would
+    have turned it into a silent EMPTY result, so it is now the same typed decline as
+    the node-ID collision, on both engines."""
+    with pytest.raises(GFQLValidationError) as exc_info:
+        _run(PEOPLE_NODES, PEOPLE_EDGES,
+             f"MATCH (a:Person)-[{alias}:KNOWS]->(b:Person) RETURN {alias}.type AS t", engine)
+    assert exc_info.value.code == ErrorCode.E108
+    assert "edge endpoint binding column" in str(exc_info.value)
+
+
+# -------------------- #1911 defect-4 round-2: single-alias rows-route restore
+
+# NULL cell on purpose: the restore must carry the NULL through (the NULL-vs-membership
+# class), never drop the row or backfill the marker.
+SELF_NAMED_NODES = pd.DataFrame({
+    "id": ["a1", "a2", "b1", "b2"],
+    "name": ["Sa", "Sb", None, "Tb"],
+    "label__P": [True, True, True, True],
+})
+SELF_NAMED_EDGES = pd.DataFrame({
+    "s": ["a1", "a2"], "d": ["b1", "b2"], "type": ["K", "K"], "w": [7, 8],
+})
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_rows_route_alias_named_as_its_property_reads_user_values(engine: str) -> None:
+    """#1911 defect-4 (rows route): ``MATCH (name:P) RETURN name.name`` answered the
+    alias marker ``[True] x 4`` on both engines (cuDF crashed with a raw mixed-types
+    TypeError). Anti-vacuity: 4 rows with 3 distinct values plus a preserved NULL."""
+    rows = _run(SELF_NAMED_NODES, SELF_NAMED_EDGES, "MATCH (name:P) RETURN name.name", engine)
+    assert [r["name.name"] for r in rows] == ["Sa", "Sb", None, "Tb"]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_rows_route_where_on_self_named_alias_filters_and_projects_user_values(engine: str) -> None:
+    """WHERE already compared user values (1 row matched) while RETURN projected the
+    marker ``True`` -- both sides must read the same user column."""
+    rows = _run(SELF_NAMED_NODES, SELF_NAMED_EDGES,
+                "MATCH (name:P) WHERE name.name = 'Sa' RETURN name.name AS n", engine)
+    assert rows == [{"n": "Sa"}]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_rows_route_edge_alias_named_as_its_property_reads_user_values(engine: str) -> None:
+    """Edge twin of the rows route (``rows(table='edges', source=alias)``): the marker
+    also overwrote the same-named edge payload column."""
+    rows = _run(SELF_NAMED_NODES, SELF_NAMED_EDGES,
+                "MATCH (a:P)-[w:K]->(b:P) RETURN w.w AS x", engine)
+    assert sorted(r["x"] for r in rows) == [7, 8]
+
+
+def test_rows_route_edge_alias_colliding_with_its_own_type_filter() -> None:
+    """``MATCH (a)-[type:K]->(b) RETURN type.type``: the alias shadows the very column
+    its ``:K`` filter reads. pandas/cuDF now answer the user values; polars' chain
+    machinery re-applies the type filter against the stamped marker and raises a typed
+    GFQLSchemaError -- an honest decline, pinned so it cannot rot into a silent wrong
+    answer (residual polish for #1911)."""
     from graphistry.compute.exceptions import GFQLSchemaError
 
+    query = "MATCH (a:P)-[type:K]->(b:P) RETURN type.type AS t"
+    assert _run(SELF_NAMED_NODES, SELF_NAMED_EDGES, query, "pandas") == [
+        {"t": "K"}, {"t": "K"}]
     with pytest.raises(GFQLSchemaError):
-        _run(PEOPLE_NODES, PEOPLE_EDGES,
-             "MATCH (a:Person)-[s:KNOWS]->(b:Person) RETURN s.type AS t", "pandas")
+        _run(SELF_NAMED_NODES, SELF_NAMED_EDGES, query, "polars")
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_mixed_whole_entity_and_self_named_property_projection(engine: str) -> None:
+    """``RETURN name, name.name AS n``: the whole-entity flatten keeps omitting the
+    shadowed column (pinned above) while the explicit property column must read the
+    restored user values, NULL included."""
+    rows = _run(SELF_NAMED_NODES, SELF_NAMED_EDGES,
+                "MATCH (name:P) RETURN name, name.name AS n", engine)
+    assert [r["n"] for r in rows] == ["Sa", "Sb", None, "Tb"]
+    assert [r["name.id"] for r in rows] == ["a1", "a2", "b1", "b2"]
+
+
+def test_cudf_rows_route_self_named_alias_parity() -> None:
+    """cuDF (dataframe ops only): the node shape crashed with a raw mixed-types
+    TypeError from the marker/user-column coalesce; both shapes now match pandas."""
+    cudf = pytest.importorskip("cudf")
+
+    g = graphistry.nodes(cudf.from_pandas(SELF_NAMED_NODES), "id").edges(
+        cudf.from_pandas(SELF_NAMED_EDGES), "s", "d"
+    )
+    out = g.gfql("MATCH (name:P) RETURN name.name", engine="cudf")._nodes.to_pandas()
+    assert list(out["name.name"].fillna("<null>")) == ["Sa", "Sb", "<null>", "Tb"]
+    out = g.gfql("MATCH (a:P)-[type:K]->(b:P) RETURN type.type AS t", engine="cudf")._nodes
+    assert sorted(out.to_pandas()["t"]) == ["K", "K"]
 
 
 def test_cudf_unshadow_and_rebind_guard_parity() -> None:

--- a/graphistry/tests/compute/gfql/test_engine_polars_binding_rows.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_binding_rows.py
@@ -180,15 +180,15 @@ def test_polars_cartesian_binding_rows_raw_meaningful_cols():
 
 
 def test_polars_cartesian_alias_name_collides_with_property():
-    """A node property named the same as a MATCH alias is shadowed by the leaked
-    named-op flag (``alias.alias = True``) on BOTH engines — polars mirrors the
-    pandas quirk exactly rather than surfacing the real property value."""
+    """A node property named the same as a MATCH alias used to be shadowed by the leaked
+    named-op flag (``alias.alias = True``) on BOTH engines; the cartesian builders now
+    unshadow it (#1911 defect-4), so the real property values surface identically."""
     nodes = pd.DataFrame({"id": [0, 1, 2], "kind": ["a", "b", "a"], "a": [10, 20, 30], "b": [1, 2, 3]})
     g = graphistry.nodes(nodes, "id").edges(pd.DataFrame({"s": [0], "d": [1]}), "s", "d")
     q = "MATCH (a {kind: 'a'}), (b {kind: 'b'}) RETURN a.id AS ai, a.a AS aa, b.id AS bi, b.b AS bb"
     rpd = g.gfql(q, engine="pandas")._nodes.reset_index(drop=True)
     rpl = g.gfql(q, engine="polars")._nodes.to_pandas().reset_index(drop=True)
-    assert list(rpd["aa"]) == [True, True] and list(rpd["bb"]) == [True, True]  # flag, not 10/30
+    assert sorted(rpd["aa"]) == [10, 30] and list(rpd["bb"]) == [2, 2]  # user values, not the flag
     pd.testing.assert_frame_equal(
         rpd.sort_values(["ai", "bi"]).reset_index(drop=True),
         rpl[rpd.columns.tolist()].sort_values(["ai", "bi"]).reset_index(drop=True),

--- a/graphistry/tests/compute/gfql/test_reentry_carry_seed_restriction.py
+++ b/graphistry/tests/compute/gfql/test_reentry_carry_seed_restriction.py
@@ -1,0 +1,215 @@
+"""#1712 residual: WITH->MATCH re-entry seeds must restrict EVERY execution route.
+
+The bare-carry single-pattern shape was fixed earlier; these pin the routes that still
+re-matched the trailing MATCH from the WHOLE graph, silently widening the carried set:
+
+1. projection carry (``WITH p, p.x AS t``) + grouped aggregate: the single-hop
+   grouped-aggregate fast path derived its seed from filter_dicts alone, leaking the
+   un-carried rows as an extra NULL-keyed group (2 extra persons here);
+2. comma-pattern trailing MATCH: the connected match-join re-ran each arm globally
+   (bare carry AND projection carry both leaked);
+3. two-hop trailing MATCH + count: the two-hop count fast path, same seed-blindness.
+
+Hand-computed oracle throughout: persons 0,1,2; only person 0 has the Books interest,
+so every carried re-entry answers 1 (the unrestricted answer is 3 — or a spurious
+second group of 2 — so a vacuous pass is impossible).
+
+polars runs the shapes it supports natively and typed-declines projection carry
+(scalar WITH columns into trailing MATCH); those declines are pinned as declines.
+"""
+from typing import Any, List
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.exceptions import GFQLValidationError
+
+NODES = pd.DataFrame({
+    "node_id": [0, 1, 2, 10, 20, 30, 40],
+    "node_type": ["Person", "Person", "Person", "City", "Interest", "Pet", "Country"],
+    # nickname is NULL for the carried person 0: the NULL must survive the carry
+    # (the NULL-vs-membership class), never a sentinel like '0000-00-00'.
+    "nickname": [None, "Bee", "Cee", None, None, None, None],
+    "interest": [None, None, None, None, "Books", None, None],
+})
+EDGES = pd.DataFrame({
+    "src": [0, 1, 2, 0, 0, 1, 10],
+    "dst": [10, 10, 10, 20, 30, 30, 40],
+    "rel": ["LIVES_IN", "LIVES_IN", "LIVES_IN", "HAS_INTEREST", "OWNS", "OWNS", "IN_COUNTRY"],
+})
+
+CARRY_PREFIX = (
+    "MATCH (p {node_type:'Person'})-[{rel:'HAS_INTEREST'}]->(i {node_type:'Interest'})\n"
+    "WHERE i.interest='Books'\n"
+)
+
+GROUPED_COUNT_PROJ = CARRY_PREFIX + (
+    "WITH p, p.node_type AS t\n"
+    "MATCH (p)-[{rel:'LIVES_IN'}]->(c {node_type:'City'})\n"
+    "RETURN t, count(p) AS numPersons"
+)
+GROUPED_COUNT_NULL_CARRY = CARRY_PREFIX + (
+    "WITH p, p.nickname AS t\n"
+    "MATCH (p)-[{rel:'LIVES_IN'}]->(c {node_type:'City'})\n"
+    "RETURN t, count(p) AS numPersons"
+)
+ROWS_PROJ = CARRY_PREFIX + (
+    "WITH p, p.node_type AS t\n"
+    "MATCH (p)-[{rel:'LIVES_IN'}]->(c {node_type:'City'})\n"
+    "RETURN t, p.node_id AS pid"
+)
+CONNECTED_JOIN_BARE = CARRY_PREFIX + (
+    "WITH p\n"
+    "MATCH (p)-[{rel:'LIVES_IN'}]->(c {node_type:'City'}), (p)-[{rel:'OWNS'}]->(d {node_type:'Pet'})\n"
+    "RETURN p.node_id AS pid, count(d) AS pets"
+)
+CONNECTED_JOIN_PROJ = CARRY_PREFIX + (
+    "WITH p, p.node_type AS t\n"
+    "MATCH (p)-[{rel:'LIVES_IN'}]->(c {node_type:'City'}), (p)-[{rel:'OWNS'}]->(d {node_type:'Pet'})\n"
+    "RETURN t, count(d) AS pets"
+)
+TWO_HOP_COUNT = CARRY_PREFIX + (
+    "WITH p\n"
+    "MATCH (p)-[{rel:'LIVES_IN'}]->(c)-[{rel:'IN_COUNTRY'}]->(x)\n"
+    "RETURN count(*) AS n"
+)
+
+POLARS_SCALAR_CARRY_DECLINE = "carries scalar WITH columns into the trailing MATCH"
+
+
+def _graph(engine: str) -> Any:
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        return graphistry.nodes(pl.from_pandas(NODES), "node_id").edges(
+            pl.from_pandas(EDGES), "src", "dst"
+        )
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        return graphistry.nodes(cudf.from_pandas(NODES), "node_id").edges(
+            cudf.from_pandas(EDGES), "src", "dst"
+        )
+    return graphistry.nodes(NODES, "node_id").edges(EDGES, "src", "dst")
+
+
+def _rows(engine: str, query: str) -> List[dict]:
+    frame = _graph(engine).gfql(query, engine=engine)._nodes
+    if hasattr(frame, "collect"):
+        frame = frame.collect()
+    if hasattr(frame, "to_pandas"):
+        frame = frame.to_pandas()
+    return frame.to_dict("records")
+
+
+# ------------------------------ route 1: single-hop grouped-aggregate fast path
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_projection_carry_grouped_count_restricts_to_carried_rows(engine: str) -> None:
+    """Was ``[{'t': 'Person', 'numPersons': 1}, {'t': NaN, 'numPersons': 2}]`` — the
+    fast path re-matched all 3 persons and parked the 2 un-carried ones in a NULL
+    group. Exactly one group may remain."""
+    assert _rows(engine, GROUPED_COUNT_PROJ) == [{"t": "Person", "numPersons": 1}]
+
+
+def test_projection_carry_grouped_count_polars_declines_typed() -> None:
+    pytest.importorskip("polars")
+    with pytest.raises(NotImplementedError) as exc_info:
+        _rows("polars", GROUPED_COUNT_PROJ)
+    assert POLARS_SCALAR_CARRY_DECLINE in str(exc_info.value)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_projection_carry_null_scalar_survives_the_carry(engine: str) -> None:
+    """NULL cell in the carried column: person 0's nickname is NULL, and the carried
+    group key must stay NULL (this rendered as the sentinel string '0000-00-00'
+    via a vacuously-true all-null temporal-constructor probe)."""
+    rows = _rows(engine, GROUPED_COUNT_NULL_CARRY)
+    assert len(rows) == 1 and rows[0]["numPersons"] == 1
+    assert pd.isna(rows[0]["t"])
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_projection_carry_row_form_control(engine: str) -> None:
+    """CONTROL (discriminator): the non-aggregate row form of the same query was
+    already restricted — the leak was fast-path-specific."""
+    assert _rows(engine, ROWS_PROJ) == [{"t": "Person", "pid": 0}]
+
+
+# ------------------------------------- route 2: connected comma-pattern join
+
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
+def test_bare_carry_connected_join_restricts_to_carried_rows(engine: str) -> None:
+    """Was ``[{'pid': 0, ...}, {'pid': 1, ...}]`` on all three engines: person 1 owns a
+    pet and lives in the city but was never carried."""
+    assert _rows(engine, CONNECTED_JOIN_BARE) == [{"pid": 0, "pets": 1}]
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_projection_carry_connected_join_restricts_to_carried_rows(engine: str) -> None:
+    assert _rows(engine, CONNECTED_JOIN_PROJ) == [{"t": "Person", "pets": 1}]
+
+
+def test_projection_carry_connected_join_polars_declines_typed() -> None:
+    pytest.importorskip("polars")
+    with pytest.raises(NotImplementedError) as exc_info:
+        _rows("polars", CONNECTED_JOIN_PROJ)
+    assert POLARS_SCALAR_CARRY_DECLINE in str(exc_info.value)
+
+
+# --------------------------------------------- route 3: two-hop count fast path
+
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
+def test_two_hop_count_after_carry_restricts_to_carried_rows(engine: str) -> None:
+    """Was ``n=3`` (all persons re-matched). Only carried person 0's path counts."""
+    assert _rows(engine, TWO_HOP_COUNT) == [{"n": 1}]
+
+
+# ----------------------------------------------------- helper-level unit pins
+
+def test_restrict_helper_filters_by_bare_alias_column() -> None:
+    from graphistry.compute.gfql.cypher.reentry.execution import (
+        restrict_connected_join_rows_to_reentry_seed,
+    )
+
+    joined = pd.DataFrame({"p": [0, 1, 2], "d": [30, 30, 31], "x": [None, "v", None]})
+    seeds = pd.DataFrame({"node_id": [0, 2]})
+    out = restrict_connected_join_rows_to_reentry_seed(
+        joined, start_nodes=seeds, reentry_alias="p", node_col="node_id"
+    )
+    # NULL cells in non-key columns ride along untouched
+    assert list(out["p"]) == [0, 2] and pd.isna(out["x"]).tolist() == [True, True]
+
+
+def test_restrict_helper_declines_without_alias_or_seed_columns() -> None:
+    from graphistry.compute.gfql.cypher.reentry.execution import (
+        restrict_connected_join_rows_to_reentry_seed,
+    )
+
+    joined = pd.DataFrame({"q": [0, 1]})
+    seeds = pd.DataFrame({"node_id": [0]})
+    with pytest.raises(GFQLValidationError):
+        restrict_connected_join_rows_to_reentry_seed(
+            joined, start_nodes=seeds, reentry_alias=None, node_col="node_id"
+        )
+    with pytest.raises(GFQLValidationError):
+        restrict_connected_join_rows_to_reentry_seed(
+            joined, start_nodes=seeds, reentry_alias="p", node_col="node_id"
+        )
+    with pytest.raises(GFQLValidationError):
+        restrict_connected_join_rows_to_reentry_seed(
+            joined, start_nodes=pd.DataFrame({"other": [0]}), reentry_alias="q", node_col="node_id"
+        )
+
+
+def test_restrict_helper_polars_frames() -> None:
+    pl = pytest.importorskip("polars")
+    from graphistry.compute.gfql.cypher.reentry.execution import (
+        restrict_connected_join_rows_to_reentry_seed,
+    )
+
+    joined = pl.DataFrame({"p": [0, 1, 2]})
+    seeds = pl.DataFrame({"node_id": [2]})
+    out = restrict_connected_join_rows_to_reentry_seed(
+        joined, start_nodes=seeds, reentry_alias="p", node_col="node_id"
+    )
+    assert out["p"].to_list() == [2]


### PR DESCRIPTION
Two verified reentry/carry-family defects, fixed against master `8f4041336` with red-at-master pins, anti-vacuity counts, and a killed-mutant check per fix. Partial-scope residuals are pinned and called out on the issues; **#1911 and #1712 stay open** (refs #1712, refs #1911 — no auto-close).

## 1. #1712 residual — WITH→MATCH re-entry seeds ignored by three execution routes

`MATCH (p …) WITH p[, p.x AS t] MATCH (p)-…` must restrict the trailing MATCH to the carried `p` rows. The bare single-pattern shape was fixed earlier; three routes still re-matched from the whole graph:

| route | before (pandas/cuDF) | after |
|---|---|---|
| single-hop grouped-aggregate fast path (`RETURN t, count(p)`) | extra NULL-keyed group of the 2 un-carried persons: `[{t: Person, n:1}, {t: NaN, n:2}]` | `[{t: Person, n:1}]` |
| connected comma-pattern join (`MATCH (p)-→(c), (p)-→(d)`), bare AND projection carry | un-carried person leaked: `[{pid:0,…},{pid:1,…}]` (also polars) | `[{pid: 0, pets: 1}]` (all three engines) |
| two-hop count fast path (`MATCH (p)-→(c)-→(x) RETURN count(*)`) | `n=3` (also polars) | `n=1` |

Mechanics: the two seed-blind fast paths now **decline** when a reentry seed is present (`reentry_start_nodes`) and fall back to the seeded chain path; the connected join post-filters its joined rows to the carried seed ids via a new `restrict_connected_join_rows_to_reentry_seed` (typed E108 decline when the alias binding column cannot be recovered). polars' pre-existing typed NIE for scalar-carry reentry is pinned as a decline.

NULL-in-the-carried-column: `WITH p, p.nickname AS t` where the carried person's `nickname` is NULL came back as the sentinel string **`'0000-00-00'`** — a vacuously-true all-null temporal-constructor probe in `entity_props._all_non_null_match`. All-null series no longer "prove" any constructor shape; the NULL survives the carry.

**Remaining on #1712**: polars still typed-declines scalar-carry reentry (`WITH p, p.x AS t MATCH …`) — pre-existing NIE, pinned; native polars support is future work.

## 2. #1911 defect-4 — alias shadowing a property name reads the marker, not the values

`MATCH (name:P) RETURN name.name` answered `[True]×4` on pandas + polars and crashed cuDF with a raw mixed-dtype `TypeError`. Root cause: the alias flag is stamped as `<alias> = True`, overwriting the same-named user column that property reads then consume.

- `chain.combine_steps` now coalesces alias-marker `_x/_y` pairs as **markers** (boolean, null→False) instead of `.where`-merging marker booleans with user values (the cuDF crash, and the pandas empty-match column drop).
- The single-alias `rows(table=…, source=alias)` route restores the user values from the base frame under the dotted self-name (`name.name`) — index-keyed with a key-merge fallback — keeping the boolean marker intact for every other property read; polars re-keys via id join.
- The cartesian binding path unshadows like the connected one (both pandas/cuDF and the native polars twin, which had reproduced the leak deliberately).
- Result projection resolves `alias.alias` property columns from the restored dotted column; whole-entity flatten keeps its documented behavior (shadowed column omitted).
- New **typed decline (E108)** for a Cypher edge alias named after an edge endpoint binding column (`MATCH (a)-[s:K]->(b)` with source bound to `s`): previously an incidental GFQLSchemaError, and the marker-aware coalesce would have made it silently empty. Scoped to Cypher chains — raw GFQL chains keep their documented overwrite parity (`test_fast_path_alias_shadowing_column_matches_full_path` unchanged).
- Same-family verify+pin: whole-entity `RETURN r` with a user column literally named `__gfql_edge_ident__` keeps omitting dunder-named user columns from the flattened entity (generic internal-name policy) while explicit `r.__gfql_edge_ident__` projection returns the user's values — no crash, no misattribution.

**Remaining on #1911**: (a) polars edge alias colliding with the very column its own type filter reads (`MATCH (a)-[type:K]->(b) RETURN type.type`) stays a typed `GFQLSchemaError` (honest decline; pandas/cuDF answer `K,K`); (b) polars multi-hop relationship-alias row over-multiplication (independent of the alias name) — both pinned as residuals; (c) `MATCH (id:P) RETURN id.id` remains the pre-existing typed decline by design.

## Verification

- Pins red at master `8f4041336`: 35 failing cells across `test_reentry_carry_seed_restriction.py` (new) and `test_alias_scoping_semantics.py` (extended); all green at head; anti-vacuity via distinct multi-row oracles (a marker leak, an unrestricted count, or an empty frame cannot pass).
- Mutation check: 11 targeted mutants (one per fix line-cluster) — all killed by the pins.
- Engines: pandas + polars + cuDF 25.10 (dataframe ops) exercised locally; typed-decline pins where an engine declines.
- Gates: ruff clean; comment-density / cypher-surface / type-hygiene guards rc=0; mypy — no new errors vs master; full `graphistry/tests/compute` failure SET identical to the master baseline; changed-line coverage clean locally (no cuDF-only changed lines); new polars-mentioning test file registered in `bin/test-polars.sh` (lane-completeness gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm
