### PR TITLE
docs(gfql): stop claiming GRAPHISTRY_GFQL_STRICT_SCHEMA affects queries

### DIFF
--- a/graphistry/compute/gfql/rollout.py
+++ b/graphistry/compute/gfql/rollout.py
@@ -7,16 +7,22 @@ This module retains the historical strict-schema resolver surface. As of
 are compatibility values for callers that still inspect the helper and do not
 restore loose binder behavior.
 
-Precedence (most specific wins):
+.. warning::
+
+    ``GRAPHISTRY_GFQL_STRICT_SCHEMA`` **does not affect query behavior.**
+    Setting it to ``0``, ``1``, or leaving it unset all produce the same
+    result: an absent label still raises ``GFQLSchemaError``. Nothing in the
+    execution path consults this module -- every symbol below is re-exported
+    but never called by product code. The precedence chain described here is
+    the shape a strictness setting WOULD take if one were wired up; it is not
+    a description of current behavior. Whether to serve absent labels loosely
+    is an open design question.
+
+Precedence the helpers implement for their own consumers (most specific wins):
     1. Explicit caller parameter (e.g. ``FrontendBinder.bind(strict_name_resolution=True)``)
     2. Catalog-level metadata flag (e.g. ``GraphSchemaCatalog.metadata['strict']``)
     3. Process-wide env default (e.g. ``GRAPHISTRY_GFQL_STRICT_SCHEMA``)
     4. Historical loose default for helper-only consumers
-
-The env tier remains default-off at the helper layer; binder execution no
-longer treats that default as permission for loose compatibility paths.
-
-Production binder callers no longer use this helper as a loose/strict gate.
 """
 
 from __future__ import annotations
@@ -52,7 +58,7 @@ def env_bool(name: str, default: bool = False) -> bool:
 
 
 def strict_schema_env_default() -> bool:
-    """Return the env-default for strict schema mode (default off)."""
+    """Report the env var's value. Execution does not consult it -- see module warning."""
     return env_bool(STRICT_SCHEMA_ENV, default=False)
 
 

--- a/graphistry/tests/compute/gfql/test_rollout.py
+++ b/graphistry/tests/compute/gfql/test_rollout.py
@@ -95,3 +95,29 @@ def test_reexports_from_compute_gfql(monkeypatch: pytest.MonkeyPatch) -> None:
     assert pkg_default() is False
     monkeypatch.setenv(STRICT_SCHEMA_ENV, "true")
     assert pkg_default() is True
+
+
+def test_strict_schema_env_does_not_change_absent_label_behavior(monkeypatch) -> None:
+    """The documented env var is inert: all three states give the identical error."""
+    import pandas as pd
+    import graphistry
+    from graphistry.compute.exceptions import GFQLSchemaError
+
+    g = (graphistry
+         .nodes(pd.DataFrame({"id": [0, 1]}), "id")
+         .edges(pd.DataFrame({"s": [0], "d": [1]}), "s", "d"))
+
+    codes = []
+    for value in (None, "0", "1"):
+        if value is None:
+            monkeypatch.delenv("GRAPHISTRY_GFQL_STRICT_SCHEMA", raising=False)
+        else:
+            monkeypatch.setenv("GRAPHISTRY_GFQL_STRICT_SCHEMA", value)
+        try:
+            g.gfql("MATCH (n:Nope) RETURN n.id", engine="pandas")
+            codes.append("answered")
+        except GFQLSchemaError as err:
+            codes.append(err.code)
+
+    assert len(set(codes)) == 1, f"env var changed behavior: {codes}"
+    assert codes[0] != "answered"


### PR DESCRIPTION
Refs #1916 (sub-bug A). Does **not** close it — the strictness design question stays open.

## The defect

`GRAPHISTRY_GFQL_STRICT_SCHEMA` is documented as a strictness toggle and is completely inert. Verified end to end on master `e4ad11c6b`:

| env value | `MATCH (n:Nope) RETURN n.id` |
|---|---|
| unset | `GFQLSchemaError [column-not-found]` |
| `0` | identical |
| `1` | identical |

Nothing in the execution path consults `rollout.py`. Every symbol it defines — `STRICT_SCHEMA_ENV`, `env_bool`, `strict_schema_env_default`, `resolve_strict_schema` — is re-exported from `graphistry.compute.gfql` and **never called by product code**.

Meanwhile the module documented a precedence chain reading as though the env tier took effect. A user setting the documented toggle to `0` expecting leniency got silence — which is its own defect regardless of how the design question resolves.

## What this changes

Documentation only. The module now states plainly that the var does not affect query behavior, and that the precedence chain describes the shape a strictness setting *would* take rather than what happens today.

Pinned so the claim cannot silently become false again: a test asserts all three env states produce the same outcome.

## What this deliberately does NOT do

- **Not wiring the knob up.** Serving absent labels loosely is the open design question in #1916 and needs an owner ruling — the module's own history notes the binder has been strict by construction since #1420 and that loose behavior should not be restored casually.
- **Not deleting the symbols.** They are public re-exports; removing API is a larger change than this defect warrants, and it would foreclose wiring them up later.

## Gates

Comment guard, `bin/lint.sh`, `bin/typecheck.sh` all rc=0 from inside the worktree; mypy clean on 333 files. `test_rollout.py`: 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm