### PR TITLE
fix(gfql): treat binding seed ids as identities

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -65,6 +65,7 @@ POLARS_TEST_FILES=(
     # #1911 alias-scoping pins: every case is parametrized pandas AND polars, and the
     # polars params (WITH-rebind decline parity, edge-identity collision crash) only run here
     graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+    graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
     # #1712 reentry-carry seed pins: no module-level importorskip (pandas params run in
     # test-gfql-core), but the polars params — native carry restriction + the typed
     # scalar-carry declines — only ever run here

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1958,7 +1958,9 @@ def binding_rows_polars(
         # `filter_by_dict_polars` is frame-polymorphic at runtime but declares the eager
         # type, so pin the path bag lazy here instead of leaving every downstream lazy
         # op to fight an eager inference.
-        state: pl.LazyFrame = seed_nodes.select(pl.col(node_id).alias(WALK_CURRENT_COL))  # type: ignore[assignment]
+        state: pl.LazyFrame = seed_nodes.select(  # type: ignore[assignment]
+            pl.col(node_id).alias(WALK_CURRENT_COL)
+        ).unique(subset=[WALK_CURRENT_COL], maintain_order=True)
         alias_frames: Dict[str, pl.LazyFrame] = {}
         node_aliases: List[str] = []
         first_alias = first_op._name

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1954,11 +1954,7 @@ def binding_rows_polars(
             seed_nodes = seed_nodes.join(seed_ids_lf, on=node_id, how="semi")
         # L4 pushdown twin of pandas `_gfql_connected_bindings_state`'s seed prefilter
         seed_nodes = _apply_alias_prefilters_polars(seed_nodes, first_op._name, alias_prefilters)  # honoured, never dropped (#1804)
-        # The whole generic builder works in LazyFrames (`nodes_lf` / `edges_lf` above);
-        # `filter_by_dict_polars` is frame-polymorphic at runtime but declares the eager
-        # type, so pin the path bag lazy here instead of leaving every downstream lazy
-        # op to fight an eager inference.
-        state: pl.LazyFrame = seed_nodes.select(  # type: ignore[assignment]
+        state = seed_nodes.select(
             pl.col(node_id).alias(WALK_CURRENT_COL)
         ).unique(subset=[WALK_CURRENT_COL], maintain_order=True)
         alias_frames: Dict[str, pl.LazyFrame] = {}

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -4057,7 +4057,12 @@ class RowPipelineMixin:
         first_nodes = self._gfql_apply_alias_prefilter(
             first_nodes, first_alias, alias_prefilters
         )
-        state_df = first_nodes[[node_id_col]].copy().rename(columns={node_id_col: WALK_CURRENT_COL})
+        state_df = (
+            first_nodes[[node_id_col]]
+            .drop_duplicates(subset=[node_id_col], keep="first")
+            .copy()
+            .rename(columns={node_id_col: WALK_CURRENT_COL})
+        )
         alias_frames: Dict[str, DataFrameT] = {}
         if isinstance(first_alias, str):
             state_df[first_alias] = state_df[WALK_CURRENT_COL]

--- a/graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
@@ -1,0 +1,89 @@
+"""Generic binding rows use node ids as identities.
+
+Duplicate physical node rows do not add nodes or relationships. Match rows come
+from relationship rows, including parallel relationships.
+"""
+from typing import Dict
+
+import pandas as pd
+import pytest
+
+import graphistry
+import graphistry.compute.gfql_unified as gfql_unified
+
+
+try:
+    import cudf
+
+    HAS_CUDF = True
+except ImportError:
+    HAS_CUDF = False
+
+
+try:
+    import polars as pl
+
+    HAS_POLARS = True
+except ImportError:
+    HAS_POLARS = False
+
+
+ENGINES = [
+    "pandas",
+    pytest.param("cudf", marks=pytest.mark.skipif(not HAS_CUDF, reason="cudf not installed")),
+    pytest.param("polars", marks=pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")),
+]
+
+
+def _run_generic(engine: str, *, parallel_edge: bool) -> Dict[str, int]:
+    nodes = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 1, 2],
+        "kind": ["P", "P", "P", "P", "C", "C", "C", "C", "P", "P"],
+        "city": [None, None, None, None, "LA", "NY", "SF", "LA", None, None],
+    })
+    edges = pd.DataFrame({
+        "s": [1, 2, 3, 4, 1, 2, 3, 4, 1],
+        "d": [5, 5, 6, 7, 8, 6, 8, 8, 5],
+    })
+    if parallel_edge:
+        edges = pd.concat(
+            [edges, pd.DataFrame({"s": [1], "d": [5]})],
+            ignore_index=True,
+        )
+
+    if engine == "cudf":
+        graph = graphistry.nodes(cudf.from_pandas(nodes), "id").edges(
+            cudf.from_pandas(edges), "s", "d"
+        )
+    elif engine == "polars":
+        graph = graphistry.nodes(pl.from_pandas(nodes), "id").edges(
+            pl.from_pandas(edges), "s", "d"
+        )
+    else:
+        graph = graphistry.nodes(nodes, "id").edges(edges, "s", "d")
+
+    result = graph.gfql(
+        "MATCH (p {kind:'P'})-->(c {kind:'C'}) "
+        "RETURN c.city AS city, count(*) AS n ORDER BY city ASC",
+        engine=engine,
+    )._nodes
+    if hasattr(result, "to_pandas"):
+        result = result.to_pandas()
+    return {str(row.city): int(row.n) for row in result.itertuples(index=False)}
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize(
+    "parallel_edge,expected",
+    [
+        (False, {"LA": 6, "NY": 2, "SF": 1}),
+        (True, {"LA": 7, "NY": 2, "SF": 1}),
+    ],
+)
+def test_generic_binding_seed_ids_are_identities(
+    engine: str, parallel_edge: bool, expected: Dict[str, int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        gfql_unified, "_execute_single_hop_grouped_aggregate_fast_path", lambda *args, **kwargs: None
+    )
+    assert _run_generic(engine, parallel_edge=parallel_edge) == expected

--- a/graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
@@ -8,16 +8,15 @@ import pytest
 from typing_extensions import Literal
 
 import graphistry
-import graphistry.compute.gfql_unified as gfql_unified
-from graphistry.Engine import Engine, EngineAbstractType, df_to_engine
+from graphistry.Engine import Engine, df_to_engine
 from graphistry.Plottable import Plottable
-from graphistry.compute.chain import Chain
-from graphistry.compute.typing import DataFrameT
+from graphistry.tests.compute.gfql.engagement import assert_fast_path
 from graphistry.tests.compute.gfql.polars_test_utils import engine_skip_reason, to_pandas_any
 
 
 _GFQLEngine = Literal["pandas", "polars", "cudf", "polars-gpu"]
 _ENGINES: typing.Tuple[_GFQLEngine, ...] = ("pandas", "polars", "cudf", "polars-gpu")
+
 
 def _bind(nodes: pd.DataFrame, edges: pd.DataFrame, engine: _GFQLEngine) -> Plottable:
     resolved_engine = Engine(engine)
@@ -38,17 +37,6 @@ def _require_engine(engine: _GFQLEngine) -> None:
         pytest.skip(skip_reason)
 
 
-def _disable_fast_path(
-    base_graph: Plottable,
-    chain: Chain,
-    *,
-    engine: EngineAbstractType,
-    reentry_start_nodes: typing.Optional[DataFrameT] = None,
-) -> typing.Optional[Plottable]:
-    _ = base_graph, chain, engine, reentry_start_nodes
-    return None
-
-
 def _run_generic(engine: _GFQLEngine, *, parallel_edge: bool) -> typing.Mapping[str, int]:
     nodes = pd.DataFrame({
         "id": [1, 2, 3, 4, 5, 6, 7, 8, 1, 2],
@@ -67,11 +55,14 @@ def _run_generic(engine: _GFQLEngine, *, parallel_edge: bool) -> typing.Mapping[
 
     _require_engine(engine)
     graph = _bind(nodes, edges, engine)
-    result_frame = graph.gfql(
+    query = (
         "MATCH (p {kind:'P'})-->(c {kind:'C'}) "
-        "RETURN c.city AS city, count(*) AS n ORDER BY city ASC",
-        engine=engine,
-    )._nodes
+        "RETURN c.city AS city, count(*) AS n ORDER BY city ASC SKIP 0"
+    )
+    assert_fast_path(
+        graph, query, "single_hop_grouped_aggregate", served=False, engine=engine
+    )
+    result_frame = graph.gfql(query, engine=engine)._nodes
     pandas_frame = to_pandas_any(result_frame)
     assert isinstance(pandas_frame, pd.DataFrame)
     return {str(row.city): int(row.n) for row in pandas_frame.itertuples(index=False)}
@@ -86,9 +77,8 @@ def _run_generic(engine: _GFQLEngine, *, parallel_edge: bool) -> typing.Mapping[
     ],
 )
 def test_generic_binding_seed_ids_are_identities(
-    engine: _GFQLEngine, parallel_edge: bool, expected: typing.Mapping[str, int], monkeypatch: pytest.MonkeyPatch
+    engine: _GFQLEngine,
+    parallel_edge: bool,
+    expected: typing.Mapping[str, int],
 ) -> None:
-    monkeypatch.setattr(
-        gfql_unified, "_execute_single_hop_grouped_aggregate_fast_path", _disable_fast_path
-    )
     assert _run_generic(engine, parallel_edge=parallel_edge) == expected

--- a/graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
+++ b/graphistry/tests/compute/gfql/cypher/test_binding_seed_identity.py
@@ -1,41 +1,55 @@
-"""Generic binding rows use node ids as identities.
+"""Generic binding rows use node ids as identities."""
+from __future__ import annotations
 
-Duplicate physical node rows do not add nodes or relationships. Match rows come
-from relationship rows, including parallel relationships.
-"""
-from typing import Dict
+import typing
 
 import pandas as pd
 import pytest
+from typing_extensions import Literal
 
 import graphistry
 import graphistry.compute.gfql_unified as gfql_unified
+from graphistry.Engine import Engine, EngineAbstractType, df_to_engine
+from graphistry.Plottable import Plottable
+from graphistry.compute.chain import Chain
+from graphistry.compute.typing import DataFrameT
+from graphistry.tests.compute.gfql.polars_test_utils import engine_skip_reason, to_pandas_any
 
 
-try:
-    import cudf
+_GFQLEngine = Literal["pandas", "polars", "cudf", "polars-gpu"]
+_ENGINES: typing.Tuple[_GFQLEngine, ...] = ("pandas", "polars", "cudf", "polars-gpu")
 
-    HAS_CUDF = True
-except ImportError:
-    HAS_CUDF = False
-
-
-try:
-    import polars as pl
-
-    HAS_POLARS = True
-except ImportError:
-    HAS_POLARS = False
+def _bind(nodes: pd.DataFrame, edges: pd.DataFrame, engine: _GFQLEngine) -> Plottable:
+    resolved_engine = Engine(engine)
+    return graphistry.nodes(df_to_engine(nodes, resolved_engine), "id").edges(
+        df_to_engine(edges, resolved_engine), "s", "d"
+    )
 
 
-ENGINES = [
-    "pandas",
-    pytest.param("cudf", marks=pytest.mark.skipif(not HAS_CUDF, reason="cudf not installed")),
-    pytest.param("polars", marks=pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")),
-]
+def _smoke(engine: _GFQLEngine) -> Plottable:
+    nodes = pd.DataFrame({"id": [1, 2]})
+    edges = pd.DataFrame({"s": [1], "d": [2]})
+    return _bind(nodes, edges, engine).gfql("MATCH (n) RETURN n.id AS id", engine=engine)
 
 
-def _run_generic(engine: str, *, parallel_edge: bool) -> Dict[str, int]:
+def _require_engine(engine: _GFQLEngine) -> None:
+    skip_reason = engine_skip_reason(engine, lambda: _smoke(engine))
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+
+def _disable_fast_path(
+    base_graph: Plottable,
+    chain: Chain,
+    *,
+    engine: EngineAbstractType,
+    reentry_start_nodes: typing.Optional[DataFrameT] = None,
+) -> typing.Optional[Plottable]:
+    _ = base_graph, chain, engine, reentry_start_nodes
+    return None
+
+
+def _run_generic(engine: _GFQLEngine, *, parallel_edge: bool) -> typing.Mapping[str, int]:
     nodes = pd.DataFrame({
         "id": [1, 2, 3, 4, 5, 6, 7, 8, 1, 2],
         "kind": ["P", "P", "P", "P", "C", "C", "C", "C", "P", "P"],
@@ -51,28 +65,19 @@ def _run_generic(engine: str, *, parallel_edge: bool) -> Dict[str, int]:
             ignore_index=True,
         )
 
-    if engine == "cudf":
-        graph = graphistry.nodes(cudf.from_pandas(nodes), "id").edges(
-            cudf.from_pandas(edges), "s", "d"
-        )
-    elif engine == "polars":
-        graph = graphistry.nodes(pl.from_pandas(nodes), "id").edges(
-            pl.from_pandas(edges), "s", "d"
-        )
-    else:
-        graph = graphistry.nodes(nodes, "id").edges(edges, "s", "d")
-
-    result = graph.gfql(
+    _require_engine(engine)
+    graph = _bind(nodes, edges, engine)
+    result_frame = graph.gfql(
         "MATCH (p {kind:'P'})-->(c {kind:'C'}) "
         "RETURN c.city AS city, count(*) AS n ORDER BY city ASC",
         engine=engine,
     )._nodes
-    if hasattr(result, "to_pandas"):
-        result = result.to_pandas()
-    return {str(row.city): int(row.n) for row in result.itertuples(index=False)}
+    pandas_frame = to_pandas_any(result_frame)
+    assert isinstance(pandas_frame, pd.DataFrame)
+    return {str(row.city): int(row.n) for row in pandas_frame.itertuples(index=False)}
 
 
-@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("engine", _ENGINES)
 @pytest.mark.parametrize(
     "parallel_edge,expected",
     [
@@ -81,9 +86,9 @@ def _run_generic(engine: str, *, parallel_edge: bool) -> Dict[str, int]:
     ],
 )
 def test_generic_binding_seed_ids_are_identities(
-    engine: str, parallel_edge: bool, expected: Dict[str, int], monkeypatch: pytest.MonkeyPatch
+    engine: _GFQLEngine, parallel_edge: bool, expected: typing.Mapping[str, int], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
-        gfql_unified, "_execute_single_hop_grouped_aggregate_fast_path", lambda *args, **kwargs: None
+        gfql_unified, "_execute_single_hop_grouped_aggregate_fast_path", _disable_fast_path
     )
     assert _run_generic(engine, parallel_edge=parallel_edge) == expected


### PR DESCRIPTION
## Summary

- treat node ids, not duplicate physical node-table rows, as identities when generic binding traversal starts
- preserve first-encounter order in pandas/cuDF and Polars seed state
- keep relationship rows as the source of MATCH bag multiplicity, including genuine parallel edges

## Correctness oracle

The fixture duplicates storage rows for node ids 1 and 2 but adds no graph identities or relationships. Its hand-derived grouped counts are `LA=6, NY=2, SF=1`; adding one parallel `1 -> 5` relationship changes only LA to 7. Before this fix the generic route returned `10/3/1` and `12/3/1` by multiplying paths from duplicate seed rows.

## Semantics boundary

GQL-conformant Cypher preserves binding-row duplicates for plain `RETURN` / `RETURN ALL`; only `DISTINCT` deduplicates ([Neo4j Cypher RETURN](https://neo4j.com/docs/cypher-manual/current/clauses/return/)). This change follows that boundary:

- duplicate physical node-table rows with the same node id collapse only at the initial identity wavefront
- relationship match rows are never collapsed by this change
- a genuine parallel edge therefore remains an additional match row and changes LA from 6 to 7

## Validation

- exact reviewed head: `a888c33f2d42f626bb0754fb1186b2d1c1bf6561`
- topology: four single-parent commits directly on `master@d509e428b0b63a7dd6d92ee5271e75afd15ca2bf`; zero merge commits
- incremental diff: four intended files, +94/-6; whitespace clean
- prohibited added-line audit: zero `Any`, `object`, `cast`, `getattr`, `setattr`, `hasattr`, or unqualified `List`/`Dict`; finite engine values use `Literal`
- focused safe CPU regression: 4 passed / 4 GPU cells deliberately deselected
- `./bin/lint.sh`: syntax, Ruff, type-hygiene, comment-density, and relative-import guards clean
- `./bin/typecheck.sh`: mypy 2.3.1, 336 source files, zero issues
- no Docker, local GPU, or broad local suite; the current GitHub Checks panel is authoritative for the full matrix

## Review resolutions

- **Stacking:** the stale predecessor merges were removed. The branch is now four linear commits directly on landed #2000 master.
- **Positive/negative boundary:** duplicate physical seed rows are the positive case that must collapse; a real parallel relationship row is the negative control that must remain multiplicative. Both cases run across the engine matrix.
- **Anti-vacuity without dynamic patching:** the regression uses semantically neutral `SKIP 0` to select the generic route and `assert_fast_path(..., served=False)` to prove the grouped fast path was consulted and declined.

Closes #1996

## Reviewer handoff

Please review the incremental four-file diff for:

1. seed-state deduplication is by node id and preserves first encounter order
2. relationship rows, including parallel edges, still determine MATCH bag multiplicity
3. the regression proves the generic route without `monkeypatch.setattr` or another dynamic-attribute escape

## Stack / landing

- predecessor #2000 is landed at `d509e428b0b63a7dd6d92ee5271e75afd15ca2bf`
- this PR is based directly on `master`
- successor #2002 must be rebased onto the resulting master after this PR lands
- land only the exact green head using GitHub **Create a merge commit**; do not delete the branch while successors are being repaired
