### PR TITLE
feat(gfql): add built-in standard graph algorithms

### DIFF
--- a/docs/source/gfql/index.rst
+++ b/docs/source/gfql/index.rst
@@ -67,6 +67,7 @@ See also:
    predicates/quick
    datetime_filtering
    builtin_calls
+   standard_algorithms
    policy
    strict_mode
    schema

--- a/docs/source/gfql/standard_algorithms.rst
+++ b/docs/source/gfql/standard_algorithms.rst
@@ -58,9 +58,9 @@ Algorithms and options
        in each component.
    * - ``pagerank``
      - ``pagerank``
-     - ``iterations`` (10), ``damping`` (0.85), ``chunks``
-     - Directed PageRank with a fixed iteration count and redistributed
-       dangling mass.
+     - cuGraph-compatible controls plus ``weight``, ``chunks``, ``stopping``
+     - Directed, optionally weighted PageRank. Convergence is the default;
+       fixed-iteration execution is explicit.
    * - ``cdlp``
      - ``cdlp``
      - ``iterations`` (10), ``chunks``
@@ -76,6 +76,52 @@ Algorithms and options
      - ``seed``, ``chunks``, ``max_rounds``
      - A deterministic-seed maximal independent set. Self-loops are ignored;
        isolated nodes are included.
+
+PageRank compatibility and extras
+---------------------------------
+
+The standard PageRank procedure uses the cuGraph parameter names and defaults:
+``alpha=0.85``, ``personalization=None``,
+``precomputed_vertex_out_weight=None``, ``max_iter=100``, ``tol=1e-5``,
+``nstart=None``, ``dangling=None``, and ``fail_on_nonconvergence=True``.
+Convergence uses the cuGraph criterion: the L1 difference between successive
+rank vectors is less than the vertex count times ``tol``. As in cuGraph,
+``dangling`` is accepted for compatibility and ignored.
+
+``personalization`` and ``nstart`` use ``vertex`` / ``values`` pairs;
+``precomputed_vertex_out_weight`` uses ``vertex`` / ``sums`` pairs. Direct
+Python calls accept pandas or cuDF frames. GFQL also accepts a node-ID-to-value
+map or a list of records. IDs are in the graph's original ID space, and omitted
+vertices receive zero for personalization/start values. Missing precomputed
+out sums are computed normally.
+
+Pass ``weight`` as an edge-column name. When omitted, the graph's bound edge
+weight is used; without either, every edge has weight 1. ``chunks`` controls
+dataframe chunking without changing the result.
+
+By default PageRank raises when ``max_iter`` is exhausted. Set
+``fail_on_nonconvergence: false`` to keep the last iterate. The Graphistry extra
+``converged_col`` then writes the solver status as a boolean node column:
+
+.. code-block:: python
+
+    attempted = g.gfql(
+        "CALL graphistry.std.pagerank.write({params: {"
+        "max_iter: 20, fail_on_nonconvergence: false, "
+        "converged_col: 'pr_converged'}})"
+    )
+
+For the LDBC Graphalytics fixed-K workload, select fixed mode explicitly:
+
+.. code-block:: python
+
+    fixed_ten = g.gfql(
+        "CALL graphistry.std.pagerank.write({params: {"
+        "stopping: 'fixed_iterations', max_iter: 10}})"
+    )
+
+The legacy extras ``iterations`` and ``damping`` remain aliases for fixed-mode
+``max_iter`` and ``alpha`` respectively.
 
 SSSP IDs and weights
 --------------------

--- a/docs/source/gfql/standard_algorithms.rst
+++ b/docs/source/gfql/standard_algorithms.rst
@@ -84,9 +84,11 @@ The standard PageRank procedure uses the cuGraph parameter names and defaults:
 ``alpha=0.85``, ``personalization=None``,
 ``precomputed_vertex_out_weight=None``, ``max_iter=100``, ``tol=1e-5``,
 ``nstart=None``, ``dangling=None``, and ``fail_on_nonconvergence=True``.
-Convergence uses the cuGraph criterion: the L1 difference between successive
-rank vectors is less than the vertex count times ``tol``. As in cuGraph,
-``dangling`` is accepted for compatibility and ignored.
+On the returned unit-mass rank scale, convergence occurs when the L1 difference
+between successive rank vectors is less than ``tol``. This matches the public
+cuGraph API's observed stopping behavior; its lower-level ``V * epsilon``
+description uses an internally vertex-scaled error. As in cuGraph, ``dangling``
+is accepted for compatibility and ignored.
 
 ``personalization`` and ``nstart`` use ``vertex`` / ``values`` pairs;
 ``precomputed_vertex_out_weight`` uses ``vertex`` / ``sums`` pairs. Direct

--- a/docs/source/gfql/standard_algorithms.rst
+++ b/docs/source/gfql/standard_algorithms.rst
@@ -22,7 +22,7 @@ options:
 
     distances = g.gfql(
         "CALL graphistry.std.sssp.write("
-        "{out_col: 'cost_from_a', params: {source: 'a', weight: 'cost'}})"
+        "{out_col: 'cost_from_a', params: {source: 'a', weight: 'weight'}})"
     )
 
 The input graph is unchanged. Explicitly bound nodes, including isolated

--- a/docs/source/gfql/standard_algorithms.rst
+++ b/docs/source/gfql/standard_algorithms.rst
@@ -1,0 +1,100 @@
+GFQL Standard Graph Algorithms
+==============================
+
+``graphistry.std`` provides built-in graph algorithms through local GFQL
+Cypher ``CALL`` queries. They require no optional graph-library dependency and
+use the dataframe engine already holding the graph.
+
+Write results to nodes
+----------------------
+
+Append an algorithm result as a node column with ``.write()``:
+
+.. code-block:: python
+
+    ranked = g.gfql("CALL graphistry.std.pagerank.write()")
+    assert "pagerank" in ranked._nodes.columns
+
+Use ``out_col`` to override the output name and ``params`` for algorithm
+options:
+
+.. code-block:: python
+
+    distances = g.gfql(
+        "CALL graphistry.std.sssp.write("
+        "{out_col: 'cost_from_a', params: {source: 'a', weight: 'cost'}})"
+    )
+
+The input graph is unchanged. Explicitly bound nodes, including isolated
+nodes, remain in the result.
+
+Return rows
+-----------
+
+Without ``.write()``, use ``YIELD`` and ``RETURN`` to get node rows:
+
+.. code-block:: python
+
+    rows = g.gfql(
+        "CALL graphistry.std.pagerank() "
+        "YIELD nodeId, pagerank RETURN nodeId, pagerank"
+    )
+
+Algorithms and options
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 18 28 40
+
+   * - Procedure
+     - Output
+     - Parameters
+     - Semantics
+   * - ``wcc``
+     - ``component``
+     - ``chunks``, ``max_iter``
+     - Weakly connected components. The label is the minimum original node ID
+       in each component.
+   * - ``pagerank``
+     - ``pagerank``
+     - ``iterations`` (10), ``damping`` (0.85), ``chunks``
+     - Directed PageRank with a fixed iteration count and redistributed
+       dangling mass.
+   * - ``cdlp``
+     - ``cdlp``
+     - ``iterations`` (10), ``chunks``
+     - Undirected label propagation with multiset edge semantics. Ties choose
+       the smallest original node-ID label.
+   * - ``sssp``
+     - ``distance``
+     - ``source``, ``weight``, ``chunks``, ``max_iter``
+     - Directed single-source shortest paths. ``source`` is an original node
+       ID. ``weight`` names an edge column.
+   * - ``mis``
+     - ``mis``
+     - ``seed``, ``chunks``, ``max_rounds``
+     - A deterministic-seed maximal independent set. Self-loops are ignored;
+       isolated nodes are included.
+
+SSSP IDs and weights
+--------------------
+
+Pass ``source`` in the graph's original node-ID space, including string IDs.
+An unknown source raises ``ValueError``. If omitted, SSSP starts at the first
+node in the algorithm's sorted dense-ID mapping.
+
+When ``weight`` is supplied, it must name an edge column. When omitted, the
+implementation generates deterministic float32 integer weights in the range
+1 through 255 from the source and destination IDs.
+
+Execution and result status
+---------------------------
+
+The implementation dispatches over pandas or cuDF frames without selecting a
+separate library backend. ``graphistry.std`` is distinct from
+``graphistry.cugraph``, ``graphistry.igraph``, and ``graphistry.nx``.
+
+These procedures implement documented Graphalytics-style semantics, but their
+results are not official or audited LDBC Graphalytics submissions. MIS is not
+an official Graphalytics algorithm.

--- a/graphistry/compute/algorithms/__init__.py
+++ b/graphistry/compute/algorithms/__init__.py
@@ -1,0 +1,26 @@
+"""Engine-agnostic graph algorithm kernels, exposed as GFQL `graphistry.std.*`.
+
+These exist because no backend implements the LDBC Graphalytics semantics:
+cuGraph has no label propagation and no maximal independent set, igraph's label
+propagation is randomized rather than deterministic, and both PageRanks converge
+to a tolerance while LDBC fixes the iteration count.
+
+They are `std` in the same sense as a standard library: no optional third-party
+dependency, and they run on whatever engine the frames already use (pandas or
+cudf, from one implementation).
+
+Validated against independent references -- networkx for WCC, Dijkstra for SSSP
+(bitwise exact), a naive Python LDBC implementation for CDLP, a hand-written
+power iteration for PageRank, and independence+maximality invariants for MIS.
+"""
+from .kernels import ConvergenceError, cdlp, make_weights, mis, pagerank, sssp, wcc
+
+__all__ = [
+    "ConvergenceError",
+    "cdlp",
+    "make_weights",
+    "mis",
+    "pagerank",
+    "sssp",
+    "wcc",
+]

--- a/graphistry/compute/algorithms/_dfops.py
+++ b/graphistry/compute/algorithms/_dfops.py
@@ -18,22 +18,26 @@ otherwise hit at 1B edges):
 Banned in kernels: `.apply`, `groupby().apply`, `idxmin`/`idxmax`, `mode()`,
 `pd.factorize`, `np.*` on Series, `.query`, `Categorical`.
 """
+
 from __future__ import annotations
 
-from typing import Any, Iterator, Sequence
+from types import ModuleType
+from typing import Iterator, Mapping, Optional, Sequence, Tuple
 
 import pandas as pd
+
+from graphistry.compute.typing import DataFrameT, SeriesT
 
 # 2**32, as a plain Python int. Used for bit-packing via arithmetic.
 SHIFT32 = 1 << 32
 
 
-def is_cudf(obj: Any) -> bool:
+def is_cudf(obj: object) -> bool:
     """True when obj belongs to cudf, without importing cudf on CPU-only hosts."""
     return type(obj).__module__.split(".")[0] == "cudf"
 
 
-def _mod(frame: Any):
+def _mod(frame: DataFrameT) -> ModuleType:
     """The dataframe module that produced `frame` (pandas or cudf)."""
     if is_cudf(frame):
         import cudf
@@ -42,12 +46,12 @@ def _mod(frame: Any):
     return pd
 
 
-def df_cons(template: Any, data: dict) -> Any:
+def df_cons(template: DataFrameT, data: Mapping[str, object]) -> DataFrameT:
     """Build a frame of the same engine as `template`."""
     return _mod(template).DataFrame(data)
 
 
-def concat_frames(frames: Sequence[Any]) -> Any:
+def concat_frames(frames: Sequence[Optional[DataFrameT]]) -> Optional[DataFrameT]:
     """Concatenate, dropping the index. Empty-safe."""
     frames = [f for f in frames if f is not None and len(f) > 0]
     if not frames:
@@ -57,8 +61,8 @@ def concat_frames(frames: Sequence[Any]) -> Any:
     return _mod(frames[0]).concat(frames, ignore_index=True)
 
 
-def gather(vec: Any, idx: Any) -> Any:
-    """vec[idx] as a positional gather -- O(E), no hash table.
+def gather(vec: SeriesT, idx: SeriesT) -> SeriesT:
+    """Select vec[idx] positionally without a hash table.
 
     `vec` must be a dense per-vertex Series indexed 0..V-1 (position == vertex
     id, which is what dense_renumber guarantees). This is the primitive that
@@ -68,12 +72,12 @@ def gather(vec: Any, idx: Any) -> Any:
     return vec.take(idx).reset_index(drop=True)
 
 
-def emin(a: Any, b: Any) -> Any:
+def emin(a: SeriesT, b: SeriesT) -> SeriesT:
     """Elementwise min of two Series, index-preserving on both engines."""
     return a.where(a <= b, b)
 
 
-def full(template: Any, n: int, value: Any, dtype: str) -> Any:
+def full(template: DataFrameT, n: int, value: object, dtype: str) -> SeriesT:
     """A length-n Series of `value` with a RangeIndex, same engine as template."""
     if is_cudf(template):
         import cudf
@@ -85,7 +89,7 @@ def full(template: Any, n: int, value: Any, dtype: str) -> Any:
     return pd.Series(np.full(n, value, dtype=dtype))
 
 
-def arange(template: Any, n: int, dtype: str = "int32") -> Any:
+def arange(template: DataFrameT, n: int, dtype: str = "int32") -> SeriesT:
     """0..n-1 as a Series, same engine as template."""
     if is_cudf(template):
         import cudf
@@ -97,12 +101,17 @@ def arange(template: Any, n: int, dtype: str = "int32") -> Any:
     return pd.Series(np.arange(n, dtype=dtype))
 
 
-def to_host_int(value: Any) -> int:
+def to_host_int(value: object) -> int:
     """Scalar reduction result -> Python int, on either engine."""
     return int(value)
 
 
-def dense_renumber(edges: Any, src: str, dst: str) -> tuple[Any, Any, int]:
+def dense_renumber(
+    edges: DataFrameT,
+    src: str,
+    dst: str,
+    node_ids: Optional[SeriesT] = None,
+) -> Tuple[DataFrameT, SeriesT, int]:
     """Map vertex ids to a dense 0..V-1 int32 range, monotonically.
 
     Returns (edges_dense, ids, V) where `ids` maps dense id -> original id.
@@ -114,7 +123,7 @@ def dense_renumber(edges: Any, src: str, dst: str) -> tuple[Any, Any, int]:
     semantics without any reference output.
 
     Uses a dense LUT gather rather than two hash joins when the raw id space is
-    small enough to make that cheaper (it is for every dataset we run: cit-Patents
+    compact enough for direct indexing (it is for every dataset we run: cit-Patents
     maxes near 6.0M, graph500-26 at 2**26).
     """
     mod = _mod(edges)
@@ -123,17 +132,24 @@ def dense_renumber(edges: Any, src: str, dst: str) -> tuple[Any, Any, int]:
     du = edges[dst].unique()
     su = su.to_frame(name="id") if hasattr(su, "to_frame") else mod.DataFrame({"id": su})
     du = du.to_frame(name="id") if hasattr(du, "to_frame") else mod.DataFrame({"id": du})
-    ids = concat_frames([su, du])["id"].unique()
+    id_frames = [su, du]
+    if node_ids is not None:
+        nu = node_ids.unique()
+        id_frames.append(nu.to_frame(name="id") if hasattr(nu, "to_frame") else mod.DataFrame({"id": nu}))
+    id_rows = concat_frames(id_frames)
+    if id_rows is None:
+        return edges.reset_index(drop=True), edges[src].iloc[:0].reset_index(drop=True), 0
+    ids = id_rows["id"].unique()
     ids = mod.Series(ids).sort_values().reset_index(drop=True)
     n = len(ids)
 
-    max_id = to_host_int(ids.iloc[n - 1])
-    if max_id < 4 * n and max_id < (1 << 31):
-        # LUT gather: two O(E) gathers instead of two O(E) hash joins.
+    id_kind = getattr(ids.dtype, "kind", "")
+    min_id = to_host_int(ids.iloc[0]) if id_kind in {"i", "u"} else -1
+    max_id = to_host_int(ids.iloc[n - 1]) if id_kind in {"i", "u"} else -1
+    if min_id >= 0 and max_id < 4 * n and max_id < (1 << 31):
+        # The LUT maps both endpoints without hash joins.
         lut = full(edges, max_id + 1, -1, "int32")
-        lut.iloc[ids] = arange(edges, n, "int32").values if not is_cudf(edges) else arange(
-            edges, n, "int32"
-        )
+        lut.iloc[ids] = arange(edges, n, "int32").values if not is_cudf(edges) else arange(edges, n, "int32")
         out = df_cons(
             edges,
             {
@@ -148,6 +164,9 @@ def dense_renumber(edges: Any, src: str, dst: str) -> tuple[Any, Any, int]:
         out = out.merge(lut, left_on=dst, right_on="id", how="left")
         out = out.drop(columns=[dst, "id"]).rename(columns={"dense": dst})
         out = out[[src, dst]].astype("int32")
+
+    for column in (column for column in edges.columns if column not in {src, dst}):
+        out[column] = edges[column].reset_index(drop=True)
 
     return out.reset_index(drop=True), ids, n
 
@@ -172,7 +191,7 @@ def vertex_ranges(v_count: int, chunks: int) -> Iterator[tuple[int, int]]:
         yield a, min(a + step, v_count)
 
 
-def slice_by_key(sorted_edges: Any, key: str, a: int, b: int) -> Any:
+def slice_by_key(sorted_edges: DataFrameT, key: str, a: int, b: int) -> DataFrameT:
     """Rows of a key-sorted frame whose key lies in [a, b), index reset to 0.
 
     The reset is NOT cosmetic. `gather` returns a 0-based Series, so if a slice
@@ -186,18 +205,18 @@ def slice_by_key(sorted_edges: Any, key: str, a: int, b: int) -> Any:
     return sorted_edges.iloc[lo:hi].reset_index(drop=True)
 
 
-def rows(frame: Any, lo: int, hi: int) -> Any:
+def rows(frame: DataFrameT, lo: int, hi: int) -> DataFrameT:
     """Contiguous positional row slice with the index reset. See slice_by_key."""
     return frame.iloc[lo:hi].reset_index(drop=True)
 
 
-def mask_rows(frame: Any, mask: Any) -> Any:
+def mask_rows(frame: DataFrameT, mask: SeriesT) -> DataFrameT:
     """Boolean-filter rows, index reset so later gathers stay aligned."""
     sel = frame[mask.values] if not is_cudf(frame) else frame[mask]
     return sel.reset_index(drop=True)
 
 
-def align(template: Any, v_count: int, res: Any, key: str, value: str, fill: Any) -> Any:
+def align(template: DataFrameT, v_count: int, res: Optional[DataFrameT], key: str, value: str, fill: object) -> SeriesT:
     """A <=V-row groupby result -> a dense V-length positional vector.
 
     `fill` is either a scalar or a dense V-length Series supplying values for
@@ -210,7 +229,7 @@ def align(template: Any, v_count: int, res: Any, key: str, value: str, fill: Any
     return out
 
 
-def u64(value: int) -> Any:
+def u64(value: int) -> object:
     """A uint64 scalar, wrapped mod 2**64.
 
     Plain Python ints above 2**63 raise `OverflowError: Python int too large to
@@ -222,7 +241,7 @@ def u64(value: int) -> Any:
     return np.uint64(value % (1 << 64))
 
 
-def splitmix64(x: Any) -> Any:
+def splitmix64(x: SeriesT) -> SeriesT:
     """SplitMix64 finalizer on a uint64 Series. Wraps identically on both engines."""
     x = x.astype("uint64")
     x = (x ^ (x // u64(1 << 30))) * u64(0xBF58476D1CE4E5B9)

--- a/graphistry/compute/algorithms/_dfops.py
+++ b/graphistry/compute/algorithms/_dfops.py
@@ -22,7 +22,7 @@ Banned in kernels: `.apply`, `groupby().apply`, `idxmin`/`idxmax`, `mode()`,
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Iterator, Mapping, Optional, Sequence, Tuple
+from typing import Iterator, Mapping, Optional, Sequence, SupportsInt, Tuple
 
 import pandas as pd
 
@@ -53,12 +53,12 @@ def df_cons(template: DataFrameT, data: Mapping[str, object]) -> DataFrameT:
 
 def concat_frames(frames: Sequence[Optional[DataFrameT]]) -> Optional[DataFrameT]:
     """Concatenate, dropping the index. Empty-safe."""
-    frames = [f for f in frames if f is not None and len(f) > 0]
-    if not frames:
+    nonempty = [frame for frame in frames if frame is not None and len(frame) > 0]
+    if not nonempty:
         return None
-    if len(frames) == 1:
-        return frames[0].reset_index(drop=True)
-    return _mod(frames[0]).concat(frames, ignore_index=True)
+    if len(nonempty) == 1:
+        return nonempty[0].reset_index(drop=True)
+    return _mod(nonempty[0]).concat(nonempty, ignore_index=True)
 
 
 def gather(vec: SeriesT, idx: SeriesT) -> SeriesT:
@@ -101,7 +101,7 @@ def arange(template: DataFrameT, n: int, dtype: str = "int32") -> SeriesT:
     return pd.Series(np.arange(n, dtype=dtype))
 
 
-def to_host_int(value: object) -> int:
+def to_host_int(value: SupportsInt) -> int:
     """Scalar reduction result -> Python int, on either engine."""
     return int(value)
 

--- a/graphistry/compute/algorithms/_dfops.py
+++ b/graphistry/compute/algorithms/_dfops.py
@@ -1,0 +1,230 @@
+"""Engine-agnostic dataframe primitives for the Graphalytics kernels.
+
+Every function here works identically on pandas and cudf. The engine is inferred
+from the frame you pass in -- callers never name an engine.
+
+Portability rules these primitives exist to enforce (each one is a bug we would
+otherwise hit at 1B edges):
+
+- `Series.__lshift__` and `&` raise TypeError on pandas. Bit-packing uses `*` and
+  `%`, never `<<`/`&`.
+- `cupy.minimum` on a cudf Series returns a cupy array and drops the index, so
+  elementwise min is `a.where(a <= b, b)`, not `np.minimum`/`s_minimum`.
+- pandas `groupby` defaults to `sort=True`, cudf to `sort=False` returning
+  arbitrary order. Always pass `sort=False` explicitly and sort after.
+- uint64 multiply/xor wraps silently and identically in numpy and libcudf; int64
+  overflow warns and Python-int masks upcast. Hashing is uint64 throughout.
+
+Banned in kernels: `.apply`, `groupby().apply`, `idxmin`/`idxmax`, `mode()`,
+`pd.factorize`, `np.*` on Series, `.query`, `Categorical`.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterator, Sequence
+
+import pandas as pd
+
+# 2**32, as a plain Python int. Used for bit-packing via arithmetic.
+SHIFT32 = 1 << 32
+
+
+def is_cudf(obj: Any) -> bool:
+    """True when obj belongs to cudf, without importing cudf on CPU-only hosts."""
+    return type(obj).__module__.split(".")[0] == "cudf"
+
+
+def _mod(frame: Any):
+    """The dataframe module that produced `frame` (pandas or cudf)."""
+    if is_cudf(frame):
+        import cudf
+
+        return cudf
+    return pd
+
+
+def df_cons(template: Any, data: dict) -> Any:
+    """Build a frame of the same engine as `template`."""
+    return _mod(template).DataFrame(data)
+
+
+def concat_frames(frames: Sequence[Any]) -> Any:
+    """Concatenate, dropping the index. Empty-safe."""
+    frames = [f for f in frames if f is not None and len(f) > 0]
+    if not frames:
+        return None
+    if len(frames) == 1:
+        return frames[0].reset_index(drop=True)
+    return _mod(frames[0]).concat(frames, ignore_index=True)
+
+
+def gather(vec: Any, idx: Any) -> Any:
+    """vec[idx] as a positional gather -- O(E), no hash table.
+
+    `vec` must be a dense per-vertex Series indexed 0..V-1 (position == vertex
+    id, which is what dense_renumber guarantees). This is the primitive that
+    replaces `merge(frontier)` in every frontier algorithm; a hash join over 1B
+    rows costs roughly 3x what gather + mask costs.
+    """
+    return vec.take(idx).reset_index(drop=True)
+
+
+def emin(a: Any, b: Any) -> Any:
+    """Elementwise min of two Series, index-preserving on both engines."""
+    return a.where(a <= b, b)
+
+
+def full(template: Any, n: int, value: Any, dtype: str) -> Any:
+    """A length-n Series of `value` with a RangeIndex, same engine as template."""
+    if is_cudf(template):
+        import cudf
+        import cupy
+
+        return cudf.Series(cupy.full(n, value, dtype=dtype))
+    import numpy as np
+
+    return pd.Series(np.full(n, value, dtype=dtype))
+
+
+def arange(template: Any, n: int, dtype: str = "int32") -> Any:
+    """0..n-1 as a Series, same engine as template."""
+    if is_cudf(template):
+        import cudf
+        import cupy
+
+        return cudf.Series(cupy.arange(n, dtype=dtype))
+    import numpy as np
+
+    return pd.Series(np.arange(n, dtype=dtype))
+
+
+def to_host_int(value: Any) -> int:
+    """Scalar reduction result -> Python int, on either engine."""
+    return int(value)
+
+
+def dense_renumber(edges: Any, src: str, dst: str) -> tuple[Any, Any, int]:
+    """Map vertex ids to a dense 0..V-1 int32 range, monotonically.
+
+    Returns (edges_dense, ids, V) where `ids` maps dense id -> original id.
+
+    The mapping is MONOTONE (built from sorted uniques), so min(dense id)
+    corresponds to min(original id). That is what lets WCC's "label = min vertex
+    id in component" and CDLP's "tie-break to smallest label" be computed on
+    dense ids and still mean the same thing -- and it lets us assert LDBC's label
+    semantics without any reference output.
+
+    Uses a dense LUT gather rather than two hash joins when the raw id space is
+    small enough to make that cheaper (it is for every dataset we run: cit-Patents
+    maxes near 6.0M, graph500-26 at 2**26).
+    """
+    mod = _mod(edges)
+    # Never concat the E-length columns; unique() first keeps this at <= 2V rows.
+    su = edges[src].unique()
+    du = edges[dst].unique()
+    su = su.to_frame(name="id") if hasattr(su, "to_frame") else mod.DataFrame({"id": su})
+    du = du.to_frame(name="id") if hasattr(du, "to_frame") else mod.DataFrame({"id": du})
+    ids = concat_frames([su, du])["id"].unique()
+    ids = mod.Series(ids).sort_values().reset_index(drop=True)
+    n = len(ids)
+
+    max_id = to_host_int(ids.iloc[n - 1])
+    if max_id < 4 * n and max_id < (1 << 31):
+        # LUT gather: two O(E) gathers instead of two O(E) hash joins.
+        lut = full(edges, max_id + 1, -1, "int32")
+        lut.iloc[ids] = arange(edges, n, "int32").values if not is_cudf(edges) else arange(
+            edges, n, "int32"
+        )
+        out = df_cons(
+            edges,
+            {
+                src: gather(lut, edges[src]).astype("int32"),
+                dst: gather(lut, edges[dst]).astype("int32"),
+            },
+        )
+    else:
+        lut = df_cons(edges, {"id": ids, "dense": arange(edges, n, "int32")})
+        out = edges[[src, dst]].merge(lut, left_on=src, right_on="id", how="left")
+        out = out.drop(columns=[src, "id"]).rename(columns={"dense": src})
+        out = out.merge(lut, left_on=dst, right_on="id", how="left")
+        out = out.drop(columns=[dst, "id"]).rename(columns={"dense": dst})
+        out = out[[src, dst]].astype("int32")
+
+    return out.reset_index(drop=True), ids, n
+
+
+def chunk_bounds(n_rows: int, chunks: int) -> Iterator[tuple[int, int]]:
+    """Contiguous [lo, hi) row ranges. `iloc` slices of these are views."""
+    if chunks <= 1:
+        yield 0, n_rows
+        return
+    step = (n_rows + chunks - 1) // chunks
+    for lo in range(0, n_rows, step):
+        yield lo, min(lo + step, n_rows)
+
+
+def vertex_ranges(v_count: int, chunks: int) -> Iterator[tuple[int, int]]:
+    """Contiguous [a, b) vertex-id ranges."""
+    if chunks <= 1:
+        yield 0, v_count
+        return
+    step = (v_count + chunks - 1) // chunks
+    for a in range(0, v_count, step):
+        yield a, min(a + step, v_count)
+
+
+def slice_by_key(sorted_edges: Any, key: str, a: int, b: int) -> Any:
+    """Rows of a key-sorted frame whose key lies in [a, b), index reset to 0.
+
+    The reset is NOT cosmetic. `gather` returns a 0-based Series, so if a slice
+    kept its original index (lo..hi-1) then `df_cons(e, {'v': e[key], 'p':
+    gather(...)})` would align on index and silently fill NaN for every row --
+    a bug that appears only once chunking is switched on, i.e. only at scale.
+    """
+    col = sorted_edges[key]
+    lo = to_host_int(col.searchsorted(a, side="left"))
+    hi = to_host_int(col.searchsorted(b, side="left"))
+    return sorted_edges.iloc[lo:hi].reset_index(drop=True)
+
+
+def rows(frame: Any, lo: int, hi: int) -> Any:
+    """Contiguous positional row slice with the index reset. See slice_by_key."""
+    return frame.iloc[lo:hi].reset_index(drop=True)
+
+
+def mask_rows(frame: Any, mask: Any) -> Any:
+    """Boolean-filter rows, index reset so later gathers stay aligned."""
+    sel = frame[mask.values] if not is_cudf(frame) else frame[mask]
+    return sel.reset_index(drop=True)
+
+
+def align(template: Any, v_count: int, res: Any, key: str, value: str, fill: Any) -> Any:
+    """A <=V-row groupby result -> a dense V-length positional vector.
+
+    `fill` is either a scalar or a dense V-length Series supplying values for
+    vertices absent from `res` (e.g. keep-your-own-label).
+    """
+    out = fill.copy() if hasattr(fill, "copy") else full(template, v_count, fill, "float64")
+    if res is None or len(res) == 0:
+        return out
+    out.iloc[res[key]] = res[value].values if not is_cudf(res) else res[value]
+    return out
+
+
+def u64(value: int) -> Any:
+    """A uint64 scalar, wrapped mod 2**64.
+
+    Plain Python ints above 2**63 raise `OverflowError: Python int too large to
+    convert to C long` when combined with a uint64 Series, so every large
+    constant in the hashing path goes through here.
+    """
+    import numpy as np
+
+    return np.uint64(value % (1 << 64))
+
+
+def splitmix64(x: Any) -> Any:
+    """SplitMix64 finalizer on a uint64 Series. Wraps identically on both engines."""
+    x = x.astype("uint64")
+    x = (x ^ (x // u64(1 << 30))) * u64(0xBF58476D1CE4E5B9)
+    x = (x ^ (x // u64(1 << 27))) * u64(0x94D049BB133111EB)
+    return x ^ (x // u64(1 << 31))

--- a/graphistry/compute/algorithms/compute.py
+++ b/graphistry/compute/algorithms/compute.py
@@ -8,9 +8,11 @@ service `compute_cugraph` performs for cuGraph's own renumbering.
 
 from __future__ import annotations
 
-from typing import Mapping, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping, Optional
 
-from ._dfops import dense_renumber, to_host_int
+from graphistry.compute.typing import DataFrameT, SeriesT
+
+from ._dfops import arange, dense_renumber, df_cons, full, to_host_int
 from .registry import STD_ALGS, output_column, run as _run_alg
 
 if TYPE_CHECKING:
@@ -18,6 +20,52 @@ if TYPE_CHECKING:
 
 # Algorithms whose output values are themselves vertex ids.
 _LABEL_IS_VERTEX_ID = frozenset({"wcc", "cdlp"})
+
+
+def _pagerank_vertex_values(
+    value: object,
+    ids: SeriesT,
+    template: DataFrameT,
+    value_column: str,
+    name: str,
+    fill_missing: bool,
+) -> SeriesT:
+    if isinstance(value, Mapping):
+        frame = df_cons(
+            template,
+            {"vertex": list(value.keys()), value_column: list(value.values())},
+        )
+    elif isinstance(value, (list, tuple)) or hasattr(value, "columns"):
+        frame = type(template)(value)
+    else:
+        raise ValueError(
+            f"PageRank {name} must be a vertex-to-value map, record list, or dataframe"
+        )
+    required = {"vertex", value_column}
+    if not required.issubset(frame.columns):
+        raise ValueError(
+            f"PageRank {name} requires columns {sorted(required)}, got {list(frame.columns)}"
+        )
+    frame = frame[["vertex", value_column]].reset_index(drop=True)
+    if to_host_int(frame["vertex"].duplicated().sum()) != 0:
+        raise ValueError(f"PageRank {name} contains duplicate vertices")
+
+    lookup = df_cons(
+        template,
+        {
+            "vertex": ids.reset_index(drop=True),
+            "__dense": arange(template, len(ids), "int32"),
+        },
+    )
+    tagged = frame.merge(lookup, on="vertex", how="left")
+    unknown = to_host_int(tagged["__dense"].isna().sum())
+    if unknown:
+        raise ValueError(
+            f"PageRank {name} contains {unknown} unknown graph vertex value(s)"
+        )
+    aligned = lookup.merge(frame, on="vertex", how="left").sort_values("__dense")
+    out = aligned[value_column].reset_index(drop=True).astype("float64")
+    return out.fillna(0.0) if fill_missing else out
 
 
 def compute_std(
@@ -28,17 +76,39 @@ def compute_std(
 ) -> "Plottable":
     """Run `alg` and return a new Plottable with the result bound to nodes."""
     if alg not in STD_ALGS:
-        raise ValueError(f"unknown graphistry.std procedure {alg!r}; known: {sorted(STD_ALGS)}")
+        raise ValueError(
+            f"unknown graphistry.std procedure {alg!r}; known: {sorted(STD_ALGS)}"
+        )
     g = self.materialize_nodes()
     src, dst, node = g._source, g._destination, g._node
     if src is None or dst is None or node is None:
-        raise ValueError("graphistry.std requires source, destination, and node bindings")
+        raise ValueError(
+            "graphistry.std requires source, destination, and node bindings"
+        )
     options = dict(params or {})
+    converged_col: Optional[str] = None
+    if alg == "pagerank":
+        converged_value = options.pop("converged_col", None)
+        if converged_value is not None:
+            if not isinstance(converged_value, str) or not converged_value:
+                raise ValueError(
+                    "PageRank converged_col must be a non-empty string"
+                )
+            if options.get("fail_on_nonconvergence", True) is not False:
+                raise ValueError(
+                    "PageRank converged_col requires fail_on_nonconvergence=False"
+                )
+            converged_col = converged_value
+        if options.get("weight") is None and g._edge_weight is not None:
+            options["weight"] = g._edge_weight
+
     edge_columns = [src, dst]
-    if alg == "sssp" and options.get("weight") is not None:
+    if alg in {"sssp", "pagerank"} and options.get("weight") is not None:
         weight = options["weight"]
         if not isinstance(weight, str) or weight not in g._edges.columns:
-            raise ValueError(f"SSSP weight must name an edge column, got {weight!r}")
+            raise ValueError(
+                f"{alg} weight must name an edge column, got {weight!r}"
+            )
         edge_columns.append(weight)
     edges = g._edges[edge_columns]
     if alg == "mis":
@@ -51,20 +121,52 @@ def compute_std(
             dense_source = to_host_int(ids.searchsorted(source))
         except (TypeError, ValueError):
             dense_source = -1
-        if dense_source < 0 or dense_source >= v_count or ids.iloc[dense_source] != source:
+        if (
+            dense_source < 0
+            or dense_source >= v_count
+            or ids.iloc[dense_source] != source
+        ):
             raise ValueError(f"SSSP source {source!r} is not a graph node")
         options["source"] = dense_source
-    result = _run_alg(dense, src, dst, v_count, alg, options)
+    if alg == "pagerank":
+        for name, value_column, fill_missing in (
+            ("personalization", "values", True),
+            ("nstart", "values", True),
+            ("precomputed_vertex_out_weight", "sums", False),
+        ):
+            value = options.get(name)
+            if value is not None:
+                options[name] = _pagerank_vertex_values(
+                    value, ids, dense, value_column, name, fill_missing
+                )
+
+    outcome = _run_alg(dense, src, dst, v_count, alg, options)
+    converged: Optional[bool] = None
+    if isinstance(outcome, tuple):
+        result, converged = outcome
+    else:
+        result = outcome
 
     # WCC/CDLP labels are vertex IDs and must return to the caller ID space.
     if alg in _LABEL_IS_VERTEX_ID:
         result = ids.reset_index(drop=True).take(result.reset_index(drop=True))
 
     col = out_col or output_column(alg)
-    # Pair dense-to-original IDs positionally with per-vertex results.
-    mapping = type(g._nodes)({node: ids, col: result.reset_index(drop=True)})
+    if converged_col in {node, col}:
+        raise ValueError(
+            "PageRank converged_col must differ from node and result columns"
+        )
+    mapping_data = {node: ids, col: result.reset_index(drop=True)}
+    if converged_col is not None:
+        if converged is None:
+            raise AssertionError("PageRank convergence status was not returned")
+        mapping_data[converged_col] = full(dense, v_count, converged, "bool")
+    mapping = type(g._nodes)(mapping_data)
 
     nodes = g._nodes
-    if col in nodes.columns:
-        nodes = nodes.drop(columns=[col])
+    replace_columns = [
+        name for name in (col, converged_col) if name in nodes.columns
+    ]
+    if replace_columns:
+        nodes = nodes.drop(columns=replace_columns)
     return g.nodes(nodes.merge(mapping, on=node, how="left"))

--- a/graphistry/compute/algorithms/compute.py
+++ b/graphistry/compute/algorithms/compute.py
@@ -1,50 +1,65 @@
-"""`g.compute_std(alg)` -- run a std kernel on a Plottable and bind the result.
+"""GFQL adapter for running a std kernel and binding its node result.
 
 The kernels require dense int32 vertex ids 0..V-1 (that is what makes their
 frontier expansion a positional gather rather than a hash join). Real graphs
 have arbitrary ids, so this layer renumbers, runs, and maps back -- the same
 service `compute_cugraph` performs for cuGraph's own renumbering.
 """
+
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional
+from typing import Mapping, Optional, TYPE_CHECKING
 
-from ._dfops import dense_renumber
+from ._dfops import dense_renumber, to_host_int
 from .registry import STD_ALGS, output_column, run as _run_alg
+
+if TYPE_CHECKING:
+    from graphistry.Plottable import Plottable
 
 # Algorithms whose output values are themselves vertex ids.
 _LABEL_IS_VERTEX_ID = frozenset({"wcc", "cdlp"})
 
 
 def compute_std(
-    self: Any,
+    self: "Plottable",
     alg: str,
     out_col: Optional[str] = None,
-    params: Optional[Mapping[str, Any]] = None,
-) -> Any:
+    params: Optional[Mapping[str, object]] = None,
+) -> "Plottable":
     """Run `alg` and return a new Plottable with the result bound to nodes."""
     if alg not in STD_ALGS:
-        raise ValueError(
-            f"unknown graphistry.std procedure {alg!r}; known: {sorted(STD_ALGS)}"
-        )
+        raise ValueError(f"unknown graphistry.std procedure {alg!r}; known: {sorted(STD_ALGS)}")
     g = self.materialize_nodes()
     src, dst, node = g._source, g._destination, g._node
-    edges = g._edges[[src, dst]]
+    options = dict(params or {})
+    edge_columns = [src, dst]
+    if alg == "sssp" and options.get("weight") is not None:
+        weight = options["weight"]
+        if not isinstance(weight, str) or weight not in g._edges.columns:
+            raise ValueError(f"SSSP weight must name an edge column, got {weight!r}")
+        edge_columns.append(weight)
+    edges = g._edges[edge_columns]
+    if alg == "mis":
+        edges = edges[edges[src] != edges[dst]].reset_index(drop=True)
 
-    dense, ids, v_count = dense_renumber(edges, src, dst)
-    result = _run_alg(dense, src, dst, v_count, alg, params)
+    dense, ids, v_count = dense_renumber(edges, src, dst, g._nodes[node])
+    if alg == "sssp" and "source" in options:
+        source = options["source"]
+        try:
+            dense_source = to_host_int(ids.searchsorted(source))
+        except (TypeError, ValueError):
+            dense_source = -1
+        if dense_source < 0 or dense_source >= v_count or ids.iloc[dense_source] != source:
+            raise ValueError(f"SSSP source {source!r} is not a graph node")
+        options["source"] = dense_source
+    result = _run_alg(dense, src, dst, v_count, alg, options)
 
-    # WCC and CDLP results ARE vertex ids (the component/community label is the
-    # minimum member id), so they must be mapped back to the caller's id space
-    # too -- not just the row order. Monotone renumbering means the dense label
-    # and the original label denote the same vertex, but a user comparing a
-    # label against their own node ids needs the original.
+    # WCC/CDLP labels are vertex IDs and must return to the caller ID space.
     if alg in _LABEL_IS_VERTEX_ID:
         result = ids.reset_index(drop=True).take(result.reset_index(drop=True))
 
     col = out_col or output_column(alg)
-    # `ids` maps dense id -> original id, so pairing them positionally maps the
-    # per-vertex result back onto the caller's node ids.
+    # Pair dense-to-original IDs positionally with per-vertex results.
     mapping = type(g._nodes)({node: ids, col: result.reset_index(drop=True)})
 
     nodes = g._nodes

--- a/graphistry/compute/algorithms/compute.py
+++ b/graphistry/compute/algorithms/compute.py
@@ -31,6 +31,8 @@ def compute_std(
         raise ValueError(f"unknown graphistry.std procedure {alg!r}; known: {sorted(STD_ALGS)}")
     g = self.materialize_nodes()
     src, dst, node = g._source, g._destination, g._node
+    if src is None or dst is None or node is None:
+        raise ValueError("graphistry.std requires source, destination, and node bindings")
     options = dict(params or {})
     edge_columns = [src, dst]
     if alg == "sssp" and options.get("weight") is not None:

--- a/graphistry/compute/algorithms/compute.py
+++ b/graphistry/compute/algorithms/compute.py
@@ -1,0 +1,53 @@
+"""`g.compute_std(alg)` -- run a std kernel on a Plottable and bind the result.
+
+The kernels require dense int32 vertex ids 0..V-1 (that is what makes their
+frontier expansion a positional gather rather than a hash join). Real graphs
+have arbitrary ids, so this layer renumbers, runs, and maps back -- the same
+service `compute_cugraph` performs for cuGraph's own renumbering.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from ._dfops import dense_renumber
+from .registry import STD_ALGS, output_column, run as _run_alg
+
+# Algorithms whose output values are themselves vertex ids.
+_LABEL_IS_VERTEX_ID = frozenset({"wcc", "cdlp"})
+
+
+def compute_std(
+    self: Any,
+    alg: str,
+    out_col: Optional[str] = None,
+    params: Optional[Mapping[str, Any]] = None,
+) -> Any:
+    """Run `alg` and return a new Plottable with the result bound to nodes."""
+    if alg not in STD_ALGS:
+        raise ValueError(
+            f"unknown graphistry.std procedure {alg!r}; known: {sorted(STD_ALGS)}"
+        )
+    g = self.materialize_nodes()
+    src, dst, node = g._source, g._destination, g._node
+    edges = g._edges[[src, dst]]
+
+    dense, ids, v_count = dense_renumber(edges, src, dst)
+    result = _run_alg(dense, src, dst, v_count, alg, params)
+
+    # WCC and CDLP results ARE vertex ids (the component/community label is the
+    # minimum member id), so they must be mapped back to the caller's id space
+    # too -- not just the row order. Monotone renumbering means the dense label
+    # and the original label denote the same vertex, but a user comparing a
+    # label against their own node ids needs the original.
+    if alg in _LABEL_IS_VERTEX_ID:
+        result = ids.reset_index(drop=True).take(result.reset_index(drop=True))
+
+    col = out_col or output_column(alg)
+    # `ids` maps dense id -> original id, so pairing them positionally maps the
+    # per-vertex result back onto the caller's node ids.
+    mapping = type(g._nodes)({node: ids, col: result.reset_index(drop=True)})
+
+    nodes = g._nodes
+    if col in nodes.columns:
+        nodes = nodes.drop(columns=[col])
+    return g.nodes(nodes.merge(mapping, on=node, how="left"))

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -1,0 +1,411 @@
+"""LDBC-Graphalytics-style graph kernels as engine-agnostic dataframe code.
+
+One implementation runs on both pandas and cudf; the engine is inferred from the
+frame you pass in. Every kernel takes a dense-renumbered int32 edge frame (see
+`dfops.dense_renumber`) and returns a dense per-vertex result Series.
+
+Three formulation decisions carry the entire memory budget at 1B edges:
+
+1. The symmetrized (2E) edge list is NEVER materialized. Undirected kernels
+   symmetrize at aggregation time via two direction-keyed groupbys over the same
+   E-row frame.
+2. Vertex ids are dense int32 and per-vertex state is positional, so frontier
+   expansion is `gather(vec, edges[src])` + a boolean mask rather than a hash
+   join over the edge list.
+3. CDLP's "most frequent label, ties to smallest" is a single groupby-max over a
+   packed key, not a global sort.
+
+Four of the five kernels are hand-written rather than delegated because cuGraph
+and igraph do not implement the LDBC semantics: PageRank there runs to a
+tolerance while LDBC fixes the iteration count, cuGraph has no label propagation
+at all, and neither has a usable MIS. cuGraph is used as an *oracle* for WCC and
+SSSP, where it is exact.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ._dfops import (
+    SHIFT32,
+    align,
+    arange,
+    chunk_bounds,
+    concat_frames,
+    df_cons,
+    emin,
+    full,
+    gather,
+    is_cudf,
+    mask_rows,
+    rows,
+    slice_by_key,
+    splitmix64,
+    to_host_int,
+    u64,
+    vertex_ranges,
+)
+
+
+class ConvergenceError(RuntimeError):
+    """A kernel hit its iteration cap without converging."""
+
+
+def _sorted_copies(edges: Any, src: str, dst: str) -> tuple[Any, Any]:
+    """Two sorted copies of the edge frame: by src and by dst.
+
+    Costs 2x the edge frame resident (16.8 GB at E=1.05B, int32) and buys free
+    contiguous-slice chunking by vertex range, key-disjoint partial aggregates,
+    and a stable deterministic row order. Sorting happens once, never in a loop.
+    """
+    return (
+        edges.sort_values(src).reset_index(drop=True),
+        edges.sort_values(dst).reset_index(drop=True),
+    )
+
+
+def _sym_min(
+    by_src: Any, by_dst: Any, src: str, dst: str, vec: Any, v_count: int, chunks: int
+) -> Any:
+    """min over the undirected neighborhood, without materializing 2E rows.
+
+    For a vertex range [a,b) every out-edge is a contiguous slice of the
+    src-sorted copy and every in-edge a contiguous slice of the dst-sorted copy,
+    so the chunk sees each vertex's COMPLETE neighbor set and the per-chunk
+    results are key-disjoint -- the combine is a concat, not a second reduce.
+    """
+    outs = []
+    for a, b in vertex_ranges(v_count, chunks):
+        ea = slice_by_key(by_src, src, a, b)
+        eb = slice_by_key(by_dst, dst, a, b)
+        if len(ea):
+            outs.append(
+                df_cons(ea, {"v": ea[src], "p": gather(vec, ea[dst])})
+                .groupby("v", sort=False)["p"]
+                .min()
+                .reset_index()
+            )
+        if len(eb):
+            outs.append(
+                df_cons(eb, {"v": eb[dst], "p": gather(vec, eb[src])})
+                .groupby("v", sort=False)["p"]
+                .min()
+                .reset_index()
+            )
+    res = concat_frames(outs)
+    if res is None:
+        return None
+    # Chunks are key-disjoint, but the two DIRECTIONS within a chunk are not.
+    return res.groupby("v", sort=False)["p"].min().reset_index()
+
+
+def wcc(edges: Any, src: str, dst: str, v_count: int, chunks: int = 1, max_iter: int = 1000) -> Any:
+    """Weakly connected components, LDBC label = min original vertex id.
+
+    Shiloach-Vishkin min-label propagation with pointer jumping. Because
+    `dense_renumber` is monotone, the dense min-label IS the min original id, so
+    the LDBC label semantics can be asserted directly with no reference output.
+
+    Pointer jumping is what makes this O(log V) rather than O(diameter) -- it is
+    the difference between ~6 iterations and hundreds on a long-path graph.
+    """
+    by_src, by_dst = _sorted_copies(edges, src, dst)
+    lbl = arange(edges, v_count, "int32")
+
+    for it in range(max_iter):
+        cand = _sym_min(by_src, by_dst, src, dst, lbl, v_count, chunks)
+        new = align(edges, v_count, cand, "v", "p", lbl)
+        new = emin(new, lbl).astype("int32")
+        # Path compression: label[v] <- label[label[v]].
+        for _ in range(2):
+            new = gather(new, new).astype("int32")
+            new = emin(new, lbl).astype("int32")
+        if to_host_int((new != lbl).sum()) == 0:
+            return lbl
+        lbl = new
+
+    raise ConvergenceError(f"wcc did not converge in {max_iter} iterations")
+
+
+def pagerank(
+    edges: Any,
+    src: str,
+    dst: str,
+    v_count: int,
+    iterations: int = 10,
+    damping: float = 0.85,
+    chunks: int = 1,
+) -> Any:
+    """LDBC PageRank: FIXED iteration count, dangling mass redistributed uniformly.
+
+    There is deliberately no early exit. With d=0.85 and K=10, d^K ~ 0.197, so a
+    fixed-K vector differs materially from a converged one -- which is exactly
+    why `cugraph.pagerank` and `igraph.pagerank` cannot serve as oracles here.
+
+    Chunking is by DST so partial results are key-disjoint and the combine is a
+    concat rather than a second groupby.
+    """
+    _, by_dst = _sorted_copies(edges, src, dst)
+
+    deg = edges.groupby(src, sort=False).size().reset_index(name="__deg")
+    outdeg = align(edges, v_count, deg, src, "__deg", full(edges, v_count, 0, "int64"))
+    dangling = outdeg == 0
+
+    pr = full(edges, v_count, 1.0 / v_count, "float64")
+    d = float(damping)
+
+    for _ in range(iterations):
+        safe_deg = outdeg.where(~dangling, 1)
+        contrib = (pr / safe_deg).where(~dangling, 0.0)
+        dang = float(pr.where(dangling, 0.0).sum())
+
+        outs = []
+        for lo, hi in chunk_bounds(len(by_dst), chunks):
+            e = rows(by_dst, lo, hi)
+            msg = gather(contrib, e[src])
+            outs.append(
+                df_cons(e, {"v": e[dst], "m": msg})
+                .groupby("v", sort=False)["m"]
+                .sum()
+                .reset_index()
+            )
+        res = concat_frames(outs)
+        if res is not None and chunks > 1:
+            # Row-chunking by dst can split a dst group across a boundary.
+            res = res.groupby("v", sort=False)["m"].sum().reset_index()
+        inflow = align(edges, v_count, res, "v", "m", full(edges, v_count, 0.0, "float64"))
+
+        pr = (1.0 - d) / v_count + d * (inflow + dang / v_count)
+
+        # Mass conservation is a free bug detector for the dangling term.
+        total = float(pr.sum())
+        if abs(total - 1.0) > 1e-9:
+            raise AssertionError(f"pagerank mass not conserved: sum={total!r}")
+
+    return pr
+
+
+def cdlp(
+    edges: Any,
+    src: str,
+    dst: str,
+    v_count: int,
+    iterations: int = 10,
+    chunks: int = 1,
+) -> Any:
+    """LDBC community detection by label propagation.
+
+    Synchronous, fixed iteration count, undirected, MULTISET semantics (parallel
+    edges count multiple times), most frequent label wins, ties break to the
+    smallest label.
+
+    The tie-break is done by maximizing a packed key `count*2^32 + (LMAX-label)`
+    in a single groupby-max. That maximizes count and, among equal counts,
+    minimizes label -- replacing a global `sort_values` that costs ~17 GB at
+    graph500-26 (~34 GB with cuDF's sort overhead) with one O(V)-output pass.
+    Being order-independent, it is also bitwise deterministic across engines.
+
+    No early exit: synchronous label propagation can oscillate with period 2, so
+    "no change" may never occur. The spec is K iterations regardless.
+    """
+    by_src, by_dst = _sorted_copies(edges, src, dst)
+    lmax = v_count - 1
+    lbl = arange(edges, v_count, "int32")
+
+    for _ in range(iterations):
+        outs = []
+        for a, b in vertex_ranges(v_count, chunks):
+            ea = slice_by_key(by_src, src, a, b)
+            eb = slice_by_key(by_dst, dst, a, b)
+            parts = []
+            if len(ea):
+                parts.append(df_cons(ea, {"v": ea[src], "l": gather(lbl, ea[dst])}))
+            if len(eb):
+                parts.append(df_cons(eb, {"v": eb[dst], "l": gather(lbl, eb[src])}))
+            pair = concat_frames(parts)
+            if pair is None:
+                continue
+            cnt = pair.groupby(["v", "l"], sort=False).size().reset_index(name="c")
+            key = cnt["c"].astype("int64") * SHIFT32 + (lmax - cnt["l"].astype("int64"))
+            cnt = df_cons(cnt, {"v": cnt["v"], "key": key})
+            outs.append(cnt.groupby("v", sort=False)["key"].max().reset_index())
+            del pair, cnt
+
+        win = concat_frames(outs)
+        if win is None:
+            break
+        win = win.groupby("v", sort=False)["key"].max().reset_index()
+        best = df_cons(win, {"v": win["v"], "l": (lmax - (win["key"] % SHIFT32)).astype("int32")})
+        # Isolated vertices are absent from `best` and keep their own label.
+        lbl = align(edges, v_count, best, "v", "l", lbl).astype("int32")
+
+    return lbl
+
+
+def sssp(
+    edges: Any,
+    src: str,
+    dst: str,
+    weight: str,
+    v_count: int,
+    source: int,
+    chunks: int = 1,
+    max_iter: Optional[int] = None,
+) -> Any:
+    """Weighted single-source shortest path, frontier Bellman-Ford.
+
+    Relaxation is gather + boolean mask, not a per-hop hash join against the
+    frontier. With small integer weights (see `make_weights`) all distances stay
+    integral and well under 2^24, so float32 sums are EXACT -- which is what
+    makes bitwise equality against `cugraph.sssp` an achievable validation gate.
+    """
+    by_src, _ = _sorted_copies(edges, src, dst)
+    # V-1 relaxation rounds suffice, plus one more to observe no-change and exit.
+    cap = max_iter if max_iter is not None else max(v_count, 2)
+
+    inf = float("inf")
+    dist = full(edges, v_count, inf, "float32")
+    dist.iloc[source] = 0.0
+    frontier = full(edges, v_count, False, "bool")
+    frontier.iloc[source] = True
+
+    for _ in range(cap):
+        if not bool(frontier.any()):
+            return dist
+        outs = []
+        for lo, hi in chunk_bounds(len(by_src), chunks):
+            e = rows(by_src, lo, hi)
+            mask = gather(frontier, e[src])
+            e = mask_rows(e, mask)
+            if len(e) == 0:
+                continue
+            nd = gather(dist, e[src]) + e[weight].reset_index(drop=True).astype("float32")
+            outs.append(
+                df_cons(e, {"v": e[dst], "d": nd}).groupby("v", sort=False)["d"].min().reset_index()
+            )
+        res = concat_frames(outs)
+        if res is None:
+            return dist
+        res = res.groupby("v", sort=False)["d"].min().reset_index()
+
+        cur = gather(dist, res["v"])
+        improved = res[(res["d"].reset_index(drop=True) < cur).values if not is_cudf(res) else (res["d"].reset_index(drop=True) < cur)]
+        if len(improved) == 0:
+            return dist
+        dist = align(edges, v_count, improved, "v", "d", dist).astype("float32")
+        frontier = full(edges, v_count, False, "bool")
+        frontier.iloc[improved["v"]] = True
+
+    raise ConvergenceError(f"sssp did not settle in {cap} iterations")
+
+
+def make_weights(edges: Any, src: str, dst: str) -> Any:
+    """Deterministic integer edge weights in [1, 255] as float32.
+
+    Pure integer arithmetic in uint64 so both engines produce bitwise identical
+    weights. Small integer weights keep every path distance exactly representable
+    in float32, which is what lets SSSP be validated by exact equality.
+    """
+    u = edges[src].astype("uint64")
+    v = edges[dst].astype("uint64")
+    h = splitmix64(u * u64(0x9E3779B97F4A7C15) + v * u64(0xC2B2AE3D27D4EB4F))
+    return (h % u64(255) + u64(1)).astype("float32")
+
+
+def mis(
+    edges: Any, src: str, dst: str, v_count: int, seed: int = 0x5EED, chunks: int = 1,
+    max_rounds: int = 200,
+) -> Any:
+    """Maximal independent set, Luby's algorithm.
+
+    NOTE: MIS is not one of the six official LDBC Graphalytics kernels
+    (BFS/PR/WCC/CDLP/LCC/SSSP), so there is no reference output and no canonical
+    variant. This is Luby's random-priority form; a greedy-by-id MIS would give a
+    different set at a very different cost.
+
+    Priority is a packed `(hash32, vertex_id)` giving a STRICT TOTAL ORDER, so
+    there are no ties, so at least one vertex joins per active component per
+    round -- termination is guaranteed, in O(log V) rounds expected. The uint64
+    hash wraps identically on both engines, making the result bitwise
+    reproducible; that is what substitutes for the missing reference output.
+
+    Self-loops MUST be dropped before calling (a self-looped vertex trivially
+    violates independence) and isolated vertices MUST start in the set (else
+    maximality fails).
+    """
+    by_src, by_dst = _sorted_copies(edges, src, dst)
+    vid = arange(edges, v_count, "int64")
+
+    deg_s = edges.groupby(src, sort=False).size().reset_index(name="__deg")
+    deg_d = edges.groupby(dst, sort=False).size().reset_index(name="__deg")
+    zero = full(edges, v_count, 0, "int64")
+    deg = align(edges, v_count, deg_s, src, "__deg", zero) + align(edges, v_count, deg_d, dst, "__deg", zero)
+
+    in_set = deg == 0          # isolated vertices are in the set
+    active = ~in_set
+    uint_max = u64((1 << 64) - 1)
+
+    for r in range(max_rounds):
+        if not bool(active.any()):
+            return in_set
+
+        h = splitmix64(vid.astype("uint64") ^ u64(seed + r * 0x9E3779B97F4A7C15))
+        prio = (h % u64(SHIFT32)) * u64(SHIFT32) + vid.astype("uint64")
+        prio = prio.where(active, uint_max)
+
+        minnbr = _sym_min_active(by_src, by_dst, src, dst, prio, active, v_count, chunks)
+        minnbr = align(edges, v_count, minnbr, "v", "p", full(edges, v_count, uint_max, "uint64"))
+
+        joins = active & (prio < minnbr)
+        if not bool(joins.any()):
+            raise ConvergenceError("mis round produced no joiners; priority order is not total")
+        in_set = in_set | joins
+
+        nbr_joined = _sym_any(by_src, by_dst, src, dst, joins, v_count, chunks)
+        nbr_joined = align(edges, v_count, nbr_joined, "v", "p", full(edges, v_count, 0, "int8"))
+        active = active & ~joins & (nbr_joined == 0)
+
+    raise ConvergenceError(f"mis did not terminate in {max_rounds} rounds")
+
+
+def _sym_min_active(
+    by_src: Any, by_dst: Any, src: str, dst: str, vec: Any, active: Any, v_count: int, chunks: int
+) -> Any:
+    """min of `vec` over ACTIVE undirected neighbours, chunked by vertex range."""
+    outs = []
+    for a, b in vertex_ranges(v_count, chunks):
+        for frame, key, other in ((by_src, src, dst), (by_dst, dst, src)):
+            e = slice_by_key(frame, key, a, b)
+            if len(e) == 0:
+                continue
+            keep = gather(active, e[key]) & gather(active, e[other])
+            e = mask_rows(e, keep)
+            if len(e) == 0:
+                continue
+            outs.append(
+                df_cons(e, {"v": e[key], "p": gather(vec, e[other])})
+                .groupby("v", sort=False)["p"]
+                .min()
+                .reset_index()
+            )
+    res = concat_frames(outs)
+    return None if res is None else res.groupby("v", sort=False)["p"].min().reset_index()
+
+
+def _sym_any(
+    by_src: Any, by_dst: Any, src: str, dst: str, flag: Any, v_count: int, chunks: int
+) -> Any:
+    """1 where any undirected neighbour has `flag` set."""
+    outs = []
+    for a, b in vertex_ranges(v_count, chunks):
+        for frame, key, other in ((by_src, src, dst), (by_dst, dst, src)):
+            e = slice_by_key(frame, key, a, b)
+            if len(e) == 0:
+                continue
+            outs.append(
+                df_cons(e, {"v": e[key], "p": gather(flag, e[other]).astype("int8")})
+                .groupby("v", sort=False)["p"]
+                .max()
+                .reset_index()
+            )
+    res = concat_frames(outs)
+    return None if res is None else res.groupby("v", sort=False)["p"].max().reset_index()

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -263,7 +263,8 @@ def pagerank(
         total = float(new.sum())
         if abs(total - 1.0) > 1e-9:
             raise AssertionError(f"pagerank mass not conserved: sum={total!r}")
-        converged = float(abs(new - pr).sum()) < v_count * float(tol)
+        # Unit-mass ranks make public cuGraph tolerance equivalent to L1 delta < tol.
+        converged = float(abs(new - pr).sum()) < float(tol)
         pr = new
         if stopping == "convergence" and converged:
             return (pr, True) if not fail_on_nonconvergence else pr

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -21,9 +21,12 @@ tolerance while LDBC fixes the iteration count, cuGraph has no label propagation
 at all, and neither has a usable MIS. cuGraph is used as an *oracle* for WCC and
 SSSP, where it is exact.
 """
+
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
+
+from graphistry.compute.typing import DataFrameT, SeriesT
 
 from ._dfops import (
     SHIFT32,
@@ -50,7 +53,7 @@ class ConvergenceError(RuntimeError):
     """A kernel hit its iteration cap without converging."""
 
 
-def _sorted_copies(edges: Any, src: str, dst: str) -> tuple[Any, Any]:
+def _sorted_copies(edges: DataFrameT, src: str, dst: str) -> tuple[DataFrameT, DataFrameT]:
     """Two sorted copies of the edge frame: by src and by dst.
 
     Costs 2x the edge frame resident (16.8 GB at E=1.05B, int32) and buys free
@@ -64,8 +67,8 @@ def _sorted_copies(edges: Any, src: str, dst: str) -> tuple[Any, Any]:
 
 
 def _sym_min(
-    by_src: Any, by_dst: Any, src: str, dst: str, vec: Any, v_count: int, chunks: int
-) -> Any:
+    by_src: DataFrameT, by_dst: DataFrameT, src: str, dst: str, vec: SeriesT, v_count: int, chunks: int
+) -> Optional[DataFrameT]:
     """min over the undirected neighborhood, without materializing 2E rows.
 
     For a vertex range [a,b) every out-edge is a contiguous slice of the
@@ -79,17 +82,11 @@ def _sym_min(
         eb = slice_by_key(by_dst, dst, a, b)
         if len(ea):
             outs.append(
-                df_cons(ea, {"v": ea[src], "p": gather(vec, ea[dst])})
-                .groupby("v", sort=False)["p"]
-                .min()
-                .reset_index()
+                df_cons(ea, {"v": ea[src], "p": gather(vec, ea[dst])}).groupby("v", sort=False)["p"].min().reset_index()
             )
         if len(eb):
             outs.append(
-                df_cons(eb, {"v": eb[dst], "p": gather(vec, eb[src])})
-                .groupby("v", sort=False)["p"]
-                .min()
-                .reset_index()
+                df_cons(eb, {"v": eb[dst], "p": gather(vec, eb[src])}).groupby("v", sort=False)["p"].min().reset_index()
             )
     res = concat_frames(outs)
     if res is None:
@@ -98,14 +95,14 @@ def _sym_min(
     return res.groupby("v", sort=False)["p"].min().reset_index()
 
 
-def wcc(edges: Any, src: str, dst: str, v_count: int, chunks: int = 1, max_iter: int = 1000) -> Any:
+def wcc(edges: DataFrameT, src: str, dst: str, v_count: int, chunks: int = 1, max_iter: int = 1000) -> SeriesT:
     """Weakly connected components, LDBC label = min original vertex id.
 
     Shiloach-Vishkin min-label propagation with pointer jumping. Because
     `dense_renumber` is monotone, the dense min-label IS the min original id, so
     the LDBC label semantics can be asserted directly with no reference output.
 
-    Pointer jumping is what makes this O(log V) rather than O(diameter) -- it is
+    Pointer jumping reduces dependence on path diameter; this is
     the difference between ~6 iterations and hundreds on a long-path graph.
     """
     by_src, by_dst = _sorted_copies(edges, src, dst)
@@ -127,14 +124,14 @@ def wcc(edges: Any, src: str, dst: str, v_count: int, chunks: int = 1, max_iter:
 
 
 def pagerank(
-    edges: Any,
+    edges: DataFrameT,
     src: str,
     dst: str,
     v_count: int,
     iterations: int = 10,
     damping: float = 0.85,
     chunks: int = 1,
-) -> Any:
+) -> SeriesT:
     """LDBC PageRank: FIXED iteration count, dangling mass redistributed uniformly.
 
     There is deliberately no early exit. With d=0.85 and K=10, d^K ~ 0.197, so a
@@ -162,12 +159,7 @@ def pagerank(
         for lo, hi in chunk_bounds(len(by_dst), chunks):
             e = rows(by_dst, lo, hi)
             msg = gather(contrib, e[src])
-            outs.append(
-                df_cons(e, {"v": e[dst], "m": msg})
-                .groupby("v", sort=False)["m"]
-                .sum()
-                .reset_index()
-            )
+            outs.append(df_cons(e, {"v": e[dst], "m": msg}).groupby("v", sort=False)["m"].sum().reset_index())
         res = concat_frames(outs)
         if res is not None and chunks > 1:
             # Row-chunking by dst can split a dst group across a boundary.
@@ -185,13 +177,13 @@ def pagerank(
 
 
 def cdlp(
-    edges: Any,
+    edges: DataFrameT,
     src: str,
     dst: str,
     v_count: int,
     iterations: int = 10,
     chunks: int = 1,
-) -> Any:
+) -> SeriesT:
     """LDBC community detection by label propagation.
 
     Synchronous, fixed iteration count, undirected, MULTISET semantics (parallel
@@ -201,7 +193,7 @@ def cdlp(
     The tie-break is done by maximizing a packed key `count*2^32 + (LMAX-label)`
     in a single groupby-max. That maximizes count and, among equal counts,
     minimizes label -- replacing a global `sort_values` that costs ~17 GB at
-    graph500-26 (~34 GB with cuDF's sort overhead) with one O(V)-output pass.
+    graph500-26 (~34 GB with cuDF's sort overhead) with a vertex-sized output pass.
     Being order-independent, it is also bitwise deterministic across engines.
 
     No early exit: synchronous label propagation can oscillate with period 2, so
@@ -242,7 +234,7 @@ def cdlp(
 
 
 def sssp(
-    edges: Any,
+    edges: DataFrameT,
     src: str,
     dst: str,
     weight: str,
@@ -250,7 +242,7 @@ def sssp(
     source: int,
     chunks: int = 1,
     max_iter: Optional[int] = None,
-) -> Any:
+) -> SeriesT:
     """Weighted single-source shortest path, frontier Bellman-Ford.
 
     Relaxation is gather + boolean mask, not a per-hop hash join against the
@@ -279,16 +271,16 @@ def sssp(
             if len(e) == 0:
                 continue
             nd = gather(dist, e[src]) + e[weight].reset_index(drop=True).astype("float32")
-            outs.append(
-                df_cons(e, {"v": e[dst], "d": nd}).groupby("v", sort=False)["d"].min().reset_index()
-            )
+            outs.append(df_cons(e, {"v": e[dst], "d": nd}).groupby("v", sort=False)["d"].min().reset_index())
         res = concat_frames(outs)
         if res is None:
             return dist
         res = res.groupby("v", sort=False)["d"].min().reset_index()
 
         cur = gather(dist, res["v"])
-        improved = res[(res["d"].reset_index(drop=True) < cur).values if not is_cudf(res) else (res["d"].reset_index(drop=True) < cur)]
+        improved = res[
+            (res["d"].reset_index(drop=True) < cur).values if not is_cudf(res) else (res["d"].reset_index(drop=True) < cur)
+        ]
         if len(improved) == 0:
             return dist
         dist = align(edges, v_count, improved, "v", "d", dist).astype("float32")
@@ -298,7 +290,7 @@ def sssp(
     raise ConvergenceError(f"sssp did not settle in {cap} iterations")
 
 
-def make_weights(edges: Any, src: str, dst: str) -> Any:
+def make_weights(edges: DataFrameT, src: str, dst: str) -> SeriesT:
     """Deterministic integer edge weights in [1, 255] as float32.
 
     Pure integer arithmetic in uint64 so both engines produce bitwise identical
@@ -312,9 +304,14 @@ def make_weights(edges: Any, src: str, dst: str) -> Any:
 
 
 def mis(
-    edges: Any, src: str, dst: str, v_count: int, seed: int = 0x5EED, chunks: int = 1,
+    edges: DataFrameT,
+    src: str,
+    dst: str,
+    v_count: int,
+    seed: int = 0x5EED,
+    chunks: int = 1,
     max_rounds: int = 200,
-) -> Any:
+) -> SeriesT:
     """Maximal independent set, Luby's algorithm.
 
     NOTE: MIS is not one of the six official LDBC Graphalytics kernels
@@ -324,7 +321,7 @@ def mis(
 
     Priority is a packed `(hash32, vertex_id)` giving a STRICT TOTAL ORDER, so
     there are no ties, so at least one vertex joins per active component per
-    round -- termination is guaranteed, in O(log V) rounds expected. The uint64
+    round. The uint64
     hash wraps identically on both engines, making the result bitwise
     reproducible; that is what substitutes for the missing reference output.
 
@@ -340,7 +337,7 @@ def mis(
     zero = full(edges, v_count, 0, "int64")
     deg = align(edges, v_count, deg_s, src, "__deg", zero) + align(edges, v_count, deg_d, dst, "__deg", zero)
 
-    in_set = deg == 0          # isolated vertices are in the set
+    in_set = deg == 0  # isolated vertices are in the set
     active = ~in_set
     uint_max = u64((1 << 64) - 1)
 
@@ -368,8 +365,8 @@ def mis(
 
 
 def _sym_min_active(
-    by_src: Any, by_dst: Any, src: str, dst: str, vec: Any, active: Any, v_count: int, chunks: int
-) -> Any:
+    by_src: DataFrameT, by_dst: DataFrameT, src: str, dst: str, vec: SeriesT, active: SeriesT, v_count: int, chunks: int
+) -> Optional[DataFrameT]:
     """min of `vec` over ACTIVE undirected neighbours, chunked by vertex range."""
     outs = []
     for a, b in vertex_ranges(v_count, chunks):
@@ -382,18 +379,15 @@ def _sym_min_active(
             if len(e) == 0:
                 continue
             outs.append(
-                df_cons(e, {"v": e[key], "p": gather(vec, e[other])})
-                .groupby("v", sort=False)["p"]
-                .min()
-                .reset_index()
+                df_cons(e, {"v": e[key], "p": gather(vec, e[other])}).groupby("v", sort=False)["p"].min().reset_index()
             )
     res = concat_frames(outs)
     return None if res is None else res.groupby("v", sort=False)["p"].min().reset_index()
 
 
 def _sym_any(
-    by_src: Any, by_dst: Any, src: str, dst: str, flag: Any, v_count: int, chunks: int
-) -> Any:
+    by_src: DataFrameT, by_dst: DataFrameT, src: str, dst: str, flag: SeriesT, v_count: int, chunks: int
+) -> Optional[DataFrameT]:
     """1 where any undirected neighbour has `flag` set."""
     outs = []
     for a, b in vertex_ranges(v_count, chunks):

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -15,16 +15,15 @@ Three formulation decisions carry the entire memory budget at 1B edges:
 3. CDLP's "most frequent label, ties to smallest" is a single groupby-max over a
    packed key, not a global sort.
 
-Four of the five kernels are hand-written rather than delegated because cuGraph
-and igraph do not implement the LDBC semantics: PageRank there runs to a
-tolerance while LDBC fixes the iteration count, cuGraph has no label propagation
-at all, and neither has a usable MIS. cuGraph is used as an *oracle* for WCC and
-SSSP, where it is exact.
+The kernels are hand-written so one implementation can run on pandas and cuDF.
+PageRank supports both cuGraph-compatible convergence and the fixed-iteration
+LDBC workload; the other algorithms retain their documented standard-library
+semantics without requiring an optional graph backend.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional, Union
 
 from graphistry.compute.typing import DataFrameT, SeriesT
 
@@ -128,52 +127,152 @@ def pagerank(
     src: str,
     dst: str,
     v_count: int,
-    iterations: int = 10,
-    damping: float = 0.85,
+    alpha: float = 0.85,
+    personalization: Optional[SeriesT] = None,
+    precomputed_vertex_out_weight: Optional[SeriesT] = None,
+    max_iter: int = 100,
+    tol: float = 1.0e-5,
+    nstart: Optional[SeriesT] = None,
+    dangling: object = None,
+    fail_on_nonconvergence: bool = True,
+    *,
+    weight: Optional[str] = None,
     chunks: int = 1,
-) -> SeriesT:
-    """LDBC PageRank: FIXED iteration count, dangling mass redistributed uniformly.
+    stopping: Literal["convergence", "fixed_iterations"] = "convergence",
+    iterations: Optional[int] = None,
+    damping: Optional[float] = None,
+) -> Union[SeriesT, tuple[SeriesT, bool]]:
+    """PageRank with cuGraph-compatible controls and portable dataframe extras."""
+    if v_count == 0:
+        empty = full(edges, 0, 0.0, "float64")
+        return (empty, True) if not fail_on_nonconvergence else empty
+    if damping is not None:
+        if alpha != 0.85 and alpha != damping:
+            raise ValueError("pagerank alpha and damping aliases disagree")
+        alpha = damping
+    if iterations is not None:
+        if max_iter != 100 and max_iter != iterations:
+            raise ValueError("pagerank max_iter and iterations aliases disagree")
+        max_iter = iterations
+        stopping = "fixed_iterations"
+    if stopping not in ("convergence", "fixed_iterations"):
+        raise ValueError("pagerank stopping must be 'convergence' or 'fixed_iterations'")
+    if not 0.0 < float(alpha) < 1.0:
+        raise ValueError("pagerank alpha must be greater than 0 and less than 1")
+    if stopping == "convergence" and max_iter <= 0:
+        max_iter = 100
+    elif max_iter < 0:
+        raise ValueError("pagerank max_iter must be non-negative in fixed mode")
+    if tol == 0.0:
+        tol = 1.0e-5
+    if tol < 0.0:
+        raise ValueError("pagerank tol must be non-negative")
 
-    There is deliberately no early exit. With d=0.85 and K=10, d^K ~ 0.197, so a
-    fixed-K vector differs materially from a converged one -- which is exactly
-    why `cugraph.pagerank` and `igraph.pagerank` cannot serve as oracles here.
+    def normalized(values: Optional[SeriesT], name: str) -> SeriesT:
+        if values is None:
+            return full(edges, v_count, 1.0 / v_count, "float64")
+        out = values.reset_index(drop=True).astype("float64")
+        if len(out) != v_count:
+            raise ValueError(f"pagerank {name} must have one value per vertex")
+        invalid = (out != out) | (out < 0.0) | (out == float("inf"))
+        if to_host_int(invalid.sum()) != 0:
+            raise ValueError(f"pagerank {name} values must be finite and non-negative")
+        total = float(out.sum())
+        if total <= 0.0:
+            raise ValueError(f"pagerank {name} values must have a positive sum")
+        return out / total
 
-    Chunking is by DST so partial results are key-disjoint and the combine is a
-    concat rather than a second groupby.
-    """
     _, by_dst = _sorted_copies(edges, src, dst)
+    if weight is None:
+        sums = edges.groupby(src, sort=False).size().reset_index(name="__out")
+        computed_out = align(
+            edges, v_count, sums, src, "__out", full(edges, v_count, 0.0, "float64")
+        )
+    else:
+        if weight not in edges.columns:
+            raise ValueError(f"pagerank weight column {weight!r} is missing")
+        edge_weight = edges[weight].reset_index(drop=True).astype("float64")
+        invalid_weight = (
+            (edge_weight != edge_weight)
+            | (edge_weight < 0.0)
+            | (edge_weight == float("inf"))
+        )
+        if to_host_int(invalid_weight.sum()) != 0:
+            raise ValueError("pagerank edge weights must be finite and non-negative")
+        sums = (
+            df_cons(edges, {src: edges[src], "__out": edge_weight})
+            .groupby(src, sort=False)["__out"]
+            .sum()
+            .reset_index()
+        )
+        computed_out = align(
+            edges, v_count, sums, src, "__out", full(edges, v_count, 0.0, "float64")
+        )
 
-    deg = edges.groupby(src, sort=False).size().reset_index(name="__deg")
-    outdeg = align(edges, v_count, deg, src, "__deg", full(edges, v_count, 0, "int64"))
-    dangling = outdeg == 0
+    out_weight = computed_out
+    if precomputed_vertex_out_weight is not None:
+        supplied = precomputed_vertex_out_weight.reset_index(drop=True).astype("float64")
+        if len(supplied) != v_count:
+            raise ValueError(
+                "pagerank precomputed_vertex_out_weight must have one value per vertex"
+            )
+        present = supplied == supplied
+        invalid_out = present & ((supplied < 0.0) | (supplied == float("inf")))
+        if to_host_int(invalid_out.sum()) != 0:
+            raise ValueError(
+                "pagerank precomputed out weights must be finite and non-negative"
+            )
+        out_weight = supplied.where(present, computed_out)
 
-    pr = full(edges, v_count, 1.0 / v_count, "float64")
-    d = float(damping)
+    is_dangling = out_weight == 0.0
+    if to_host_int(((computed_out > 0.0) & is_dangling).sum()) != 0:
+        raise ValueError(
+            "pagerank precomputed out weight is zero for a vertex with outgoing weight"
+        )
 
-    for _ in range(iterations):
-        safe_deg = outdeg.where(~dangling, 1)
-        contrib = (pr / safe_deg).where(~dangling, 0.0)
-        dang = float(pr.where(dangling, 0.0).sum())
+    teleport = normalized(personalization, "personalization")
+    pr = normalized(nstart, "nstart")
+    d = float(alpha)
+    converged = False
+    _ = dangling
+
+    for _iteration in range(max_iter):
+        safe_out = out_weight.where(~is_dangling, 1.0)
+        contrib = (pr / safe_out).where(~is_dangling, 0.0)
+        dangling_mass = float(pr.where(is_dangling, 0.0).sum())
 
         outs = []
         for lo, hi in chunk_bounds(len(by_dst), chunks):
             e = rows(by_dst, lo, hi)
             msg = gather(contrib, e[src])
-            outs.append(df_cons(e, {"v": e[dst], "m": msg}).groupby("v", sort=False)["m"].sum().reset_index())
+            if weight is not None:
+                msg = msg * e[weight].reset_index(drop=True)
+            outs.append(
+                df_cons(e, {"v": e[dst], "m": msg})
+                .groupby("v", sort=False)["m"]
+                .sum()
+                .reset_index()
+            )
         res = concat_frames(outs)
         if res is not None and chunks > 1:
-            # Row-chunking by dst can split a dst group across a boundary.
             res = res.groupby("v", sort=False)["m"].sum().reset_index()
-        inflow = align(edges, v_count, res, "v", "m", full(edges, v_count, 0.0, "float64"))
-
-        pr = (1.0 - d) / v_count + d * (inflow + dang / v_count)
-
-        # Mass conservation is a free bug detector for the dangling term.
-        total = float(pr.sum())
+        inflow = align(
+            edges, v_count, res, "v", "m", full(edges, v_count, 0.0, "float64")
+        )
+        new = (1.0 - d) * teleport + d * (inflow + dangling_mass * teleport)
+        total = float(new.sum())
         if abs(total - 1.0) > 1e-9:
             raise AssertionError(f"pagerank mass not conserved: sum={total!r}")
+        converged = float(abs(new - pr).sum()) < v_count * float(tol)
+        pr = new
+        if stopping == "convergence" and converged:
+            return (pr, True) if not fail_on_nonconvergence else pr
 
-    return pr
+    if stopping == "fixed_iterations":
+        return (pr, converged) if not fail_on_nonconvergence else pr
+    if fail_on_nonconvergence:
+        raise ConvergenceError(f"pagerank did not converge in {max_iter} iterations")
+    return pr, False
 
 
 def cdlp(

--- a/graphistry/compute/algorithms/registry.py
+++ b/graphistry/compute/algorithms/registry.py
@@ -5,21 +5,23 @@ dependency and run on whatever engine the frames already use. That is the
 distinction from `graphistry.cugraph.*` / `graphistry.igraph.*` / `graphistry.nx.*`,
 which are named for the backend library doing the work and require it installed.
 
-Deliberately NOT named after the benchmark that motivated them. "Graphalytics"
-is LDBC's benchmark name; putting it in a shipped public API would imply an
+Deliberately NOT named after the external workload that motivated them. "Graphalytics"
+is LDBC's external workload name; putting it in a shipped public API would imply an
 endorsement and a conformance audit we do not have, and would read oddly for a
 user who just wants label propagation. Conformance belongs in the docs and
 tests, not the identifier.
 """
+
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Mapping, Tuple
+from typing import Callable, Dict, Mapping, Tuple
+
+from graphistry.compute.typing import DataFrameT, SeriesT
 
 from . import kernels as _k
 
-# algorithm -> (output column, default options). Output naming follows the
-# existing plugin convention: one node-attribute column written back.
-STD_ALGS: Dict[str, Tuple[str, Dict[str, Any]]] = {
+# Algorithm -> output column and default options, following plugin naming.
+STD_ALGS: Dict[str, Tuple[str, Dict[str, object]]] = {
     "wcc": ("component", {}),
     "pagerank": ("pagerank", {"iterations": 10, "damping": 0.85}),
     "cdlp": ("cdlp", {"iterations": 10}),
@@ -30,12 +32,13 @@ STD_ALGS: Dict[str, Tuple[str, Dict[str, Any]]] = {
 STD_COMPUTE_ALGS: Tuple[str, ...] = tuple(STD_ALGS)
 
 # Result dtypes, for the GFQL planner's schema effects.
-STD_FLOAT_ALGS = frozenset({"pagerank", "sssp"})
-STD_INT_ALGS = frozenset({"wcc", "cdlp"})
+STD_FLOAT64_ALGS = frozenset({"pagerank"})
+STD_FLOAT32_ALGS = frozenset({"sssp"})
+STD_LABEL_ALGS = frozenset({"wcc", "cdlp"})
 STD_BOOL_ALGS = frozenset({"mis"})
 
 
-def _dispatch(alg: str) -> Callable[..., Any]:
+def _dispatch(alg: str) -> Callable[..., SeriesT]:
     return {
         "wcc": _k.wcc,
         "pagerank": _k.pagerank,
@@ -45,8 +48,7 @@ def _dispatch(alg: str) -> Callable[..., Any]:
     }[alg]
 
 
-def run(edges: Any, src: str, dst: str, v_count: int, alg: str,
-        options: Mapping[str, Any] | None = None) -> Any:
+def run(edges: DataFrameT, src: str, dst: str, v_count: int, alg: str, options: Mapping[str, object] | None = None) -> SeriesT:
     """Run a std kernel, merging caller options over the defaults."""
     if alg not in STD_ALGS:
         raise KeyError(f"unknown graphistry.std procedure {alg!r}; known: {list(STD_ALGS)}")
@@ -55,13 +57,11 @@ def run(edges: Any, src: str, dst: str, v_count: int, alg: str,
     fn = _dispatch(alg)
 
     if alg == "sssp":
-        # SSSP needs a weight column and a source; both are its own parameters
-        # rather than graph-wide state, so they are supplied here.
+        # Weight and source are SSSP parameters rather than graph-wide state.
         weight = opts.pop("weight", None)
         if weight is None:
             weight = "__std_w"
-            edges = edges.assign(**{weight: _k.make_weights(edges, src, dst)}) \
-                if hasattr(edges, "assign") else edges
+            edges = edges.assign(**{weight: _k.make_weights(edges, src, dst)}) if hasattr(edges, "assign") else edges
         source = opts.pop("source", 0)
         return fn(edges, src, dst, weight, v_count, source=source, **opts)
 

--- a/graphistry/compute/algorithms/registry.py
+++ b/graphistry/compute/algorithms/registry.py
@@ -1,0 +1,72 @@
+"""Registry of `graphistry.std.*` procedures for the GFQL CALL surface.
+
+`std` in the standard-library sense: these need no optional third-party
+dependency and run on whatever engine the frames already use. That is the
+distinction from `graphistry.cugraph.*` / `graphistry.igraph.*` / `graphistry.nx.*`,
+which are named for the backend library doing the work and require it installed.
+
+Deliberately NOT named after the benchmark that motivated them. "Graphalytics"
+is LDBC's benchmark name; putting it in a shipped public API would imply an
+endorsement and a conformance audit we do not have, and would read oddly for a
+user who just wants label propagation. Conformance belongs in the docs and
+tests, not the identifier.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Tuple
+
+from . import kernels as _k
+
+# algorithm -> (output column, default options). Output naming follows the
+# existing plugin convention: one node-attribute column written back.
+STD_ALGS: Dict[str, Tuple[str, Dict[str, Any]]] = {
+    "wcc": ("component", {}),
+    "pagerank": ("pagerank", {"iterations": 10, "damping": 0.85}),
+    "cdlp": ("cdlp", {"iterations": 10}),
+    "sssp": ("distance", {}),
+    "mis": ("mis", {"seed": 0x5EED}),
+}
+
+STD_COMPUTE_ALGS: Tuple[str, ...] = tuple(STD_ALGS)
+
+# Result dtypes, for the GFQL planner's schema effects.
+STD_FLOAT_ALGS = frozenset({"pagerank", "sssp"})
+STD_INT_ALGS = frozenset({"wcc", "cdlp"})
+STD_BOOL_ALGS = frozenset({"mis"})
+
+
+def _dispatch(alg: str) -> Callable[..., Any]:
+    return {
+        "wcc": _k.wcc,
+        "pagerank": _k.pagerank,
+        "cdlp": _k.cdlp,
+        "sssp": _k.sssp,
+        "mis": _k.mis,
+    }[alg]
+
+
+def run(edges: Any, src: str, dst: str, v_count: int, alg: str,
+        options: Mapping[str, Any] | None = None) -> Any:
+    """Run a std kernel, merging caller options over the defaults."""
+    if alg not in STD_ALGS:
+        raise KeyError(f"unknown graphistry.std procedure {alg!r}; known: {list(STD_ALGS)}")
+    _out_col, defaults = STD_ALGS[alg]
+    opts = {**defaults, **dict(options or {})}
+    fn = _dispatch(alg)
+
+    if alg == "sssp":
+        # SSSP needs a weight column and a source; both are its own parameters
+        # rather than graph-wide state, so they are supplied here.
+        weight = opts.pop("weight", None)
+        if weight is None:
+            weight = "__std_w"
+            edges = edges.assign(**{weight: _k.make_weights(edges, src, dst)}) \
+                if hasattr(edges, "assign") else edges
+        source = opts.pop("source", 0)
+        return fn(edges, src, dst, weight, v_count, source=source, **opts)
+
+    return fn(edges, src, dst, v_count, **opts)
+
+
+def output_column(alg: str) -> str:
+    return STD_ALGS[alg][0]

--- a/graphistry/compute/algorithms/registry.py
+++ b/graphistry/compute/algorithms/registry.py
@@ -14,7 +14,7 @@ tests, not the identifier.
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Mapping, Tuple
+from typing import Callable, Dict, Mapping, Tuple, Union
 
 from graphistry.compute.typing import DataFrameT, SeriesT
 
@@ -23,7 +23,19 @@ from . import kernels as _k
 # Algorithm -> output column and default options, following plugin naming.
 STD_ALGS: Dict[str, Tuple[str, Dict[str, object]]] = {
     "wcc": ("component", {}),
-    "pagerank": ("pagerank", {"iterations": 10, "damping": 0.85}),
+    "pagerank": (
+        "pagerank",
+        {
+            "alpha": 0.85,
+            "personalization": None,
+            "precomputed_vertex_out_weight": None,
+            "max_iter": 100,
+            "tol": 1.0e-5,
+            "nstart": None,
+            "dangling": None,
+            "fail_on_nonconvergence": True,
+        },
+    ),
     "cdlp": ("cdlp", {"iterations": 10}),
     "sssp": ("distance", {}),
     "mis": ("mis", {"seed": 0x5EED}),
@@ -37,8 +49,10 @@ STD_FLOAT32_ALGS = frozenset({"sssp"})
 STD_LABEL_ALGS = frozenset({"wcc", "cdlp"})
 STD_BOOL_ALGS = frozenset({"mis"})
 
+AlgorithmResult = Union[SeriesT, Tuple[SeriesT, bool]]
 
-_STD_RUNNERS: Dict[str, Callable[..., SeriesT]] = {
+
+_STD_RUNNERS: Dict[str, Callable[..., AlgorithmResult]] = {
     "wcc": _k.wcc,
     "pagerank": _k.pagerank,
     "cdlp": _k.cdlp,
@@ -47,14 +61,23 @@ _STD_RUNNERS: Dict[str, Callable[..., SeriesT]] = {
 }
 
 
-def _dispatch(alg: str) -> Callable[..., SeriesT]:
+def _dispatch(alg: str) -> Callable[..., AlgorithmResult]:
     return _STD_RUNNERS[alg]
 
 
-def run(edges: DataFrameT, src: str, dst: str, v_count: int, alg: str, options: Mapping[str, object] | None = None) -> SeriesT:
+def run(
+    edges: DataFrameT,
+    src: str,
+    dst: str,
+    v_count: int,
+    alg: str,
+    options: Mapping[str, object] | None = None,
+) -> AlgorithmResult:
     """Run a std kernel, merging caller options over the defaults."""
     if alg not in STD_ALGS:
-        raise KeyError(f"unknown graphistry.std procedure {alg!r}; known: {list(STD_ALGS)}")
+        raise KeyError(
+            f"unknown graphistry.std procedure {alg!r}; known: {list(STD_ALGS)}"
+        )
     _out_col, defaults = STD_ALGS[alg]
     opts = {**defaults, **dict(options or {})}
     fn = _dispatch(alg)
@@ -64,7 +87,11 @@ def run(edges: DataFrameT, src: str, dst: str, v_count: int, alg: str, options: 
         weight = opts.pop("weight", None)
         if weight is None:
             weight = "__std_w"
-            edges = edges.assign(**{weight: _k.make_weights(edges, src, dst)}) if hasattr(edges, "assign") else edges
+            edges = (
+                edges.assign(**{weight: _k.make_weights(edges, src, dst)})
+                if hasattr(edges, "assign")
+                else edges
+            )
         source = opts.pop("source", 0)
         return fn(edges, src, dst, weight, v_count, source=source, **opts)
 

--- a/graphistry/compute/algorithms/registry.py
+++ b/graphistry/compute/algorithms/registry.py
@@ -38,14 +38,17 @@ STD_LABEL_ALGS = frozenset({"wcc", "cdlp"})
 STD_BOOL_ALGS = frozenset({"mis"})
 
 
+_STD_RUNNERS: Dict[str, Callable[..., SeriesT]] = {
+    "wcc": _k.wcc,
+    "pagerank": _k.pagerank,
+    "cdlp": _k.cdlp,
+    "sssp": _k.sssp,
+    "mis": _k.mis,
+}
+
+
 def _dispatch(alg: str) -> Callable[..., SeriesT]:
-    return {
-        "wcc": _k.wcc,
-        "pagerank": _k.pagerank,
-        "cdlp": _k.cdlp,
-        "sssp": _k.sssp,
-        "mis": _k.mis,
-    }[alg]
+    return _STD_RUNNERS[alg]
 
 
 def run(edges: DataFrameT, src: str, dst: str, v_count: int, alg: str, options: Mapping[str, object] | None = None) -> SeriesT:

--- a/graphistry/compute/algorithms/validate.py
+++ b/graphistry/compute/algorithms/validate.py
@@ -1,0 +1,142 @@
+"""Result validation, run at full scale inside the suite.
+
+These checks need no reference output, which matters because for three of the
+five kernels no usable reference exists: cuGraph has no label propagation,
+neither backend has MIS, and both PageRank implementations converge to a
+tolerance while LDBC fixes the iteration count.
+
+What is checkable without a reference turns out to be most of what matters:
+
+* WCC -- the LDBC label semantics are self-verifying. With monotone renumbering
+  the label must equal the minimum vertex id of its own component, and every
+  edge must join two vertices carrying the same label.
+* PageRank -- mass conservation and positivity.
+* SSSP -- the triangle inequality over every edge, plus dist[source] == 0.
+* MIS -- independence and maximality, which together are the definition.
+* CDLP -- labels must be drawn from the vertex id space and stable under a
+  further application of the update rule only if it has converged, so the honest
+  check is structural rather than a fixpoint assertion.
+
+A `fail` here marks the cell `validation_failed` and its timing is not published.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ._dfops import concat_frames, df_cons, gather, to_host_int
+
+
+def _ok(**extra: Any) -> dict[str, Any]:
+    return {"status": "ok", **extra}
+
+
+def _fail(reason: str, **extra: Any) -> dict[str, Any]:
+    return {"status": "fail", "reason": reason, **extra}
+
+
+def _both_directions(edges: Any, src: str, dst: str, vec: Any):
+    return gather(vec, edges[src]), gather(vec, edges[dst])
+
+
+def validate_wcc(labels: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+    edges = prepared["edges"]
+    ls, ld = _both_directions(edges, "src", "dst", labels)
+    if to_host_int((ls != ld).sum()) != 0:
+        return _fail("an edge joins two different component labels")
+
+    # The label must be a fixed point: the representative labels itself.
+    if to_host_int((gather(labels, labels) != labels).sum()) != 0:
+        return _fail("a component label is not a fixed point (label[label[v]] != label[v])")
+
+    # LDBC semantics: the label IS the minimum vertex id of its component. This
+    # is only assertable because dense_renumber is monotone, so dense order and
+    # original order agree -- no reference output needed.
+    from ._dfops import arange
+
+    vids = arange(edges, len(labels), "int64")
+    pairs = df_cons(edges, {"lbl": labels.reset_index(drop=True), "v": vids})
+    mins = pairs.groupby("lbl", sort=False)["v"].min().reset_index()
+    if to_host_int((mins["lbl"] != mins["v"]).sum()) != 0:
+        return _fail("a component label is not the minimum vertex id of its component")
+
+    return _ok(components=int(len(mins)))
+
+
+def validate_pagerank(pr: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+    total = float(pr.sum())
+    if abs(total - 1.0) > 1e-9:
+        return _fail(f"mass not conserved: sum={total!r}")
+    if to_host_int((pr <= 0).sum()) != 0:
+        return _fail("non-positive PageRank value")
+    return _ok(mass=round(total, 12), max_rank=float(pr.max()))
+
+
+def validate_cdlp(labels: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+    v_count = prepared["vertices"]
+    if to_host_int(((labels < 0) | (labels >= v_count)).sum()) != 0:
+        return _fail("label outside the vertex id range")
+    return _ok(communities=int(labels.nunique()))
+
+
+def validate_sssp(dist: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+    edges = prepared["edges"]
+    source = prepared["sssp_source"]
+    if float(dist.iloc[source]) != 0.0:
+        return _fail(f"dist[source]={float(dist.iloc[source])!r}, expected 0")
+
+    # Triangle inequality: no edge may offer a cheaper route than the recorded
+    # distance. One masked pass over E; finite-only so inf - inf never appears.
+    ds = gather(dist, edges["src"])
+    dd = gather(dist, edges["dst"])
+    w = edges["w"].reset_index(drop=True)
+    slack = dd - (ds + w)
+    finite = (ds == ds) & (ds < float("inf")) & (dd < float("inf"))
+    violations = to_host_int(((slack > 1e-6) & finite).sum())
+    if violations:
+        return _fail(f"{violations} edges violate the triangle inequality")
+
+    reached = to_host_int((dist < float("inf")).sum())
+    return _ok(reached=reached, unreachable=int(prepared["vertices"]) - reached)
+
+
+def validate_mis(in_set: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+    edges = prepared["edges"]
+    a, b = _both_directions(edges, "src", "dst", in_set)
+    if to_host_int((a & b).sum()) != 0:
+        return _fail("not independent: an edge has both endpoints in the set")
+
+    # Maximality: every vertex outside the set needs a neighbour inside it.
+    from .kernels import _sym_any, _sorted_copies
+    from ._dfops import align, full
+
+    by_src, by_dst = _sorted_copies(edges, "src", "dst")
+    v_count = prepared["vertices"]
+    nbr = _sym_any(by_src, by_dst, "src", "dst", in_set, v_count, chunks=1)
+    nbr = align(edges, v_count, nbr, "v", "p", full(edges, v_count, 0, "int8"))
+    orphans = to_host_int(((~in_set) & (nbr == 0)).sum())
+    if orphans:
+        return _fail(f"not maximal: {orphans} vertices outside the set have no neighbour in it")
+
+    size = to_host_int(in_set.sum())
+    if size == 0:
+        return _fail("empty independent set")
+    return _ok(set_size=size, fraction=round(size / v_count, 4))
+
+
+_VALIDATORS = {
+    "wcc": validate_wcc,
+    "pagerank": validate_pagerank,
+    "cdlp": validate_cdlp,
+    "sssp": validate_sssp,
+    "mis": validate_mis,
+}
+
+
+def validate_result(kernel: str, result: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+    fn = _VALIDATORS.get(kernel)
+    if fn is None:
+        return {"status": "skipped", "reason": f"no validator for {kernel!r}"}
+    try:
+        return fn(result, prepared)
+    except Exception as exc:
+        return _fail(f"validator raised {type(exc).__name__}: {exc}")

--- a/graphistry/compute/algorithms/validate.py
+++ b/graphistry/compute/algorithms/validate.py
@@ -22,11 +22,17 @@ A `fail` here marks the cell `validation_failed` and its timing is not published
 
 from __future__ import annotations
 
-from typing import Dict, Mapping, Tuple
+from typing import Dict, Tuple, TypedDict
 
 from graphistry.compute.typing import DataFrameT, SeriesT
 
 from ._dfops import concat_frames, df_cons, gather, to_host_int
+
+
+class PreparedGraph(TypedDict, total=False):
+    edges: DataFrameT
+    vertices: int
+    sssp_source: int
 
 
 def _ok(**extra: object) -> Dict[str, object]:
@@ -41,7 +47,7 @@ def _both_directions(edges: DataFrameT, src: str, dst: str, vec: SeriesT) -> Tup
     return gather(vec, edges[src]), gather(vec, edges[dst])
 
 
-def validate_wcc(labels: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
+def validate_wcc(labels: SeriesT, prepared: PreparedGraph) -> Dict[str, object]:
     edges = prepared["edges"]
     ls, ld = _both_directions(edges, "src", "dst", labels)
     if to_host_int((ls != ld).sum()) != 0:
@@ -63,7 +69,7 @@ def validate_wcc(labels: SeriesT, prepared: Mapping[str, object]) -> Dict[str, o
     return _ok(components=int(len(mins)))
 
 
-def validate_pagerank(pr: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
+def validate_pagerank(pr: SeriesT, prepared: PreparedGraph) -> Dict[str, object]:
     total = float(pr.sum())
     if abs(total - 1.0) > 1e-9:
         return _fail(f"mass not conserved: sum={total!r}")
@@ -72,14 +78,14 @@ def validate_pagerank(pr: SeriesT, prepared: Mapping[str, object]) -> Dict[str, 
     return _ok(mass=round(total, 12), max_rank=float(pr.max()))
 
 
-def validate_cdlp(labels: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
+def validate_cdlp(labels: SeriesT, prepared: PreparedGraph) -> Dict[str, object]:
     v_count = prepared["vertices"]
     if to_host_int(((labels < 0) | (labels >= v_count)).sum()) != 0:
         return _fail("label outside the vertex id range")
     return _ok(communities=int(labels.nunique()))
 
 
-def validate_sssp(dist: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
+def validate_sssp(dist: SeriesT, prepared: PreparedGraph) -> Dict[str, object]:
     edges = prepared["edges"]
     source = prepared["sssp_source"]
     if float(dist.iloc[source]) != 0.0:
@@ -99,7 +105,7 @@ def validate_sssp(dist: SeriesT, prepared: Mapping[str, object]) -> Dict[str, ob
     return _ok(reached=reached, unreachable=int(prepared["vertices"]) - reached)
 
 
-def validate_mis(in_set: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
+def validate_mis(in_set: SeriesT, prepared: PreparedGraph) -> Dict[str, object]:
     edges = prepared["edges"]
     a, b = _both_directions(edges, "src", "dst", in_set)
     if to_host_int((a & b).sum()) != 0:
@@ -132,7 +138,7 @@ _VALIDATORS = {
 }
 
 
-def validate_result(kernel: str, result: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
+def validate_result(kernel: str, result: SeriesT, prepared: PreparedGraph) -> Dict[str, object]:
     fn = _VALIDATORS.get(kernel)
     if fn is None:
         return {"status": "skipped", "reason": f"no validator for {kernel!r}"}

--- a/graphistry/compute/algorithms/validate.py
+++ b/graphistry/compute/algorithms/validate.py
@@ -19,26 +19,29 @@ What is checkable without a reference turns out to be most of what matters:
 
 A `fail` here marks the cell `validation_failed` and its timing is not published.
 """
+
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Dict, Mapping, Tuple
+
+from graphistry.compute.typing import DataFrameT, SeriesT
 
 from ._dfops import concat_frames, df_cons, gather, to_host_int
 
 
-def _ok(**extra: Any) -> dict[str, Any]:
+def _ok(**extra: object) -> Dict[str, object]:
     return {"status": "ok", **extra}
 
 
-def _fail(reason: str, **extra: Any) -> dict[str, Any]:
+def _fail(reason: str, **extra: object) -> Dict[str, object]:
     return {"status": "fail", "reason": reason, **extra}
 
 
-def _both_directions(edges: Any, src: str, dst: str, vec: Any):
+def _both_directions(edges: DataFrameT, src: str, dst: str, vec: SeriesT) -> Tuple[SeriesT, SeriesT]:
     return gather(vec, edges[src]), gather(vec, edges[dst])
 
 
-def validate_wcc(labels: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+def validate_wcc(labels: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
     edges = prepared["edges"]
     ls, ld = _both_directions(edges, "src", "dst", labels)
     if to_host_int((ls != ld).sum()) != 0:
@@ -48,9 +51,7 @@ def validate_wcc(labels: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
     if to_host_int((gather(labels, labels) != labels).sum()) != 0:
         return _fail("a component label is not a fixed point (label[label[v]] != label[v])")
 
-    # LDBC semantics: the label IS the minimum vertex id of its component. This
-    # is only assertable because dense_renumber is monotone, so dense order and
-    # original order agree -- no reference output needed.
+    # Monotone renumbering preserves LDBC minimum-ID component labels.
     from ._dfops import arange
 
     vids = arange(edges, len(labels), "int64")
@@ -62,7 +63,7 @@ def validate_wcc(labels: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
     return _ok(components=int(len(mins)))
 
 
-def validate_pagerank(pr: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+def validate_pagerank(pr: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
     total = float(pr.sum())
     if abs(total - 1.0) > 1e-9:
         return _fail(f"mass not conserved: sum={total!r}")
@@ -71,21 +72,20 @@ def validate_pagerank(pr: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
     return _ok(mass=round(total, 12), max_rank=float(pr.max()))
 
 
-def validate_cdlp(labels: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+def validate_cdlp(labels: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
     v_count = prepared["vertices"]
     if to_host_int(((labels < 0) | (labels >= v_count)).sum()) != 0:
         return _fail("label outside the vertex id range")
     return _ok(communities=int(labels.nunique()))
 
 
-def validate_sssp(dist: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+def validate_sssp(dist: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
     edges = prepared["edges"]
     source = prepared["sssp_source"]
     if float(dist.iloc[source]) != 0.0:
         return _fail(f"dist[source]={float(dist.iloc[source])!r}, expected 0")
 
-    # Triangle inequality: no edge may offer a cheaper route than the recorded
-    # distance. One masked pass over E; finite-only so inf - inf never appears.
+    # Check finite distances only so infinity subtraction cannot mask violations.
     ds = gather(dist, edges["src"])
     dd = gather(dist, edges["dst"])
     w = edges["w"].reset_index(drop=True)
@@ -99,7 +99,7 @@ def validate_sssp(dist: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
     return _ok(reached=reached, unreachable=int(prepared["vertices"]) - reached)
 
 
-def validate_mis(in_set: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+def validate_mis(in_set: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
     edges = prepared["edges"]
     a, b = _both_directions(edges, "src", "dst", in_set)
     if to_host_int((a & b).sum()) != 0:
@@ -132,7 +132,7 @@ _VALIDATORS = {
 }
 
 
-def validate_result(kernel: str, result: Any, prepared: Mapping[str, Any]) -> dict[str, Any]:
+def validate_result(kernel: str, result: SeriesT, prepared: Mapping[str, object]) -> Dict[str, object]:
     fn = _VALIDATORS.get(kernel)
     if fn is None:
         return {"status": "skipped", "reason": f"no validator for {kernel!r}"}

--- a/graphistry/compute/gfql/call/executor.py
+++ b/graphistry/compute/gfql/call/executor.py
@@ -144,6 +144,12 @@ def _execute_validated_call(g: Plottable, function: str, validated_params: Dict[
         from graphistry.compute.gfql.lazy.engine.polars import degrees as _pl_degrees
         return getattr(_pl_degrees, function + "_polars")(g, engine=engine.value, **validated_params)
 
+    if function == "compute_std":
+        if engine in (Engine.POLARS, Engine.POLARS_GPU):
+            g = _bridge_graph_for_offengine_call(g, function, engine)
+        from graphistry.compute.algorithms.compute import compute_std
+        return compute_std(g, **validated_params)
+
     if not hasattr(g, function):
         raise AttributeError(
             f"Plottable has no method '{function}'. "

--- a/graphistry/compute/gfql/call/validation.py
+++ b/graphistry/compute/gfql/call/validation.py
@@ -646,6 +646,29 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
         schema_effects=_schema_effects(adds_node_cols=lambda p: [p.get('out_col', p['alg'])]),
     ),
 
+    'compute_std': _safelist_entry(
+        {'alg', 'out_col', 'params'},
+        required_params={'alg'},
+        param_validators={
+            'alg': is_string,
+            'out_col': is_string_or_none,
+            'params': is_dict,
+        },
+        description='Run built-in engine-agnostic graph algorithms (wcc, pagerank, cdlp, sssp, mis)',
+        schema_effects=_schema_effects(
+            # Output column defaults to the registry's name for the algorithm,
+            # not the algorithm name itself: wcc writes `component`, mis writes `mis`.
+            # Deferred import: the registry pulls in the kernels, and this module
+            # is imported while validating every query.
+            adds_node_cols=lambda p: [
+                p.get('out_col')
+                or __import__(
+                    'graphistry.compute.algorithms.registry', fromlist=['output_column']
+                ).output_column(p['alg'])
+            ]
+        ),
+    ),
+
     'compute_igraph': _safelist_entry(
         {'alg', 'out_col', 'directed', 'use_vids', 'params'},
         required_params={'alg'},

--- a/graphistry/compute/gfql/call/validation.py
+++ b/graphistry/compute/gfql/call/validation.py
@@ -656,10 +656,7 @@ SAFELIST_V1: Dict[str, Dict[str, Any]] = {
         },
         description='Run built-in engine-agnostic graph algorithms (wcc, pagerank, cdlp, sssp, mis)',
         schema_effects=_schema_effects(
-            # Output column defaults to the registry's name for the algorithm,
-            # not the algorithm name itself: wcc writes `component`, mis writes `mis`.
-            # Deferred import: the registry pulls in the kernels, and this module
-            # is imported while validating every query.
+            # Resolve registry output names lazily to avoid a validation import cycle.
             adds_node_cols=lambda p: [
                 p.get('out_col')
                 or __import__(

--- a/graphistry/compute/gfql/cypher/call_procedures.py
+++ b/graphistry/compute/gfql/cypher/call_procedures.py
@@ -350,6 +350,13 @@ def _normalized_value_columns(
         if len(value_cols) > 1:
             _raise_multi_column_out_col(call_params["out_col"])
         value_cols[0] = cast(str, call_params["out_col"])
+    if definition.backend == "std" and definition.algorithm == "pagerank":
+        params = call_params.get("params")
+        converged_col = (
+            params.get("converged_col") if isinstance(params, Mapping) else None
+        )
+        if isinstance(converged_col, str):
+            value_cols.append(converged_col)
     return tuple(value_cols)
 
 

--- a/graphistry/compute/gfql/cypher/call_procedures.py
+++ b/graphistry/compute/gfql/cypher/call_procedures.py
@@ -156,10 +156,7 @@ def _resolve_procedure_definition(call: CallClause) -> _ProcedureDefinition:
     algorithm = algorithm_parts[0]
 
     if backend_name == "std":
-        # `std` in the standard-library sense: our own engine-agnostic kernels,
-        # no optional third-party dependency, running on whichever engine holds
-        # the frames. Deliberately not named after the LDBC benchmark that
-        # motivated them -- that would imply a conformance audit we do not have.
+        # std selects built-in engine-agnostic kernels without optional dependencies.
         if algorithm not in _STD_COMPUTE_ALGS:
             raise _unsupported_call(
                 "Unsupported graphistry.std.* procedure in the local compiler",
@@ -391,8 +388,7 @@ def _source_value_columns(definition: _ProcedureDefinition) -> Tuple[str, ...]:
         return (definition.algorithm,)
 
     if definition.backend == "std":
-        # The output column is the registry's name for the algorithm, not the
-        # algorithm name: wcc writes `component`, sssp writes `distance`.
+        # Registry output names differ from algorithm names for WCC and SSSP.
         assert definition.algorithm is not None
         from graphistry.compute.algorithms.registry import output_column
 

--- a/graphistry/compute/gfql/cypher/call_procedures.py
+++ b/graphistry/compute/gfql/cypher/call_procedures.py
@@ -39,14 +39,16 @@ from graphistry.plugins.cugraph import (
     node_compute_algs_to_attr,
 )
 from graphistry.plugins.igraph import compute_algs as _IGRAPH_COMPUTE_ALGS
+from graphistry.compute.algorithms.registry import STD_COMPUTE_ALGS as _STD_COMPUTE_ALGS
 
 
 _ROW_KIND = Literal["degree", "node", "edge", "graph_only", "node_or_graph"]
-_BACKEND = Literal["degree", "cugraph", "igraph", "networkx"]
+_BACKEND = Literal["degree", "cugraph", "igraph", "networkx", "std"]
 
 _DEGREE_OUTPUTS: Tuple[str, ...] = ("nodeId", "degree", "degree_in", "degree_out")
 _CUGRAPH_RESERVED_KEYS = frozenset({"out_col", "params", "kind", "directed", "G"})
 _IGRAPH_RESERVED_KEYS = frozenset({"out_col", "directed", "use_vids", "params"})
+_STD_RESERVED_KEYS = frozenset({"out_col", "params"})
 
 
 @dataclass(frozen=True)
@@ -137,7 +139,7 @@ def _resolve_procedure_definition(call: CallClause) -> _ProcedureDefinition:
 
     is_write = parts[-1] == "write"
     backend_name = parts[1]
-    if backend_name not in {"igraph", "cugraph", "nx"}:
+    if backend_name not in {"igraph", "cugraph", "nx", "std"}:
         raise _unsupported_call(
             "Unsupported Cypher CALL procedure in the local compiler",
             call=call,
@@ -152,6 +154,26 @@ def _resolve_procedure_definition(call: CallClause) -> _ProcedureDefinition:
             value=call.procedure,
         )
     algorithm = algorithm_parts[0]
+
+    if backend_name == "std":
+        # `std` in the standard-library sense: our own engine-agnostic kernels,
+        # no optional third-party dependency, running on whichever engine holds
+        # the frames. Deliberately not named after the LDBC benchmark that
+        # motivated them -- that would imply a conformance audit we do not have.
+        if algorithm not in _STD_COMPUTE_ALGS:
+            raise _unsupported_call(
+                "Unsupported graphistry.std.* procedure in the local compiler",
+                call=call,
+                value=call.procedure,
+            )
+        return _ProcedureDefinition(
+            procedure=call.procedure,
+            backend="std",
+            algorithm=algorithm,
+            call_function="compute_std",
+            result_kind="graph" if is_write else "rows",
+            row_kind="node_or_graph",
+        )
 
     if backend_name == "igraph":
         if algorithm not in _IGRAPH_COMPUTE_ALGS:
@@ -368,6 +390,14 @@ def _source_value_columns(definition: _ProcedureDefinition) -> Tuple[str, ...]:
         assert definition.algorithm is not None
         return (definition.algorithm,)
 
+    if definition.backend == "std":
+        # The output column is the registry's name for the algorithm, not the
+        # algorithm name: wcc writes `component`, sssp writes `distance`.
+        assert definition.algorithm is not None
+        from graphistry.compute.algorithms.registry import output_column
+
+        return (output_column(definition.algorithm),)
+
     if definition.backend == "networkx":
         return networkx_source_value_columns(definition.algorithm)
 
@@ -463,6 +493,8 @@ def _normalize_call_params(
     raw_options = _parse_call_options(definition, call, params=params)
     if definition.backend == "igraph":
         reserved_keys = _IGRAPH_RESERVED_KEYS
+    elif definition.backend == "std":
+        reserved_keys = _STD_RESERVED_KEYS
     elif definition.backend == "networkx":
         reserved_keys = _NETWORKX_RESERVED_KEYS
     else:
@@ -670,6 +702,13 @@ def _execute_backend_call(base_graph: Plottable, compiled_call: CompiledCypherPr
                 suggestion="Install python-igraph or use graphistry.cugraph.* procedures.",
                 exc=exc,
             )
+
+    if compiled_call.call_function == "compute_std":
+        from graphistry.compute.algorithms.compute import compute_std
+
+        return compute_std(
+            _materialized_graph(base_graph), **dict(compiled_call.call_params)
+        )
 
     if compiled_call.call_function == "compute_cugraph":
         try:

--- a/graphistry/compute/gfql/ir/logical_plan.py
+++ b/graphistry/compute/gfql/ir/logical_plan.py
@@ -187,7 +187,7 @@ class ProcedureOutputColumn:
 @dataclass(frozen=True)
 class ProcedureCall(LogicalPlan):
     procedure: str = ""
-    backend: Literal["degree", "cugraph", "igraph", "networkx"] = "degree"
+    backend: Literal["degree", "cugraph", "igraph", "networkx", "std"] = "degree"
     algorithm: Optional[str] = None
     call_function: Optional[str] = None
     result_kind: Literal["rows", "graph"] = "rows"

--- a/graphistry/compute/gfql/schema_effects.py
+++ b/graphistry/compute/gfql/schema_effects.py
@@ -240,8 +240,11 @@ def schema_effect_for_procedure_output(
             if algorithm in STD_LABEL_ALGS
             else _STRING
         )
+        properties = _typed_properties(value_columns, logical_type)
+        if algorithm == "pagerank" and len(value_columns) > 1:
+            properties.update(_typed_properties(value_columns[1:], _BOOL))
         return SchemaEffect(
-            adds_node_properties=_typed_properties(value_columns, logical_type),
+            adds_node_properties=properties,
             confidence="declared",
         )
     if not value_columns:

--- a/graphistry/compute/gfql/schema_effects.py
+++ b/graphistry/compute/gfql/schema_effects.py
@@ -54,7 +54,10 @@ class SchemaEffect:
 _INT32 = ScalarType("int32")
 _INT64 = ScalarType("int64")
 _FLOAT64 = ScalarType("float64")
+_FLOAT32 = ScalarType("float32")
+_BOOL = ScalarType("bool")
 _STRING = ScalarType("string")
+_UNKNOWN = ScalarType("unknown")
 
 _NODE_FLOAT_ALGS: FrozenSet[str] = frozenset(
     (
@@ -214,6 +217,31 @@ def schema_effect_for_procedure_output(
                 "degree_in": _INT32,
                 "degree_out": _INT32,
             },
+            confidence="declared",
+        )
+    if backend == "std":
+        if not value_columns:
+            return None
+        from graphistry.compute.algorithms.registry import (
+            STD_BOOL_ALGS,
+            STD_FLOAT32_ALGS,
+            STD_FLOAT64_ALGS,
+            STD_LABEL_ALGS,
+        )
+
+        logical_type = (
+            _FLOAT64
+            if algorithm in STD_FLOAT64_ALGS
+            else _FLOAT32
+            if algorithm in STD_FLOAT32_ALGS
+            else _BOOL
+            if algorithm in STD_BOOL_ALGS
+            else _UNKNOWN
+            if algorithm in STD_LABEL_ALGS
+            else _STRING
+        )
+        return SchemaEffect(
+            adds_node_properties=_typed_properties(value_columns, logical_type),
             confidence="declared",
         )
     if not value_columns:

--- a/graphistry/tests/compute/algorithms/test_std_call.py
+++ b/graphistry/tests/compute/algorithms/test_std_call.py
@@ -1,0 +1,54 @@
+"""`CALL graphistry.std.*` — the kernels reachable as GFQL queries."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.algorithms import kernels as K
+from graphistry.compute.algorithms._dfops import dense_renumber
+
+
+@pytest.fixture(scope="module")
+def g():
+    return graphistry.edges(pd.DataFrame({"s": [10, 11, 10, 55], "d": [11, 12, 12, 66]}), "s", "d")
+
+
+@pytest.mark.parametrize("query,col", [
+    ("CALL graphistry.std.wcc.write()", "component"),
+    ("CALL graphistry.std.cdlp.write({params: {iterations: 3}})", "cdlp"),
+    ("CALL graphistry.std.mis.write()", "mis"),
+    ("CALL graphistry.std.sssp.write({params: {source: 0}})", "distance"),
+    ("CALL graphistry.std.pagerank.write()", "pagerank"),
+])
+def test_std_call_writes_expected_column(g, query, col):
+    assert col in g.gfql(query)._nodes.columns
+
+
+def test_out_col_override(g):
+    assert "pr" in g.gfql("CALL graphistry.std.pagerank.write({out_col: 'pr'})")._nodes.columns
+
+
+def test_unknown_std_procedure_is_rejected(g):
+    from graphistry.compute.exceptions import GFQLValidationError
+
+    with pytest.raises(GFQLValidationError):
+        g.gfql("CALL graphistry.std.louvain.write()")
+
+
+def test_call_result_matches_the_direct_kernel():
+    """The query surface must not change the answer, and WCC labels must come
+    back in the caller's id space -- the label IS a vertex id."""
+    rng = np.random.default_rng(5)
+    e = pd.DataFrame({"s": rng.integers(0, 500, 3000), "d": rng.integers(0, 500, 3000)})
+    e = e[e["s"] != e["d"]]
+
+    out = graphistry.edges(e, "s", "d").gfql("CALL graphistry.std.wcc.write()")
+    got = out._nodes.sort_values("id").reset_index(drop=True)
+
+    dense, ids, v_count = dense_renumber(e, "s", "d")
+    ref = [int(ids.iloc[int(x)]) for x in K.wcc(dense, "s", "d", v_count)]
+
+    assert list(got["component"]) == ref
+    assert got["component"].min() == got["id"].min()

--- a/graphistry/tests/compute/algorithms/test_std_call.py
+++ b/graphistry/tests/compute/algorithms/test_std_call.py
@@ -1,4 +1,5 @@
 """`CALL graphistry.std.*` — the kernels reachable as GFQL queries."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -15,13 +16,16 @@ def g():
     return graphistry.edges(pd.DataFrame({"s": [10, 11, 10, 55], "d": [11, 12, 12, 66]}), "s", "d")
 
 
-@pytest.mark.parametrize("query,col", [
-    ("CALL graphistry.std.wcc.write()", "component"),
-    ("CALL graphistry.std.cdlp.write({params: {iterations: 3}})", "cdlp"),
-    ("CALL graphistry.std.mis.write()", "mis"),
-    ("CALL graphistry.std.sssp.write({params: {source: 0}})", "distance"),
-    ("CALL graphistry.std.pagerank.write()", "pagerank"),
-])
+@pytest.mark.parametrize(
+    "query,col",
+    [
+        ("CALL graphistry.std.wcc.write()", "component"),
+        ("CALL graphistry.std.cdlp.write({params: {iterations: 3}})", "cdlp"),
+        ("CALL graphistry.std.mis.write()", "mis"),
+        ("CALL graphistry.std.sssp.write({params: {source: 10}})", "distance"),
+        ("CALL graphistry.std.pagerank.write()", "pagerank"),
+    ],
+)
 def test_std_call_writes_expected_column(g, query, col):
     assert col in g.gfql(query)._nodes.columns
 
@@ -30,11 +34,64 @@ def test_out_col_override(g):
     assert "pr" in g.gfql("CALL graphistry.std.pagerank.write({out_col: 'pr'})")._nodes.columns
 
 
+def test_std_row_call_yields_node_values(g):
+    out = g.gfql("CALL graphistry.std.pagerank() YIELD nodeId, pagerank RETURN nodeId, pagerank")
+    assert list(out._nodes.columns) == ["nodeId", "pagerank"]
+    assert set(out._nodes["nodeId"]) == {10, 11, 12, 55, 66}
+
+
 def test_unknown_std_procedure_is_rejected(g):
     from graphistry.compute.exceptions import GFQLValidationError
 
     with pytest.raises(GFQLValidationError):
         g.gfql("CALL graphistry.std.louvain.write()")
+
+
+def test_weighted_sssp_uses_original_string_source_id():
+    edges = pd.DataFrame({"s": ["a", "b", "a"], "d": ["b", "c", "c"], "cost": [2.0, 3.0, 99.0]})
+    out = graphistry.edges(edges, "s", "d").gfql("CALL graphistry.std.sssp.write({params: {source: 'a', weight: 'cost'}})")
+    got = out._nodes.set_index("id")["distance"].to_dict()
+    assert got == {"a": 0.0, "b": 2.0, "c": 5.0}
+
+
+@pytest.mark.parametrize("source", [0, "missing"])
+def test_sssp_rejects_unknown_original_source_id(g, source):
+    with pytest.raises(ValueError, match="is not a graph node"):
+        g.gfql(f"CALL graphistry.std.sssp.write({{params: {{source: {source!r}}}}})")
+
+
+def test_mis_drops_self_loops_at_public_boundary():
+    graph = graphistry.edges(pd.DataFrame({"s": [1], "d": [1]}), "s", "d").nodes(pd.DataFrame({"id": [1]}), "id")
+    out = graph.gfql("CALL graphistry.std.mis.write()")
+    assert bool(out._nodes.set_index("id").loc[1, "mis"]) is True
+
+
+@pytest.mark.parametrize(
+    "query,column,expected",
+    [
+        ("CALL graphistry.std.wcc.write()", "component", 99),
+        ("CALL graphistry.std.cdlp.write()", "cdlp", 99),
+        ("CALL graphistry.std.mis.write()", "mis", True),
+        ("CALL graphistry.std.sssp.write({params: {source: 10}})", "distance", np.inf),
+    ],
+)
+def test_std_call_retains_explicit_isolate(query, column, expected):
+    graph = graphistry.edges(pd.DataFrame({"s": [10], "d": [20]}), "s", "d").nodes(pd.DataFrame({"id": [10, 20, 99]}), "id")
+    out = graph.gfql(query)
+    isolate = out._nodes.set_index("id").loc[99, column]
+    assert isolate == expected
+
+
+def test_pagerank_retains_explicit_isolate():
+    graph = graphistry.edges(pd.DataFrame({"s": [10], "d": [20]}), "s", "d").nodes(pd.DataFrame({"id": [10, 20, 99]}), "id")
+    isolate = graph.gfql("CALL graphistry.std.pagerank.write()")._nodes.set_index("id").loc[99]
+    assert isolate["pagerank"] > 0.0
+
+
+def test_std_call_supports_negative_node_ids():
+    graph = graphistry.edges(pd.DataFrame({"s": [-2], "d": [-1]}), "s", "d")
+    got = graph.gfql("CALL graphistry.std.wcc.write()")._nodes.set_index("id")["component"]
+    assert got.to_dict() == {-2: -2, -1: -2}
 
 
 def test_call_result_matches_the_direct_kernel():

--- a/graphistry/tests/compute/algorithms/test_std_call.py
+++ b/graphistry/tests/compute/algorithms/test_std_call.py
@@ -109,3 +109,81 @@ def test_call_result_matches_the_direct_kernel():
 
     assert list(got["component"]) == ref
     assert got["component"].min() == got["id"].min()
+
+
+def _pagerank_compat_graph() -> object:
+    edges = pd.DataFrame({
+        "s": ["a", "a", "b", "c"],
+        "d": ["b", "c", "c", "a"],
+        "w": [2.0, 1.0, 3.0, 4.0],
+    })
+    nodes = pd.DataFrame({"id": ["a", "b", "c", "d"]})
+    return (
+        graphistry.edges(edges, "s", "d")
+        .nodes(nodes, "id")
+        .bind(edge_weight="w")
+    )
+
+
+def test_pagerank_cugraph_inputs_match_direct_and_gfql() -> None:
+    from graphistry.compute.algorithms.compute import compute_std
+
+    graph = _pagerank_compat_graph()
+    direct = compute_std(
+        graph,
+        "pagerank",
+        params={
+            "personalization": pd.DataFrame({
+                "vertex": ["a", "d"],
+                "values": [0.8, 0.2],
+            }),
+            "nstart": {"a": 1.0},
+            "precomputed_vertex_out_weight": [
+                {"vertex": "a", "sums": 3.0},
+                {"vertex": "b", "sums": 3.0},
+                {"vertex": "c", "sums": 4.0},
+            ],
+            "max_iter": 1,
+            "tol": 1.0e-30,
+            "fail_on_nonconvergence": False,
+            "converged_col": "pr_converged",
+        },
+    )
+    query = (
+        "CALL graphistry.std.pagerank.write({params: {"
+        "max_iter: 1, tol: 1e-30, fail_on_nonconvergence: false, "
+        "converged_col: 'pr_converged', "
+        "personalization: [{vertex: 'a', values: 0.8}, "
+        "{vertex: 'd', values: 0.2}], nstart: {a: 1.0}, "
+        "precomputed_vertex_out_weight: [{vertex: 'a', sums: 3.0}, "
+        "{vertex: 'b', sums: 3.0}, {vertex: 'c', sums: 4.0}]}})"
+    )
+    via_gfql = graph.gfql(query)
+
+    columns = ["id", "pagerank", "pr_converged"]
+    pd.testing.assert_frame_equal(direct._nodes[columns], via_gfql._nodes[columns])
+    got = via_gfql._nodes.set_index("id")
+    assert got["pagerank"].to_dict() == pytest.approx({
+        "a": 0.12,
+        "b": 0.85 * 2.0 / 3.0,
+        "c": 0.85 / 3.0,
+        "d": 0.03,
+    })
+    assert not bool(got["pr_converged"].any())
+
+
+def test_pagerank_vector_and_converged_column_validation() -> None:
+    from graphistry.compute.algorithms.compute import compute_std
+
+    graph = _pagerank_compat_graph()
+    with pytest.raises(ValueError, match="unknown graph vertex"):
+        compute_std(
+            graph,
+            "pagerank",
+            params={"personalization": {"missing": 1.0}},
+        )
+    with pytest.raises(
+        ValueError,
+        match="requires fail_on_nonconvergence=False",
+    ):
+        compute_std(graph, "pagerank", params={"converged_col": "converged"})

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -15,6 +15,7 @@ Three tiers in fail-fast order:
 
 from __future__ import annotations
 
+import inspect
 from collections import Counter
 
 import numpy as np
@@ -83,6 +84,91 @@ def test_pagerank_matches_hand_computation_with_dangling():
     assert float(pr.sum()) == pytest.approx(1.0, abs=1e-12)
     for got, want in zip(pr, ref):
         assert float(got) == pytest.approx(want, rel=1e-12)
+
+
+def test_pagerank_cugraph_compatible_signature_defaults():
+    signature = inspect.signature(K.pagerank)
+    expected = {
+        "alpha": 0.85,
+        "personalization": None,
+        "precomputed_vertex_out_weight": None,
+        "max_iter": 100,
+        "tol": 1.0e-5,
+        "nstart": None,
+        "dangling": None,
+        "fail_on_nonconvergence": True,
+    }
+    assert {name: signature.parameters[name].default for name in expected} == expected
+
+
+def test_pagerank_weighted_personalized_matches_networkx():
+    nx = pytest.importorskip("networkx")
+    edges = _edges([0, 0, 1, 2], [1, 2, 2, 0], [2.0, 1.0, 3.0, 4.0])
+    personalization = pd.Series([0.7, 0.1, 0.1, 0.1])
+    nstart = pd.Series([0.0, 1.0, 0.0, 0.0])
+    out_weight = pd.Series([3.0, 3.0, 4.0, np.nan])
+
+    got = K.pagerank(
+        edges,
+        "s",
+        "d",
+        4,
+        alpha=0.85,
+        personalization=personalization,
+        precomputed_vertex_out_weight=out_weight,
+        max_iter=1000,
+        tol=1.0e-12,
+        nstart=nstart,
+        dangling={"ignored": 1.0},
+        weight="w",
+    )
+
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(4))
+    for row in edges.itertuples(index=False):
+        graph.add_edge(row.s, row.d, weight=row.w)
+    ref = nx.pagerank(
+        graph,
+        alpha=0.85,
+        personalization={i: float(v) for i, v in enumerate(personalization)},
+        nstart={i: float(v) for i, v in enumerate(nstart)},
+        max_iter=1000,
+        tol=1.0e-12,
+        weight="weight",
+    )
+    assert [float(value) for value in got] == pytest.approx(
+        [ref[i] for i in range(4)], rel=1.0e-12, abs=1.0e-15
+    )
+
+
+def test_pagerank_nonconvergence_policy_and_fixed_alias():
+    edges = _edges([0, 1], [1, 2])
+    with pytest.raises(K.ConvergenceError):
+        K.pagerank(edges, "s", "d", 3, max_iter=1, tol=1.0e-30)
+
+    ranks, converged = K.pagerank(
+        edges,
+        "s",
+        "d",
+        3,
+        max_iter=1,
+        tol=1.0e-30,
+        fail_on_nonconvergence=False,
+    )
+    assert converged is False
+    assert float(ranks.sum()) == pytest.approx(1.0)
+
+    legacy = K.pagerank(edges, "s", "d", 3, iterations=10, damping=0.85)
+    explicit = K.pagerank(
+        edges,
+        "s",
+        "d",
+        3,
+        max_iter=10,
+        alpha=0.85,
+        stopping="fixed_iterations",
+    )
+    assert list(legacy) == pytest.approx(list(explicit), rel=1.0e-15)
 
 
 def test_cdlp_tie_breaks_to_smallest_label_and_oscillates():

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -1,6 +1,6 @@
 """Correctness gates for the Graphalytics kernels.
 
-Three tiers, cheapest first (this is step 1 of the benchmark's fail-fast order):
+Three tiers in fail-fast order:
 
 1. Toy graphs with hand-computed answers -- catches semantics bugs (the dangling
    term, CDLP's tie-break, multiset counting, MIS isolated-vertex handling).
@@ -12,6 +12,7 @@ Three tiers, cheapest first (this is step 1 of the benchmark's fail-fast order):
    original index, so a misaligned `df_cons` silently produced NaN. It only
    showed up once chunking was switched on.
 """
+
 from __future__ import annotations
 
 from collections import Counter

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -133,7 +133,7 @@ def test_pagerank_weighted_personalized_matches_networkx():
         personalization={i: float(v) for i, v in enumerate(personalization)},
         nstart={i: float(v) for i, v in enumerate(nstart)},
         max_iter=1000,
-        tol=1.0e-12,
+        tol=1.0e-12 / 4,
         weight="weight",
     )
     assert [float(value) for value in got] == pytest.approx(
@@ -169,6 +169,23 @@ def test_pagerank_nonconvergence_policy_and_fixed_alias():
         stopping="fixed_iterations",
     )
     assert list(legacy) == pytest.approx(list(explicit), rel=1.0e-15)
+
+
+def test_pagerank_tolerance_is_on_unit_mass_rank_scale():
+    edges = _edges([0], [1])
+    ranks, converged = K.pagerank(
+        edges,
+        "s",
+        "d",
+        100,
+        max_iter=1,
+        tol=0.01,
+        fail_on_nonconvergence=False,
+    )
+
+    # First-step L1 delta is 0.01683: above tol, but below V * tol (=1).
+    assert converged is False
+    assert float(ranks.sum()) == pytest.approx(1.0)
 
 
 def test_cdlp_tie_breaks_to_smallest_label_and_oscillates():

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -101,8 +101,7 @@ def test_pagerank_cugraph_compatible_signature_defaults():
     assert {name: signature.parameters[name].default for name in expected} == expected
 
 
-def test_pagerank_weighted_personalized_matches_networkx():
-    nx = pytest.importorskip("networkx")
+def test_pagerank_weighted_personalized_matches_linear_system():
     edges = _edges([0, 0, 1, 2], [1, 2, 2, 0], [2.0, 1.0, 3.0, 4.0])
     personalization = pd.Series([0.7, 0.1, 0.1, 0.1])
     nstart = pd.Series([0.0, 1.0, 0.0, 0.0])
@@ -123,21 +122,20 @@ def test_pagerank_weighted_personalized_matches_networkx():
         weight="w",
     )
 
-    graph = nx.DiGraph()
-    graph.add_nodes_from(range(4))
-    for row in edges.itertuples(index=False):
-        graph.add_edge(row.s, row.d, weight=row.w)
-    ref = nx.pagerank(
-        graph,
-        alpha=0.85,
-        personalization={i: float(v) for i, v in enumerate(personalization)},
-        nstart={i: float(v) for i, v in enumerate(nstart)},
-        max_iter=1000,
-        tol=1.0e-12 / 4,
-        weight="weight",
+    transition = np.array(
+        [
+            [0.0, 2.0 / 3.0, 1.0 / 3.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            list(personalization),
+        ]
+    )
+    ref = np.linalg.solve(
+        np.eye(4) - 0.85 * transition.T,
+        (1.0 - 0.85) * personalization.to_numpy(),
     )
     assert [float(value) for value in got] == pytest.approx(
-        [ref[i] for i in range(4)], rel=1.0e-12, abs=1.0e-15
+        list(ref), rel=1.0e-12, abs=1.0e-15
     )
 
 

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -1,0 +1,320 @@
+"""Correctness gates for the Graphalytics kernels.
+
+Three tiers, cheapest first (this is step 1 of the benchmark's fail-fast order):
+
+1. Toy graphs with hand-computed answers -- catches semantics bugs (the dangling
+   term, CDLP's tie-break, multiset counting, MIS isolated-vertex handling).
+2. Independent references on random graphs -- networkx for WCC and Dijkstra, a
+   naive Python LDBC implementation for CDLP, a plain-Python loop for PageRank.
+3. Chunk invariance -- chunked results must equal unchunked ones. This is the
+   property the 1B-edge runs depend on, and it is where an index-alignment bug
+   hid: `gather` returns a 0-based Series while an `iloc` slice keeps its
+   original index, so a misaligned `df_cons` silently produced NaN. It only
+   showed up once chunking was switched on.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from graphistry.compute.algorithms import _dfops as D
+from graphistry.compute.algorithms import kernels as K
+
+
+def _edges(src, dst, weights=None):
+    e = pd.DataFrame({"s": np.array(src, dtype="int32"), "d": np.array(dst, dtype="int32")})
+    if weights is not None:
+        e["w"] = np.array(weights, dtype="float32")
+    return e
+
+
+def _random_graph(seed: int, n: int, m: int, weighted: bool = False):
+    rng = np.random.default_rng(seed)
+    e = pd.DataFrame({"s": rng.integers(0, n, m), "d": rng.integers(0, n, m)})
+    e = e[e["s"] != e["d"]]
+    dense, ids, v_count = D.dense_renumber(e, "s", "d")
+    if weighted:
+        dense["w"] = K.make_weights(dense, "s", "d")
+    return dense, ids, v_count
+
+
+# --------------------------------------------------------------------------
+# Tier 1: hand-computed answers
+# --------------------------------------------------------------------------
+
+
+def test_dense_renumber_is_monotone():
+    """Monotone renumbering is what makes dense min-label == min original id."""
+    e = _edges([10, 10, 50, 90], [50, 90, 90, 10])
+    dense, ids, v_count = D.dense_renumber(e, "s", "d")
+    assert v_count == 3
+    assert list(ids) == [10, 50, 90] == sorted(ids)
+    assert str(dense["s"].dtype) == "int32"
+
+
+def test_wcc_labels_are_min_original_id():
+    e = _edges([0, 1, 0, 5], [1, 2, 2, 6])
+    dense, ids, v_count = D.dense_renumber(e, "s", "d")
+    lbl = K.wcc(dense, "s", "d", v_count)
+    as_orig = [int(ids.iloc[int(x)]) for x in lbl]
+    assert as_orig == [0, 0, 0, 5, 5]
+
+
+def test_pagerank_matches_hand_computation_with_dangling():
+    """Chain 0->1->2 where 2 is dangling; mass must be conserved."""
+    e = _edges([0, 1], [1, 2])
+    pr = K.pagerank(e, "s", "d", 3, iterations=10)
+
+    v_count, damping, iters = 3, 0.85, 10
+    out = {0: [1], 1: [2], 2: []}
+    ref = [1 / v_count] * v_count
+    for _ in range(iters):
+        dang = sum(ref[v] for v in range(v_count) if not out[v])
+        inflow = [0.0] * v_count
+        for u in range(v_count):
+            for w in out[u]:
+                inflow[w] += ref[u] / len(out[u])
+        ref = [(1 - damping) / v_count + damping * (inflow[v] + dang / v_count) for v in range(v_count)]
+
+    assert float(pr.sum()) == pytest.approx(1.0, abs=1e-12)
+    for got, want in zip(pr, ref):
+        assert float(got) == pytest.approx(want, rel=1e-12)
+
+
+def test_cdlp_tie_breaks_to_smallest_label_and_oscillates():
+    """Star 0--{1,2,3}: vertex 0 sees a 3-way tie and must pick the smallest.
+
+    The period-2 oscillation is why CDLP has no early exit -- 'no change' may
+    never happen, so the spec is K iterations regardless.
+    """
+    e = _edges([0, 0, 0], [1, 2, 3])
+    assert list(K.cdlp(e, "s", "d", 4, iterations=1)) == [1, 0, 0, 0]
+    assert list(K.cdlp(e, "s", "d", 4, iterations=2)) == [0, 1, 1, 1]
+    assert list(K.cdlp(e, "s", "d", 4, iterations=3)) == [1, 0, 0, 0]
+
+
+def test_cdlp_uses_multiset_not_set_semantics():
+    """Parallel edges count multiple times.
+
+    Neighbours of 0 are the multiset {2,2,1}, so label 2 wins with count 2.
+    Under set semantics it would be a {1,2} tie and resolve to 1, so this case
+    discriminates the two readings of the spec.
+    """
+    e = _edges([0, 0, 0], [2, 2, 1])
+    assert int(K.cdlp(e, "s", "d", 3, iterations=1).iloc[0]) == 2
+
+
+def test_sssp_re_relaxes_a_settled_vertex():
+    """0->2 costs 100 directly but 7 via 1, so vertex 2 must be improved after
+    it has already been assigned -- the case a visited-set BFS gets wrong."""
+    e = _edges([0, 1, 0], [1, 2, 2], [5.0, 2.0, 100.0])
+    assert list(K.sssp(e, "s", "d", "w", 3, source=0)) == [0.0, 5.0, 7.0]
+
+
+def test_sssp_marks_unreachable_as_inf():
+    e = _edges([0], [1], [2.0])
+    out = list(K.sssp(e, "s", "d", "w", 3, source=0))
+    assert out[:2] == [0.0, 2.0]
+    assert np.isinf(out[2])
+
+
+def test_mis_on_a_path_with_an_isolated_vertex():
+    e = _edges([0, 1, 2, 3], [1, 2, 3, 4])
+    in_set = K.mis(e, "s", "d", 6)
+    chosen = {i for i, x in enumerate(in_set) if x}
+    edges = [(0, 1), (1, 2), (2, 3), (3, 4)]
+    assert all(not (u in chosen and v in chosen) for u, v in edges)
+    assert 5 in chosen, "isolated vertices must be in the set or maximality fails"
+
+
+# --------------------------------------------------------------------------
+# Tier 2: independent references
+# --------------------------------------------------------------------------
+
+
+def test_wcc_matches_networkx():
+    nx = pytest.importorskip("networkx")
+    dense, _, v_count = _random_graph(11, 500, 2500)
+    g = nx.DiGraph()
+    g.add_nodes_from(range(v_count))
+    g.add_edges_from(zip(dense["s"].tolist(), dense["d"].tolist()))
+
+    ref = {}
+    for comp in nx.weakly_connected_components(g):
+        low = min(comp)
+        for v in comp:
+            ref[v] = low
+
+    mine = K.wcc(dense, "s", "d", v_count)
+    assert all(int(mine.iloc[v]) == ref[v] for v in range(v_count))
+
+
+def test_sssp_matches_dijkstra_exactly():
+    """Integer weights in [1,255] keep every distance exactly representable in
+    float32, so this is an EXACT comparison, not a tolerance one."""
+    nx = pytest.importorskip("networkx")
+    dense, _, v_count = _random_graph(11, 500, 2500, weighted=True)
+    g = nx.DiGraph()
+    g.add_nodes_from(range(v_count))
+    for s, d, w in zip(dense["s"].tolist(), dense["d"].tolist(), dense["w"].tolist()):
+        g.add_edge(int(s), int(d), weight=float(w))
+
+    ref = nx.single_source_dijkstra_path_length(g, 0, weight="weight")
+    mine = K.sssp(dense, "s", "d", "w", v_count, source=0)
+    for v in range(v_count):
+        assert float(mine.iloc[v]) == ref.get(v, float("inf"))
+
+
+def test_cdlp_matches_naive_ldbc_reference():
+    dense, _, v_count = _random_graph(11, 300, 1500)
+    iterations = 10
+
+    nbr: dict[int, list[int]] = {v: [] for v in range(v_count)}
+    for s, d in zip(dense["s"].tolist(), dense["d"].tolist()):
+        nbr[int(s)].append(int(d))
+        nbr[int(d)].append(int(s))
+
+    lbl = list(range(v_count))
+    for _ in range(iterations):
+        nxt = list(lbl)
+        for v in range(v_count):
+            if not nbr[v]:
+                continue
+            counts = Counter(lbl[u] for u in nbr[v])
+            # most frequent, ties -> smallest label
+            nxt[v] = max(counts.items(), key=lambda kv: (kv[1], -kv[0]))[0]
+        lbl = nxt
+
+    mine = K.cdlp(dense, "s", "d", v_count, iterations=iterations)
+    assert [int(x) for x in mine] == lbl
+
+
+def test_mis_invariants_hold_at_scale():
+    dense, _, v_count = _random_graph(3, 2000, 12000)
+    in_set = K.mis(dense, "s", "d", v_count).values
+    src = dense["s"].values
+    dst = dense["d"].values
+
+    assert not bool((in_set[src] & in_set[dst]).any()), "not independent"
+
+    nbr_in_set = np.zeros(v_count, dtype=bool)
+    np.logical_or.at(nbr_in_set, src, in_set[dst])
+    np.logical_or.at(nbr_in_set, dst, in_set[src])
+    assert not bool((~in_set & ~nbr_in_set).any()), "not maximal"
+
+    assert in_set.sum() > 0
+
+
+def test_mis_is_deterministic_and_seed_sensitive():
+    dense, _, v_count = _random_graph(3, 2000, 12000)
+    a = K.mis(dense, "s", "d", v_count).values
+    assert np.array_equal(a, K.mis(dense, "s", "d", v_count).values)
+    assert not np.array_equal(a, K.mis(dense, "s", "d", v_count, seed=99).values)
+
+
+# --------------------------------------------------------------------------
+# Tier 3: chunk invariance -- the property the 1B-edge runs depend on
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kernel", ["wcc", "cdlp", "sssp", "mis"])
+def test_chunked_equals_unchunked_exactly(kernel):
+    dense, _, v_count = _random_graph(7, 400, 3000, weighted=True)
+    run = {
+        "wcc": lambda c: K.wcc(dense, "s", "d", v_count, chunks=c),
+        "cdlp": lambda c: K.cdlp(dense, "s", "d", v_count, chunks=c),
+        "sssp": lambda c: K.sssp(dense, "s", "d", "w", v_count, source=0, chunks=c),
+        "mis": lambda c: K.mis(dense, "s", "d", v_count, chunks=c),
+    }[kernel]
+    assert np.array_equal(run(1).values, run(4).values)
+
+
+def test_pagerank_chunking_drift_is_float_noise_only():
+    """PageRank is the one kernel compared by tolerance: float64 summation is
+    not associative, so chunk boundaries shift the last bits (~1e-16). Every
+    other kernel is integer or exact-float32 and must match bitwise."""
+    dense, _, v_count = _random_graph(7, 400, 3000)
+    a = K.pagerank(dense, "s", "d", v_count, chunks=1).values
+    b = K.pagerank(dense, "s", "d", v_count, chunks=4).values
+    rel = np.max(np.abs(a - b) / np.maximum(np.abs(a), 1e-30))
+    assert rel < 1e-12, f"chunking drift {rel:.3e} is larger than float noise"
+
+
+# --------------------------------------------------------------------------
+# Validators must REJECT corrupted results, not just accept good ones.
+# A validator that always passes is worse than no validator, because it makes
+# an unchecked number look checked.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _prepared():
+    # The validators address columns as src/dst/w, matching what the runner's
+    # `prepare` step produces -- so the fixture must use those names too.
+    dense, _, v_count = _random_graph(5, 800, 5000, weighted=True)
+    dense = dense.rename(columns={"s": "src", "d": "dst"})
+    return {
+        "edges": dense,
+        "vertices": v_count,
+        "edge_count": len(dense),
+        "sssp_source": 0,
+    }
+
+
+def _run(kernel, prep):
+    d, v = prep["edges"], prep["vertices"]
+    return {
+        "wcc": lambda: K.wcc(d, "src", "dst", v),
+        "pagerank": lambda: K.pagerank(d, "src", "dst", v),
+        "cdlp": lambda: K.cdlp(d, "src", "dst", v),
+        "sssp": lambda: K.sssp(d, "src", "dst", "w", v, source=0),
+        "mis": lambda: K.mis(d, "src", "dst", v),
+    }[kernel]()
+
+
+@pytest.mark.parametrize("kernel", ["wcc", "pagerank", "cdlp", "sssp", "mis"])
+def test_validator_accepts_a_correct_result(kernel, _prepared):
+    from graphistry.compute.algorithms import validate as V
+
+    assert V.validate_result(kernel, _run(kernel, _prepared), _prepared)["status"] == "ok"
+
+
+def test_wcc_validator_rejects_a_wrong_label(_prepared):
+    from graphistry.compute.algorithms import validate as V
+
+    bad = _run("wcc", _prepared).copy()
+    bad.iloc[5] = 1 if int(bad.iloc[5]) != 1 else 2
+    assert V.validate_result("wcc", bad, _prepared)["status"] == "fail"
+
+
+def test_pagerank_validator_rejects_broken_mass(_prepared):
+    from graphistry.compute.algorithms import validate as V
+
+    bad = _run("pagerank", _prepared).copy()
+    bad.iloc[0] *= 2
+    assert V.validate_result("pagerank", bad, _prepared)["status"] == "fail"
+
+
+def test_sssp_validator_rejects_a_triangle_inequality_violation(_prepared):
+    from graphistry.compute.algorithms import validate as V
+
+    bad = _run("sssp", _prepared).copy()
+    bad.iloc[3] = bad.iloc[3] + 50
+    assert V.validate_result("sssp", bad, _prepared)["status"] == "fail"
+
+
+def test_mis_validator_rejects_both_failure_modes(_prepared):
+    """All-in violates independence; all-out violates maximality. A validator
+    that only checked one would pass one of these."""
+    from graphistry.compute.algorithms import validate as V
+
+    everything = _run("mis", _prepared).copy()
+    everything.iloc[:] = True
+    assert V.validate_result("mis", everything, _prepared)["status"] == "fail"
+
+    nothing = _run("mis", _prepared).copy()
+    nothing.iloc[:] = False
+    assert V.validate_result("mis", nothing, _prepared)["status"] == "fail"

--- a/graphistry/tests/compute/gfql/test_engine_polars_conformance_matrix.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_conformance_matrix.py
@@ -858,8 +858,8 @@ _CALL_CONSISTENCY_FNS = ["get_degrees", "hypergraph", "limit"]
 
 def _call_exercised_functions():
     """call()-safelist names this matrix exercises (importable for the ledger): the consistency
-    test drives _CALL_CONSISTENCY_FNS; the degree trio also has dedicated conformance tests."""
-    return set(_CALL_CONSISTENCY_FNS) | {"get_degrees", "get_indegrees", "get_outdegrees"}
+    test drives _CALL_CONSISTENCY_FNS; the degree trio and compute_std have dedicated tests."""
+    return set(_CALL_CONSISTENCY_FNS) | {"compute_std", "get_degrees", "get_indegrees", "get_outdegrees"}
 
 
 def _rowop_exercised():
@@ -886,6 +886,14 @@ def test_conformance_call_chain_vs_dag_consistent(fn):
     chain = _run(g, chain_q, "polars")
     dag = _run(g, let({"a": (call(fn, params) if params else call(fn))}), "polars")
     assert_surfaces_agree(chain, dag, f"call '{fn}' chain-vs-dag")
+
+
+def test_conformance_compute_std_call_chain_vs_dag_consistent():
+    g = _graph(3)
+    params = {"alg": "wcc"}
+    chain = _run(g, [call("compute_std", params)], "polars")
+    dag = _run(g, let({"a": call("compute_std", params)}), "polars")
+    assert_surfaces_agree(chain, dag, "call 'compute_std' chain-vs-dag")
 
 
 # ---- generative predicate fuzz across surfaces (verify-not-trust: broad, seeded) ----

--- a/graphistry/tests/compute/gfql/test_schema_effects.py
+++ b/graphistry/tests/compute/gfql/test_schema_effects.py
@@ -173,6 +173,20 @@ def test_cypher_std_write_updates_bound_schema_with_truthful_type(query: str, co
     assert enriched._gfql_schema.node_types[0].properties[column] == logical_type
 
 
+def test_cypher_std_pagerank_convergence_column_is_bool() -> None:
+    enriched = _bound_graph().gfql(
+        "CALL graphistry.std.pagerank.write({params: {"
+        "max_iter: 1, tol: 1e-30, fail_on_nonconvergence: false, "
+        "converged_col: 'pr_converged'}})"
+    )
+
+    _assert_node_property_validates(enriched, "pagerank")
+    _assert_node_property_validates(enriched, "pr_converged")
+    properties = enriched._gfql_schema.node_types[0].properties
+    assert properties["pagerank"] == ScalarType("float64")
+    assert properties["pr_converged"] == ScalarType("bool")
+
+
 def test_cypher_cugraph_edge_write_updates_bound_schema_for_next_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/graphistry/tests/compute/gfql/test_schema_effects.py
+++ b/graphistry/tests/compute/gfql/test_schema_effects.py
@@ -152,6 +152,27 @@ def test_cypher_igraph_pagerank_write_updates_bound_schema_for_next_validation(
     assert enriched._gfql_schema.node_types[0].properties["pagerank"] == ScalarType("float64")
 
 
+@pytest.mark.parametrize(
+    "query,column,logical_type",
+    [
+        ("CALL graphistry.std.pagerank.write()", "pagerank", ScalarType("float64")),
+        (
+            "CALL graphistry.std.sssp.write({params: {source: 'a'}})",
+            "distance",
+            ScalarType("float32"),
+        ),
+        ("CALL graphistry.std.mis.write()", "mis", ScalarType("bool")),
+        ("CALL graphistry.std.wcc.write()", "component", ScalarType("unknown")),
+        ("CALL graphistry.std.cdlp.write()", "cdlp", ScalarType("unknown")),
+    ],
+)
+def test_cypher_std_write_updates_bound_schema_with_truthful_type(query: str, column: str, logical_type: ScalarType) -> None:
+    enriched = _bound_graph().gfql(query)
+
+    _assert_node_property_validates(enriched, column)
+    assert enriched._gfql_schema.node_types[0].properties[column] == logical_type
+
+
 def test_cypher_cugraph_edge_write_updates_bound_schema_for_next_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- add engine-agnostic dataframe kernels for WCC, PageRank, CDLP, weighted SSSP, and MIS
- expose graph-write and row-returning forms through `CALL graphistry.std.*`
- preserve original node IDs, explicit isolates, edge weight columns, and truthful schema effects
- document syntax, options, engine behavior, and result status

## PageRank compatibility

`graphistry.std.pagerank` now accepts the current cuGraph PageRank signature and defaults:

```python
alpha=0.85
personalization=None
precomputed_vertex_out_weight=None
max_iter=100
tol=1.0e-5
nstart=None
dangling=None
fail_on_nonconvergence=True
```

The std implementation also keeps Graphistry extras: dataframe-engine portability (pandas on CPU or cuDF on GPU), `weight`, chunk sizing, `stopping="fixed_iterations"`, legacy `iterations` / `damping` aliases, and optional `converged_col`. Vector inputs accept original-ID maps, record lists, and dataframe forms. `dangling` is accepted for signature compatibility and intentionally ignored, matching cuGraph's public contract.

This is a portable GFQL/std fallback, not a replacement for native backends on performance. Native `graphistry.cugraph.*` and igraph integrations remain the preferred fast path when installed.

## Correctness boundaries

- PageRank convergence uses L1 change on the unit-mass rank vector; `fail_on_nonconvergence=False` returns convergence status
- SSSP `source` is an original node ID; unknown or incompatible IDs fail clearly
- WCC/CDLP labels map back to original node IDs
- MIS ignores self-loops and includes isolated nodes
- PageRank/SSSP/MIS schema types are float64/float32/bool; WCC/CDLP remain caller-ID-dependent
- implementations follow documented Graphalytics-style semantics, but are not official or audited LDBC Graphalytics submissions; MIS is not an official Graphalytics algorithm

## Matched PageRank performance

Guarded same-dataset measurements on directed, unweighted cit-Patents (3,774,768 vertices / 16,518,947 edges), with graph preparation excluded and three timed repetitions:

| backend/profile | median | native comparison |
|---|---:|---:|
| cuGraph 26.02, default | 0.0352s | baseline |
| std-cuDF, default | 1.7796s | 50.6x slower |
| cuGraph 26.02, `tol=1e-8` | 0.0443s | baseline |
| std-cuDF, `tol=1e-8` | 2.5368s | 57.2x slower |
| igraph 1.0 PRPACK | 1.4495s | baseline |
| std-pandas, default | 6.0490s | 4.17x slower |
| std-pandas, `tol=1e-8` | 8.1265s | 5.61x slower |

Retained top-10 vertex IDs match in every comparison. Maximum retained-rank deltas are below `1e-10` for the aligned GPU profiles; igraph PRPACK does not expose a matching tolerance control. Full artifacts and reproducibility details are in graphistry/pyg-bench#193.

## Validation

- focused std/schema/docs regression: 66 passed
- post-CI dependency-neutral PageRank kernel module: 31 passed
- `./bin/lint.sh`
- `./bin/typecheck.sh` (337 source files)
- `./bin/check_docs_latex_unicode.sh`
- `git diff --check`

No Docker, GPU, dataset, or benchmark workload was run locally. All performance work ran on dgx-spark through the shared perf lock and `safe_run.sh`, with cgroup/RMM limits, host-memory floor, watchdog, and hard timeouts.

Closes #1975
