### PR TITLE
docs(remote): csv warns and serves, it is not refused

### DIFF
--- a/graphistry/compute/chain_remote.py
+++ b/graphistry/compute/chain_remote.py
@@ -544,13 +544,13 @@ def chain_remote(
     :param output_type: Whether to return nodes and edges ("all", default), Plottable with just nodes ("nodes"), or Plottable with just edges ("edges"). For just a dataframe of the resultant graph shape (output_type="shape"), use instead chain_remote_shape().
     :type output_type: OutputType
 
-    :param format: What format to fetch results. We recommend a columnar format such as parquet, which it defaults to when output_type is not shape. ``'csv'`` is untyped on the wire and is refused unless ``df_import_args`` is supplied.
+    :param format: What format to fetch results. We recommend a columnar format such as parquet, which it defaults to when output_type is not shape. ``'csv'`` is untyped on the wire: the client re-infers dtypes and can rewrite values, so it warns and serves. Pass ``df_import_args`` to control the reader.
     :type format: Optional[FormatType]
 
     :param df_export_args: When server parses data, any additional parameters to pass in.
     :type df_export_args: Optional[Dict, str, Any]]
 
-    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Required to use ``format='csv'`` at all: csv is untyped on the wire, so without explicit reader control the client would re-infer dtypes and can rewrite values. Prefer ``format='parquet'``, which is faithful and needs no reader args.
+    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Optional; without it csv dtypes are re-inferred from text, which can rewrite values (``'007'`` -> ``7.0``) and break the returned graph's own node/edge id join. Supplying it takes explicit control and silences the warning. Prefer ``format='parquet'``, which is faithful and needs no reader args.
     :type df_import_args: Optional[Dict[str, Any]]
 
     :param node_col_subset: When server returns nodes, what property subset to return. Defaults to all.

--- a/graphistry/compute/python_remote.py
+++ b/graphistry/compute/python_remote.py
@@ -85,7 +85,7 @@ def python_remote_generic(
     :param dataset_id: Optional dataset_id. If not provided, will fallback to self._dataset_id. If not defined, will upload current data, store that dataset_id, and run code against that.
     :type dataset_id: Optional[str]
 
-    :param format: What format to fetch results. Defaults to 'json'. We recommend a columnar format such as parquet. ``'csv'`` is untyped on the wire and is refused unless ``df_import_args`` is supplied.
+    :param format: What format to fetch results. Defaults to 'json'. We recommend a columnar format such as parquet. ``'csv'`` is untyped on the wire: the client re-infers dtypes and can rewrite values, so it warns and serves. Pass ``df_import_args`` to control the reader.
     :type format: Optional[FormatType]
 
     :param output_type: What shape of output to fetch. Defaults to 'json'. Options include 'nodes', 'edges', 'all' (both), 'table', 'shape', and 'json'.
@@ -100,7 +100,7 @@ def python_remote_generic(
     :param validate: Whether to locally test code, and if uploading data, the data. Default true.
     :type validate: bool
 
-    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Required to use ``format='csv'`` at all: csv is untyped on the wire, so without explicit reader control the client would re-infer dtypes and can rewrite values. Prefer ``format='parquet'``, which is faithful and needs no reader args.
+    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Optional; without it csv dtypes are re-inferred from text, which can rewrite values (``'007'`` -> ``7.0``) and break the returned graph's own node/edge id join. Supplying it takes explicit control and silences the warning. Prefer ``format='parquet'``, which is faithful and needs no reader args.
     :type df_import_args: Optional[Dict[str, Any]]
 
     **Example: Upload data and count the results**
@@ -301,7 +301,7 @@ def python_remote_g(
     :param dataset_id: Optional dataset_id. If not provided, will fallback to self._dataset_id. If not defined, will upload current data, store that dataset_id, and run code against that.
     :type dataset_id: Optional[str]
 
-    :param format: What format to fetch results. Defaults to 'parquet'. ``'csv'`` is untyped on the wire and is refused unless ``df_import_args`` is supplied.
+    :param format: What format to fetch results. Defaults to 'parquet'. ``'csv'`` is untyped on the wire: the client re-infers dtypes and can rewrite values, so it warns and serves. Pass ``df_import_args`` to control the reader.
     :type format: Optional[FormatType]
 
     :param output_type: What shape of output to fetch. Defaults to 'all'. Options include 'nodes', 'edges', 'all' (both). For other variants, see python_remote_shape and python_remote_json.
@@ -316,7 +316,7 @@ def python_remote_g(
     :param validate: Whether to locally test code, and if uploading data, the data. Default true.
     :type validate: bool
 
-    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Required to use ``format='csv'`` at all. Prefer ``format='parquet'``, which is faithful and needs no reader args.
+    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Optional; without it csv dtypes are re-inferred from text, which can rewrite values and break the returned graph's own node/edge id join. Supplying it takes explicit control and silences the warning. Prefer ``format='parquet'``, which is faithful and needs no reader args.
     :type df_import_args: Optional[Dict[str, Any]]
 
     **Example: Upload data and count the results**
@@ -387,7 +387,7 @@ def python_remote_table(
     :param dataset_id: Optional dataset_id. If not provided, will fallback to self._dataset_id. If not defined, will upload current data, store that dataset_id, and run code against that.
     :type dataset_id: Optional[str]
 
-    :param format: What format to fetch results. Defaults to 'parquet'. ``'csv'`` is untyped on the wire and is refused unless ``df_import_args`` is supplied.
+    :param format: What format to fetch results. Defaults to 'parquet'. ``'csv'`` is untyped on the wire: the client re-infers dtypes and can rewrite values, so it warns and serves. Pass ``df_import_args`` to control the reader.
     :type format: Optional[FormatType]
 
     :param output_type: What shape of output to fetch. Defaults to 'table'. Options include 'table', 'nodes', and 'edges'.
@@ -402,7 +402,7 @@ def python_remote_table(
     :param validate: Whether to locally test code, and if uploading data, the data. Default true.
     :type validate: bool
 
-    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Required to use ``format='csv'`` at all. Prefer ``format='parquet'``, which is faithful and needs no reader args.
+    :param df_import_args: Reader kwargs the client applies when decoding a ``format='csv'`` response. Optional; without it csv dtypes are re-inferred from text, which can rewrite values and break the returned graph's own node/edge id join. Supplying it takes explicit control and silences the warning. Prefer ``format='parquet'``, which is faithful and needs no reader args.
     :type df_import_args: Optional[Dict[str, Any]]
 
     **Example: Upload data and count the results**


### PR DESCRIPTION
Found by an audit of claims made across the 2026-08-19 landings. **This is a live, user-facing falsehood on master, introduced by #1974.**

## What is wrong

#1974 changed `format='csv'` from a hard decline to warn-and-serve. It did not update the docstrings. Eight `:param` entries on master still say:

> ``'csv'`` is untyped on the wire and **is refused unless** ``df_import_args`` is supplied.

> ``df_import_args``: **Required to use** ``format='csv'`` **at all**

Both are false. Verified on `54266cc6f`: csv serves without `df_import_args`, emits a `UserWarning`, and returns `id = [7.0, 8.0, NaN]` as `float64` while edge endpoints stay `int64`.

The failure mode is the bad one: a user reads the API doc, believes the lossy path is **blocked**, and therefore never passes `df_import_args` — while that lossy path is in fact the **default**. The docs advertise a guardrail that was removed.

Affected: `chain_remote.py` :547, :553 · `python_remote.py` :88, :103, :304, :319, :390, :405.

## What this changes

Documentation only, no behavior. The entries now describe what actually happens: csv warns and serves; dtypes are re-inferred from text and can rewrite values (`'007'` → `7.0`) and break the returned graph's own node↔edge id join; `df_import_args` is the **optional** opt-in that takes explicit reader control and silences the warning; `format='parquet'` remains the faithful default.

## Gates

`bin/ci_comment_density_guard.py`, `bin/lint.sh`, `bin/typecheck.sh` all rc=0 from inside the worktree. `test_remote_csv_fidelity.py` + `test_chain_remote_v2.py`: 42 passed, 2 skipped.

## Related, not fixed here

The underlying behavior question — csv re-inferring dtypes by default — is the ruled design (warn, don't refuse). Issue #1958 was auto-closed by #1971 and then #1974 reverted that fix to a warning; the issue was never reopened, so the still-reproducing default currently has no tracking issue. Flagging separately rather than bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjbKuKheqDu78oapRT5AYm