### PR TITLE
fix(ci): unblock master lint lane (comment-guard finding above cap)

### DIFF
--- a/bin/ci_comment_density_baseline.json
+++ b/bin/ci_comment_density_baseline.json
@@ -144,7 +144,7 @@
       "graphistry/ArrowFileUploader.py": 3,
       "graphistry/compute/ComputeMixin.py": 3,
       "graphistry/compute/ast.py": 1,
-      "graphistry/compute/chain.py": 7,
+      "graphistry/compute/chain.py": 6,
       "graphistry/compute/chain_fast_paths.py": 4,
       "graphistry/compute/chain_lean_combine.py": 2,
       "graphistry/compute/gfql/agg_types.py": 1,

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1651,7 +1651,7 @@ def _cartesian_node_bindings_polars(
         cols = matched.collect_schema().names()
         # prop_cols excludes node_id and any real column named == alias; that column is
         # emitted once below as ``alias.alias``: the real user values when the column
-        # exists (#1911 defect-4 parity with pandas' unshadow), else the flag ``True``.
+        # exists (unshadow parity with pandas), else the flag ``True``.
         prop_cols = [c for c in cols if c != node_id and c != alias]
         exprs = [
             pl.col(node_id).alias(alias),


### PR DESCRIPTION
## Master is red

`python-lint-types` fails on master at `0c3f3a1fa` (run [32215582520](https://github.com/graphistry/pygraphistry/actions/runs/32215582520)). Because every test lane `needs:` lint, **all PR test lanes are skipping** — CI is reporting no signal repo-wide, not green.

## Cause

Another baseline-union: `row_pipeline.py` reached 7 issue-citing comments against a cap of 6. Each contributing PR was green against its own snapshot; the union crossed the cap that neither could see.

## Fix

Restate the `alias.alias` unshadow contract by name rather than citing the issue number. The guard's premise holds here — the pin `test_unshadow_alias_marker_column_declines_when_there_is_nothing_to_restore` already carries the issue in its name.

**No cap was raised.** `--update-baseline` additionally locks a never-recorded improvement in `chain.py` (7 → 6), so this tightens the gate rather than relaxing it.

Comment-only change to product code; no behavior change.

## Verification

- `bin/ci_comment_density_guard.py` run **inside this worktree** (it resolves SCAN_ROOT from `__file__`, so running it by path from elsewhere silently checks the wrong tree): rc=0
- `bin/lint.sh` rc=0
- `bin/typecheck.sh`: `Success: no issues found in 331 source files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm