### PR TITLE
perf(pagerank): add fast, bounded, and memory-aware auto paths

### DIFF
--- a/docs/source/gfql/standard_algorithms.rst
+++ b/docs/source/gfql/standard_algorithms.rst
@@ -101,12 +101,13 @@ Pass ``weight`` as an edge-column name. When omitted, the graph's bound edge
 weight is used; without either, every edge has weight 1. ``chunks`` controls
 dataframe chunking without changing the result.
 
-``method='auto'`` is the default. It uses a backend-native NumPy or CuPy array
-reduction when ``chunks=1``, avoiding per-iteration dataframe sorting and
-groupby materialization on both CPU and GPU. Set ``method='bounded'`` to retain
-the chunkable dataframe path when peak memory is the priority. Explicit
-``method='fast'`` requires ``chunks=1``; setting ``chunks`` above one makes
-``auto`` select ``bounded``.
+``method='auto'`` is the default. With ``chunks=1``, it uses a conservative
+preflight estimate and selects the backend-native NumPy or CuPy fast path only
+when its estimated peak scratch is at most half the detected free host/device
+memory. Unknown or tighter memory falls back to the dataframe path. Explicit
+``method='fast'`` bypasses the estimate and requires ``chunks=1``. Set
+``method='bounded'`` with ``chunks>1`` for the strongest explicit peak-memory
+control; setting ``chunks`` above one also makes ``auto`` select ``bounded``.
 
 By default PageRank raises when ``max_iter`` is exhausted. Set
 ``fail_on_nonconvergence: false`` to keep the last iterate. The Graphistry extra

--- a/docs/source/gfql/standard_algorithms.rst
+++ b/docs/source/gfql/standard_algorithms.rst
@@ -58,7 +58,7 @@ Algorithms and options
        in each component.
    * - ``pagerank``
      - ``pagerank``
-     - cuGraph-compatible controls plus ``weight``, ``chunks``, ``stopping``
+     - cuGraph controls plus ``weight``, ``method``, ``chunks``, ``stopping``
      - Directed, optionally weighted PageRank. Convergence is the default;
        fixed-iteration execution is explicit.
    * - ``cdlp``
@@ -100,6 +100,13 @@ out sums are computed normally.
 Pass ``weight`` as an edge-column name. When omitted, the graph's bound edge
 weight is used; without either, every edge has weight 1. ``chunks`` controls
 dataframe chunking without changing the result.
+
+``method='auto'`` is the default. It uses a backend-native NumPy or CuPy array
+reduction when ``chunks=1``, avoiding per-iteration dataframe sorting and
+groupby materialization on both CPU and GPU. Set ``method='bounded'`` to retain
+the chunkable dataframe path when peak memory is the priority. Explicit
+``method='fast'`` requires ``chunks=1``; setting ``chunks`` above one makes
+``auto`` select ``bounded``.
 
 By default PageRank raises when ``max_iter`` is exhausted. Set
 ``fail_on_nonconvergence: false`` to keep the last iterate. The Graphistry extra

--- a/graphistry/compute/algorithms/_dfops.py
+++ b/graphistry/compute/algorithms/_dfops.py
@@ -22,11 +22,11 @@ Banned in kernels: `.apply`, `groupby().apply`, `idxmin`/`idxmax`, `mode()`,
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Iterator, Mapping, Optional, Sequence, SupportsInt, Tuple
+from typing import Iterator, Mapping, Optional, Sequence, SupportsFloat, SupportsInt, Tuple
 
 import pandas as pd
 
-from graphistry.compute.typing import DataFrameT, SeriesT
+from graphistry.compute.typing import ArrayLike, ArrayNamespace, DataFrameT, SeriesT
 
 # 2**32, as a plain Python int. Used for bit-packing via arithmetic.
 SHIFT32 = 1 << 32
@@ -35,6 +35,44 @@ SHIFT32 = 1 << 32
 def is_cudf(obj: object) -> bool:
     """True when obj belongs to cudf, without importing cudf on CPU-only hosts."""
     return type(obj).__module__.split(".")[0] == "cudf"
+
+
+def array_namespace(template: object) -> ArrayNamespace:
+    """NumPy or CuPy for the dataframe or Series engine holding the template."""
+    if is_cudf(template):
+        import cupy
+
+        return cupy
+    import numpy
+
+    return numpy  # type: ignore[return-value]
+
+
+def series_to_array(series: SeriesT) -> ArrayLike:
+    """A host or device array view of a dense positional Series."""
+    if is_cudf(series):
+        return series.values
+    return series.to_numpy()
+
+
+def series_from_array(template: object, values: ArrayLike) -> SeriesT:
+    """Build a default-index Series on the same engine as the template."""
+    if is_cudf(template):
+        import cudf
+
+        return cudf.Series(values)
+    return pd.Series(values)
+
+
+def to_host_floats(values: Sequence[SupportsFloat]) -> tuple[float, ...]:
+    """Transfer several backend scalars together, requiring one GPU sync."""
+    if not values:
+        return ()
+    if type(values[0]).__module__.split(".")[0] == "cupy":
+        import cupy
+
+        return tuple(float(value) for value in cupy.asnumpy(cupy.stack(values)))
+    return tuple(float(value) for value in values)
 
 
 def _mod(frame: DataFrameT) -> ModuleType:

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -23,6 +23,7 @@ semantics without requiring an optional graph backend.
 
 from __future__ import annotations
 
+import os
 from typing import Callable, Literal, Optional, Union
 
 from graphistry.compute.typing import ArrayLike, DataFrameT, SeriesT
@@ -384,6 +385,89 @@ def _pagerank_bounded(
     return _pagerank_iterations(initial, step, max_iter, tol, stopping)
 
 
+_PAGERANK_AUTO_FIXED_BYTES = 64 * 1024 * 1024
+_PAGERANK_AUTO_HEADROOM_DIVISOR = 2
+
+
+def _pagerank_fast_estimated_bytes(
+    edges: DataFrameT, v_count: int, weighted: bool
+) -> int:
+    """Conservative peak scratch estimate calibrated against matched runs."""
+    edge_count = len(edges)
+    if is_cudf(edges):
+        vertex_bytes = 96 * v_count
+        edge_bytes = 16 * edge_count if weighted else 0
+    else:
+        vertex_bytes = 64 * v_count
+        edge_bytes = (24 if weighted else 8) * edge_count
+    return _PAGERANK_AUTO_FIXED_BYTES + vertex_bytes + edge_bytes
+
+
+def _pagerank_cgroup_available_bytes(
+    limit_path: str, current_path: str
+) -> Optional[int]:
+    try:
+        with open(limit_path, encoding="utf-8") as limit_file:
+            limit_text = limit_file.read().strip()
+        if limit_text == "max":
+            return None
+        with open(current_path, encoding="utf-8") as current_file:
+            current_text = current_file.read().strip()
+        limit = int(limit_text)
+        current = int(current_text)
+    except (OSError, ValueError):
+        return None
+    if limit <= 0 or limit >= 1 << 60 or current < 0:
+        return None
+    return max(0, limit - current)
+
+
+def _pagerank_host_available_bytes() -> Optional[int]:
+    candidates = []
+    try:
+        pages = int(os.sysconf("SC_AVPHYS_PAGES"))
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+        if pages > 0 and page_size > 0:
+            candidates.append(pages * page_size)
+    except (AttributeError, OSError, TypeError, ValueError):
+        pass
+    for limit_path, current_path in (
+        ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
+        (
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+        ),
+    ):
+        remaining = _pagerank_cgroup_available_bytes(limit_path, current_path)
+        if remaining is not None:
+            candidates.append(remaining)
+    return min(candidates) if candidates else None
+
+
+def _pagerank_available_bytes(edges: DataFrameT) -> Optional[int]:
+    if is_cudf(edges):
+        try:
+            import cupy
+
+            free_bytes, _ = cupy.cuda.Device().mem_info
+            return int(free_bytes)
+        except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+            return None
+    return _pagerank_host_available_bytes()
+
+
+def _pagerank_auto_uses_fast(
+    edges: DataFrameT, v_count: int, weighted: bool, chunks: int
+) -> bool:
+    if chunks != 1:
+        return False
+    available = _pagerank_available_bytes(edges)
+    if available is None or available <= 0:
+        return False
+    estimate = _pagerank_fast_estimated_bytes(edges, v_count, weighted)
+    return estimate <= available // _PAGERANK_AUTO_HEADROOM_DIVISOR
+
+
 def pagerank(
     edges: DataFrameT,
     src: str,
@@ -449,7 +533,10 @@ def pagerank(
             raise ValueError(f"pagerank {name} values must have a positive sum")
         return out / total
 
-    use_fast = method == "fast" or (method == "auto" and chunks == 1)
+    use_fast = method == "fast" or (
+        method == "auto"
+        and _pagerank_auto_uses_fast(edges, v_count, weight is not None, chunks)
+    )
     use_cudf_fast = use_fast and is_cudf(edges)
 
     if weight is None:

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -164,13 +164,13 @@ def _pagerank_cudf_fast(
     stopping: Literal["convergence", "fixed_iterations"],
 ) -> tuple[SeriesT, bool]:
     """CuPy fast path with reusable dense buffers and fused atomic scatter."""
-    xp = array_namespace(edges)
+    import cupy as xp
     src_values = series_to_array(edges[src])
     dst_values = series_to_array(edges[dst])
     out_weight_values = series_to_array(out_weight)
     teleport_values = series_to_array(teleport)
     initial_values = series_to_array(initial)
-    dangling_weights = series_to_array(is_dangling).astype(xp.float64, copy=False)
+    dangling_weights = xp.asarray(series_to_array(is_dangling), dtype=xp.float64)
     weight_values = series_to_array(edges[weight].reset_index(drop=True).astype("float64")) if weight is not None else None
     weighted = weight_values is not None
     weight_parameter = "const double* edge_weight," if weighted else ""
@@ -214,7 +214,7 @@ def _pagerank_cudf_fast(
     )
     inflow = xp.empty(v_count, dtype=xp.float64)
     next_values = xp.empty(v_count, dtype=xp.float64)
-    edge_count = int(src_values.size)
+    edge_count = int(src_values.shape[0])
     edge_count_arg = xp.uint64(edge_count)
     threads = 256
     blocks = min(65535, max(1, (edge_count + threads - 1) // threads))
@@ -541,7 +541,7 @@ def pagerank(
 
     if weight is None:
         if use_cudf_fast:
-            xp = array_namespace(edges)
+            import cupy as xp
             computed_out = series_from_array(
                 edges,
                 xp.bincount(series_to_array(edges[src]), minlength=v_count).astype(xp.float64, copy=False),
@@ -568,7 +568,7 @@ def pagerank(
         if to_host_int(invalid_weight.sum()) != 0:
             raise ValueError("pagerank edge weights must be finite and non-negative")
         if use_cudf_fast:
-            xp = array_namespace(edges)
+            import cupy as xp
             computed_out = series_from_array(
                 edges,
                 xp.bincount(

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -23,14 +23,15 @@ semantics without requiring an optional graph backend.
 
 from __future__ import annotations
 
-from typing import Literal, Optional, Union
+from typing import Callable, Literal, Optional, Union
 
-from graphistry.compute.typing import DataFrameT, SeriesT
+from graphistry.compute.typing import ArrayLike, DataFrameT, SeriesT
 
 from ._dfops import (
     SHIFT32,
     align,
     arange,
+    array_namespace,
     chunk_bounds,
     concat_frames,
     df_cons,
@@ -40,8 +41,11 @@ from ._dfops import (
     is_cudf,
     mask_rows,
     rows,
+    series_from_array,
+    series_to_array,
     slice_by_key,
     splitmix64,
+    to_host_floats,
     to_host_int,
     u64,
     vertex_ranges,
@@ -122,6 +126,136 @@ def wcc(edges: DataFrameT, src: str, dst: str, v_count: int, chunks: int = 1, ma
     raise ConvergenceError(f"wcc did not converge in {max_iter} iterations")
 
 
+def _pagerank_iterations(
+    initial: ArrayLike,
+    step: Callable[[ArrayLike], tuple[ArrayLike, float, float]],
+    max_iter: int,
+    tol: float,
+    stopping: Literal["convergence", "fixed_iterations"],
+) -> tuple[ArrayLike, bool]:
+    """Run the common PageRank convergence and mass policy for either backend."""
+    current = initial
+    converged = False
+    for _iteration in range(max_iter):
+        new, total, delta = step(current)
+        if abs(total - 1.0) > 1e-9:
+            raise AssertionError(f"pagerank mass not conserved: sum={total!r}")
+        converged = delta < float(tol)
+        current = new
+        if stopping == "convergence" and converged:
+            break
+    return current, converged
+
+
+def _pagerank_fast(
+    edges: DataFrameT,
+    src: str,
+    dst: str,
+    v_count: int,
+    weight: Optional[str],
+    out_weight: SeriesT,
+    is_dangling: SeriesT,
+    teleport: SeriesT,
+    initial: SeriesT,
+    damping: float,
+    max_iter: int,
+    tol: float,
+    stopping: Literal["convergence", "fixed_iterations"],
+) -> tuple[SeriesT, bool]:
+    """Backend-native dense reduction without dataframe materialization."""
+    xp = array_namespace(edges)
+    src_values = series_to_array(edges[src])
+    dst_values = series_to_array(edges[dst])
+    weight_values = (
+        series_to_array(edges[weight].reset_index(drop=True).astype("float64"))
+        if weight is not None
+        else None
+    )
+    dangling_mask = series_to_array(is_dangling)
+    safe_out = series_to_array(out_weight.where(~is_dangling, 1.0))
+    teleport_values = series_to_array(teleport)
+    initial_values = series_to_array(initial)
+
+    def step(current: ArrayLike) -> tuple[ArrayLike, float, float]:
+        contribution = xp.where(
+            dangling_mask, 0.0, xp.divide(current, safe_out)
+        )
+        messages = contribution[src_values]
+        if weight_values is not None:
+            messages = xp.multiply(messages, weight_values)
+        inflow = xp.bincount(dst_values, weights=messages, minlength=v_count)
+        dangling_mass = xp.multiply(current, dangling_mask).sum()
+        new = xp.multiply(teleport_values, 1.0 - damping) + xp.multiply(
+            inflow + xp.multiply(teleport_values, dangling_mass), damping
+        )
+        total, delta = to_host_floats(
+            (new.sum(), xp.absolute(new - current).sum())
+        )
+        return new, total, delta
+
+    result, converged = _pagerank_iterations(
+        initial_values, step, max_iter, tol, stopping
+    )
+    return series_from_array(edges, result), converged
+
+
+def _pagerank_bounded(
+    edges: DataFrameT,
+    src: str,
+    dst: str,
+    v_count: int,
+    weight: Optional[str],
+    chunks: int,
+    out_weight: SeriesT,
+    is_dangling: SeriesT,
+    teleport: SeriesT,
+    initial: SeriesT,
+    damping: float,
+    max_iter: int,
+    tol: float,
+    stopping: Literal["convergence", "fixed_iterations"],
+) -> tuple[SeriesT, bool]:
+    """Chunkable dataframe path retained for explicit bounded-memory use."""
+    by_dst = edges.sort_values(dst).reset_index(drop=True)
+    safe_out = out_weight.where(~is_dangling, 1.0)
+
+    def step(current: SeriesT) -> tuple[SeriesT, float, float]:
+        contribution = (current / safe_out).where(~is_dangling, 0.0)
+        dangling_mass = float(current.where(is_dangling, 0.0).sum())
+
+        outs = []
+        for lo, hi in chunk_bounds(len(by_dst), chunks):
+            edge_chunk = rows(by_dst, lo, hi)
+            messages = gather(contribution, edge_chunk[src])
+            if weight is not None:
+                messages = messages * edge_chunk[weight].reset_index(drop=True)
+            outs.append(
+                df_cons(edge_chunk, {"v": edge_chunk[dst], "m": messages})
+                .groupby("v", sort=False)["m"]
+                .sum()
+                .reset_index()
+            )
+        reduced = concat_frames(outs)
+        if reduced is not None and chunks > 1:
+            reduced = (
+                reduced.groupby("v", sort=False)["m"].sum().reset_index()
+            )
+        inflow = align(
+            edges,
+            v_count,
+            reduced,
+            "v",
+            "m",
+            full(edges, v_count, 0.0, "float64"),
+        )
+        new = (1.0 - damping) * teleport + damping * (
+            inflow + dangling_mass * teleport
+        )
+        return new, float(new.sum()), float(abs(new - current).sum())
+
+    return _pagerank_iterations(initial, step, max_iter, tol, stopping)
+
+
 def pagerank(
     edges: DataFrameT,
     src: str,
@@ -141,8 +275,9 @@ def pagerank(
     stopping: Literal["convergence", "fixed_iterations"] = "convergence",
     iterations: Optional[int] = None,
     damping: Optional[float] = None,
+    method: Literal["auto", "fast", "bounded"] = "auto",
 ) -> Union[SeriesT, tuple[SeriesT, bool]]:
-    """PageRank with cuGraph-compatible controls and portable dataframe extras."""
+    """PageRank with cuGraph-compatible controls and fast/bounded extras."""
     if v_count == 0:
         empty = full(edges, 0, 0.0, "float64")
         return (empty, True) if not fail_on_nonconvergence else empty
@@ -157,6 +292,10 @@ def pagerank(
         stopping = "fixed_iterations"
     if stopping not in ("convergence", "fixed_iterations"):
         raise ValueError("pagerank stopping must be 'convergence' or 'fixed_iterations'")
+    if method not in ("auto", "fast", "bounded"):
+        raise ValueError("pagerank method must be 'auto', 'fast', or 'bounded'")
+    if method == "fast" and chunks != 1:
+        raise ValueError("pagerank method='fast' requires chunks=1")
     if not 0.0 < float(alpha) < 1.0:
         raise ValueError("pagerank alpha must be greater than 0 and less than 1")
     if stopping == "convergence" and max_iter <= 0:
@@ -182,7 +321,6 @@ def pagerank(
             raise ValueError(f"pagerank {name} values must have a positive sum")
         return out / total
 
-    _, by_dst = _sorted_copies(edges, src, dst)
     if weight is None:
         sums = edges.groupby(src, sort=False).size().reset_index(name="__out")
         computed_out = align(
@@ -233,43 +371,44 @@ def pagerank(
     teleport = normalized(personalization, "personalization")
     pr = normalized(nstart, "nstart")
     d = float(alpha)
-    converged = False
     _ = dangling
 
-    for _iteration in range(max_iter):
-        safe_out = out_weight.where(~is_dangling, 1.0)
-        contrib = (pr / safe_out).where(~is_dangling, 0.0)
-        dangling_mass = float(pr.where(is_dangling, 0.0).sum())
-
-        outs = []
-        for lo, hi in chunk_bounds(len(by_dst), chunks):
-            e = rows(by_dst, lo, hi)
-            msg = gather(contrib, e[src])
-            if weight is not None:
-                msg = msg * e[weight].reset_index(drop=True)
-            outs.append(
-                df_cons(e, {"v": e[dst], "m": msg})
-                .groupby("v", sort=False)["m"]
-                .sum()
-                .reset_index()
-            )
-        res = concat_frames(outs)
-        if res is not None and chunks > 1:
-            res = res.groupby("v", sort=False)["m"].sum().reset_index()
-        inflow = align(
-            edges, v_count, res, "v", "m", full(edges, v_count, 0.0, "float64")
+    use_fast = method == "fast" or (method == "auto" and chunks == 1)
+    if use_fast:
+        pr, converged = _pagerank_fast(
+            edges,
+            src,
+            dst,
+            v_count,
+            weight,
+            out_weight,
+            is_dangling,
+            teleport,
+            pr,
+            d,
+            max_iter,
+            tol,
+            stopping,
         )
-        new = (1.0 - d) * teleport + d * (inflow + dangling_mass * teleport)
-        total = float(new.sum())
-        if abs(total - 1.0) > 1e-9:
-            raise AssertionError(f"pagerank mass not conserved: sum={total!r}")
-        # Unit-mass ranks make public cuGraph tolerance equivalent to L1 delta < tol.
-        converged = float(abs(new - pr).sum()) < float(tol)
-        pr = new
-        if stopping == "convergence" and converged:
-            return (pr, True) if not fail_on_nonconvergence else pr
+    else:
+        pr, converged = _pagerank_bounded(
+            edges,
+            src,
+            dst,
+            v_count,
+            weight,
+            chunks,
+            out_weight,
+            is_dangling,
+            teleport,
+            pr,
+            d,
+            max_iter,
+            tol,
+            stopping,
+        )
 
-    if stopping == "fixed_iterations":
+    if stopping == "fixed_iterations" or converged:
         return (pr, converged) if not fail_on_nonconvergence else pr
     if fail_on_nonconvergence:
         raise ConvergenceError(f"pagerank did not converge in {max_iter} iterations")

--- a/graphistry/compute/algorithms/kernels.py
+++ b/graphistry/compute/algorithms/kernels.py
@@ -147,6 +147,118 @@ def _pagerank_iterations(
     return current, converged
 
 
+def _pagerank_cudf_fast(
+    edges: DataFrameT,
+    src: str,
+    dst: str,
+    v_count: int,
+    weight: Optional[str],
+    out_weight: SeriesT,
+    is_dangling: SeriesT,
+    teleport: SeriesT,
+    initial: SeriesT,
+    damping: float,
+    max_iter: int,
+    tol: float,
+    stopping: Literal["convergence", "fixed_iterations"],
+) -> tuple[SeriesT, bool]:
+    """CuPy fast path with reusable dense buffers and fused atomic scatter."""
+    xp = array_namespace(edges)
+    src_values = series_to_array(edges[src])
+    dst_values = series_to_array(edges[dst])
+    out_weight_values = series_to_array(out_weight)
+    teleport_values = series_to_array(teleport)
+    initial_values = series_to_array(initial)
+    dangling_weights = series_to_array(is_dangling).astype(xp.float64, copy=False)
+    weight_values = series_to_array(edges[weight].reset_index(drop=True).astype("float64")) if weight is not None else None
+    weighted = weight_values is not None
+    weight_parameter = "const double* edge_weight," if weighted else ""
+    weight_factor = " * edge_weight[edge]" if weighted else ""
+    kernel_name = "graphistry_pagerank_scatter_weighted" if weighted else "graphistry_pagerank_scatter_unweighted"
+    scatter = xp.RawKernel(
+        f"""
+        extern "C" __global__
+        void {kernel_name}(
+            const int* src,
+            const int* dst,
+            const double* ranks,
+            const double* out_weight,
+            {weight_parameter}
+            double* inflow,
+            const unsigned long long edge_count
+        ) {{
+            unsigned long long edge =
+                (unsigned long long) blockDim.x * blockIdx.x + threadIdx.x;
+            const unsigned long long stride =
+                (unsigned long long) blockDim.x * gridDim.x;
+            for (; edge < edge_count; edge += stride) {{
+                const int source = src[edge];
+                const double denominator = out_weight[source];
+                if (denominator > 0.0) {{
+                    atomicAdd(
+                        &inflow[dst[edge]],
+                        (ranks[source] / denominator){weight_factor}
+                    );
+                }}
+            }}
+        }}
+        """,
+        kernel_name,
+    )
+    rank_update = xp.ElementwiseKernel(
+        "float64 inflow, float64 teleport, float64 dangling_mass, float64 alpha",
+        "float64 rank",
+        "rank = (1.0 - alpha) * teleport + alpha * (inflow + dangling_mass * teleport)",
+        "graphistry_pagerank_rank_update",
+    )
+    inflow = xp.empty(v_count, dtype=xp.float64)
+    next_values = xp.empty(v_count, dtype=xp.float64)
+    edge_count = int(src_values.size)
+    edge_count_arg = xp.uint64(edge_count)
+    threads = 256
+    blocks = min(65535, max(1, (edge_count + threads - 1) // threads))
+
+    def step(current: ArrayLike) -> tuple[ArrayLike, float, float]:
+        nonlocal next_values
+        inflow.fill(0.0)
+        args = (
+            (
+                src_values,
+                dst_values,
+                current,
+                out_weight_values,
+                weight_values,
+                inflow,
+                edge_count_arg,
+            )
+            if weighted
+            else (
+                src_values,
+                dst_values,
+                current,
+                out_weight_values,
+                inflow,
+                edge_count_arg,
+            )
+        )
+        scatter((blocks,), (threads,), args)
+        dangling_mass = xp.dot(current, dangling_weights)
+        rank_update(
+            inflow,
+            teleport_values,
+            dangling_mass,
+            damping,
+            next_values,
+        )
+        new = next_values
+        total, delta = to_host_floats((new.sum(), xp.absolute(new - current).sum()))
+        next_values = current
+        return new, total, delta
+
+    result, converged = _pagerank_iterations(initial_values, step, max_iter, tol, stopping)
+    return series_from_array(edges, result), converged
+
+
 def _pagerank_fast(
     edges: DataFrameT,
     src: str,
@@ -163,6 +275,22 @@ def _pagerank_fast(
     stopping: Literal["convergence", "fixed_iterations"],
 ) -> tuple[SeriesT, bool]:
     """Backend-native dense reduction without dataframe materialization."""
+    if is_cudf(edges):
+        return _pagerank_cudf_fast(
+            edges,
+            src,
+            dst,
+            v_count,
+            weight,
+            out_weight,
+            is_dangling,
+            teleport,
+            initial,
+            damping,
+            max_iter,
+            tol,
+            stopping,
+        )
     xp = array_namespace(edges)
     src_values = series_to_array(edges[src])
     dst_values = series_to_array(edges[dst])
@@ -321,11 +449,26 @@ def pagerank(
             raise ValueError(f"pagerank {name} values must have a positive sum")
         return out / total
 
+    use_fast = method == "fast" or (method == "auto" and chunks == 1)
+    use_cudf_fast = use_fast and is_cudf(edges)
+
     if weight is None:
-        sums = edges.groupby(src, sort=False).size().reset_index(name="__out")
-        computed_out = align(
-            edges, v_count, sums, src, "__out", full(edges, v_count, 0.0, "float64")
-        )
+        if use_cudf_fast:
+            xp = array_namespace(edges)
+            computed_out = series_from_array(
+                edges,
+                xp.bincount(series_to_array(edges[src]), minlength=v_count).astype(xp.float64, copy=False),
+            )
+        else:
+            sums = edges.groupby(src, sort=False).size().reset_index(name="__out")
+            computed_out = align(
+                edges,
+                v_count,
+                sums,
+                src,
+                "__out",
+                full(edges, v_count, 0.0, "float64"),
+            )
     else:
         if weight not in edges.columns:
             raise ValueError(f"pagerank weight column {weight!r} is missing")
@@ -337,15 +480,31 @@ def pagerank(
         )
         if to_host_int(invalid_weight.sum()) != 0:
             raise ValueError("pagerank edge weights must be finite and non-negative")
-        sums = (
-            df_cons(edges, {src: edges[src], "__out": edge_weight})
-            .groupby(src, sort=False)["__out"]
-            .sum()
-            .reset_index()
-        )
-        computed_out = align(
-            edges, v_count, sums, src, "__out", full(edges, v_count, 0.0, "float64")
-        )
+        if use_cudf_fast:
+            xp = array_namespace(edges)
+            computed_out = series_from_array(
+                edges,
+                xp.bincount(
+                    series_to_array(edges[src]),
+                    weights=series_to_array(edge_weight),
+                    minlength=v_count,
+                ).astype(xp.float64, copy=False),
+            )
+        else:
+            sums = (
+                df_cons(edges, {src: edges[src], "__out": edge_weight})
+                .groupby(src, sort=False)["__out"]
+                .sum()
+                .reset_index()
+            )
+            computed_out = align(
+                edges,
+                v_count,
+                sums,
+                src,
+                "__out",
+                full(edges, v_count, 0.0, "float64"),
+            )
 
     out_weight = computed_out
     if precomputed_vertex_out_weight is not None:
@@ -373,7 +532,6 @@ def pagerank(
     d = float(alpha)
     _ = dangling
 
-    use_fast = method == "fast" or (method == "auto" and chunks == 1)
     if use_fast:
         pr, converged = _pagerank_fast(
             edges,

--- a/graphistry/compute/typing.py
+++ b/graphistry/compute/typing.py
@@ -137,6 +137,16 @@ class ArrayNamespace(Protocol):
     def subtract(self, a: Any, b: Any, out: "Optional[ArrayLike]" = None) -> ArrayLike:  # hygiene-ok: explicit-any -- ufunc accepts array|scalar operands (numpy/cupy)
         ...
 
+    def multiply(self, a: ArrayLike, b: Union[ArrayLike, float]) -> ArrayLike:
+        ...
+
+    def divide(self, a: ArrayLike, b: Union[ArrayLike, float]) -> ArrayLike:
+        ...
+
+    def absolute(self, a: ArrayLike) -> ArrayLike:
+        ...
+
+
     def argsort(self, a: ArrayLike) -> ArrayLike:
         ...
 

--- a/graphistry/tests/compute/algorithms/test_std_call.py
+++ b/graphistry/tests/compute/algorithms/test_std_call.py
@@ -147,12 +147,13 @@ def test_pagerank_cugraph_inputs_match_direct_and_gfql() -> None:
             "tol": 1.0e-30,
             "fail_on_nonconvergence": False,
             "converged_col": "pr_converged",
+            "method": "fast",
         },
     )
     query = (
         "CALL graphistry.std.pagerank.write({params: {"
         "max_iter: 1, tol: 1e-30, fail_on_nonconvergence: false, "
-        "converged_col: 'pr_converged', "
+        "converged_col: 'pr_converged', method: 'fast', "
         "personalization: [{vertex: 'a', values: 0.8}, "
         "{vertex: 'd', values: 0.2}], nstart: {a: 1.0}, "
         "precomputed_vertex_out_weight: [{vertex: 'a', sums: 3.0}, "

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -99,9 +99,11 @@ def test_pagerank_cugraph_compatible_signature_defaults():
         "fail_on_nonconvergence": True,
     }
     assert {name: signature.parameters[name].default for name in expected} == expected
+    assert signature.parameters["method"].default == "auto"
 
 
-def test_pagerank_weighted_personalized_matches_linear_system():
+@pytest.mark.parametrize("method", ["fast", "bounded"])
+def test_pagerank_weighted_personalized_matches_linear_system(method):
     edges = _edges([0, 0, 1, 2], [1, 2, 2, 0], [2.0, 1.0, 3.0, 4.0])
     personalization = pd.Series([0.7, 0.1, 0.1, 0.1])
     nstart = pd.Series([0.0, 1.0, 0.0, 0.0])
@@ -120,6 +122,7 @@ def test_pagerank_weighted_personalized_matches_linear_system():
         nstart=nstart,
         dangling={"ignored": 1.0},
         weight="w",
+        method=method,
     )
 
     transition = np.array(
@@ -184,6 +187,20 @@ def test_pagerank_tolerance_is_on_unit_mass_rank_scale():
     # First-step L1 delta is 0.01683: above tol, but below V * tol (=1).
     assert converged is False
     assert float(ranks.sum()) == pytest.approx(1.0)
+
+
+def test_pagerank_method_validation_and_chunk_contract():
+    edges = _edges([0, 1], [1, 2])
+    with pytest.raises(ValueError, match="method must be"):
+        K.pagerank(
+            edges,
+            "s",
+            "d",
+            3,
+            method="unknown",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="requires chunks=1"):
+        K.pagerank(edges, "s", "d", 3, method="fast", chunks=2)
 
 
 def test_cdlp_tie_breaks_to_smallest_label_and_oscillates():
@@ -335,14 +352,22 @@ def test_chunked_equals_unchunked_exactly(kernel):
 
 
 def test_pagerank_chunking_drift_is_float_noise_only():
-    """PageRank is the one kernel compared by tolerance: float64 summation is
-    not associative, so chunk boundaries shift the last bits (~1e-16). Every
-    other kernel is integer or exact-float32 and must match bitwise."""
+    """Fast, bounded, and chunked reductions differ only by float noise."""
     dense, _, v_count = _random_graph(7, 400, 3000)
-    a = K.pagerank(dense, "s", "d", v_count, chunks=1).values
-    b = K.pagerank(dense, "s", "d", v_count, chunks=4).values
-    rel = np.max(np.abs(a - b) / np.maximum(np.abs(a), 1e-30))
-    assert rel < 1e-12, f"chunking drift {rel:.3e} is larger than float noise"
+    auto_fast = K.pagerank(dense, "s", "d", v_count, chunks=1).values
+    explicit_fast = K.pagerank(
+        dense, "s", "d", v_count, method="fast"
+    ).values
+    bounded = K.pagerank(
+        dense, "s", "d", v_count, method="bounded"
+    ).values
+    auto_chunked = K.pagerank(dense, "s", "d", v_count, chunks=4).values
+    assert np.array_equal(auto_fast, explicit_fast)
+    for candidate in (bounded, auto_chunked):
+        rel = np.max(
+            np.abs(auto_fast - candidate) / np.maximum(np.abs(auto_fast), 1e-30)
+        )
+        assert rel < 1e-12, f"PageRank drift {rel:.3e} exceeds float noise"
 
 
 # --------------------------------------------------------------------------

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -142,6 +142,50 @@ def test_pagerank_weighted_personalized_matches_linear_system(method):
     )
 
 
+@pytest.mark.skipif(__import__("os").environ.get("TEST_CUDF") != "1", reason="cuDF tests need TEST_CUDF=1")
+def test_pagerank_cudf_fast_matches_pandas_full_controls():
+    cudf = pytest.importorskip("cudf")
+    edges = _edges([0, 0, 1, 2], [1, 2, 2, 0], [2.0, 1.0, 0.0, 4.0])
+    gpu_edges = cudf.from_pandas(edges)
+
+    expected_unweighted = K.pagerank(edges[["s", "d"]], "s", "d", 4, method="fast")
+    actual_unweighted = K.pagerank(gpu_edges[["s", "d"]], "s", "d", 4, method="fast")
+    assert actual_unweighted.to_pandas().to_numpy() == pytest.approx(expected_unweighted.to_numpy(), rel=1.0e-12, abs=1.0e-15)
+
+    personalization = pd.Series([0.7, 0.1, 0.1, 0.1])
+    nstart = pd.Series([0.0, 1.0, 0.0, 0.0])
+    out_weight = pd.Series([3.0, 0.0, 4.0, np.nan])
+    expected_weighted = K.pagerank(
+        edges,
+        "s",
+        "d",
+        4,
+        alpha=0.85,
+        personalization=personalization,
+        precomputed_vertex_out_weight=out_weight,
+        max_iter=1000,
+        tol=1.0e-12,
+        nstart=nstart,
+        weight="w",
+        method="fast",
+    )
+    actual_weighted = K.pagerank(
+        gpu_edges,
+        "s",
+        "d",
+        4,
+        alpha=0.85,
+        personalization=cudf.from_pandas(personalization),
+        precomputed_vertex_out_weight=cudf.from_pandas(out_weight),
+        max_iter=1000,
+        tol=1.0e-12,
+        nstart=cudf.from_pandas(nstart),
+        weight="w",
+        method="fast",
+    )
+    assert actual_weighted.to_pandas().to_numpy() == pytest.approx(expected_weighted.to_numpy(), rel=1.0e-12, abs=1.0e-15)
+
+
 def test_pagerank_nonconvergence_policy_and_fixed_alias():
     edges = _edges([0, 1], [1, 2])
     with pytest.raises(K.ConvergenceError):

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -16,7 +16,9 @@ Three tiers in fail-fast order:
 from __future__ import annotations
 
 import inspect
+import sys
 from collections import Counter
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -263,6 +265,150 @@ def test_pagerank_auto_memory_preflight(monkeypatch):
     assert K._pagerank_auto_uses_fast(edges, 3, False, 1) is False
     monkeypatch.setattr(K, "_pagerank_available_bytes", lambda _: None)
     assert K._pagerank_auto_uses_fast(edges, 3, False, 1) is False
+
+
+def test_pagerank_iteration_rejects_mass_drift():
+    initial = pd.Series([1.0])
+
+    def bad_step(current):
+        return current, 1.5, 0.0
+
+    with pytest.raises(AssertionError, match="mass not conserved"):
+        K._pagerank_iterations(initial, bad_step, 1, 1.0e-5, "convergence")
+
+
+def test_pagerank_gpu_memory_estimate_without_gpu(monkeypatch):
+    edges = _edges([0, 1, 2, 2], [1, 2, 0, 1])
+    monkeypatch.setattr(K, "is_cudf", lambda _: True)
+
+    fixed = 64 * 1024 * 1024
+    assert K._pagerank_fast_estimated_bytes(edges, 3, False) == fixed + 96 * 3
+    assert K._pagerank_fast_estimated_bytes(edges, 3, True) == fixed + 96 * 3 + 16 * len(edges)
+
+
+def test_pagerank_cgroup_available_bytes_contract(tmp_path):
+    limit_path = tmp_path / "limit"
+    current_path = tmp_path / "current"
+
+    limit_path.write_text("1000", encoding="utf-8")
+    current_path.write_text("250", encoding="utf-8")
+    assert K._pagerank_cgroup_available_bytes(str(limit_path), str(current_path)) == 750
+
+    limit_path.write_text("max", encoding="utf-8")
+    assert K._pagerank_cgroup_available_bytes(str(limit_path), str(current_path)) is None
+
+    limit_path.write_text("invalid", encoding="utf-8")
+    assert K._pagerank_cgroup_available_bytes(str(limit_path), str(current_path)) is None
+
+    limit_path.write_text(str(1 << 60), encoding="utf-8")
+    current_path.write_text("0", encoding="utf-8")
+    assert K._pagerank_cgroup_available_bytes(str(limit_path), str(current_path)) is None
+
+    limit_path.write_text("100", encoding="utf-8")
+    current_path.write_text("-1", encoding="utf-8")
+    assert K._pagerank_cgroup_available_bytes(str(limit_path), str(current_path)) is None
+
+
+def test_pagerank_host_available_bytes_contract(monkeypatch):
+    values = {"SC_AVPHYS_PAGES": 10, "SC_PAGE_SIZE": 100}
+    monkeypatch.setattr(K.os, "sysconf", lambda name: values[name])
+    monkeypatch.setattr(
+        K,
+        "_pagerank_cgroup_available_bytes",
+        lambda limit_path, _current_path: 300 if limit_path.endswith("memory.max") else None,
+    )
+    assert K._pagerank_host_available_bytes() == 300
+
+    def unavailable(_name):
+        raise OSError("sysconf unavailable")
+
+    monkeypatch.setattr(K.os, "sysconf", unavailable)
+    monkeypatch.setattr(K, "_pagerank_cgroup_available_bytes", lambda *_: None)
+    assert K._pagerank_host_available_bytes() is None
+
+
+def test_pagerank_gpu_available_bytes_probe_without_gpu(monkeypatch):
+    fake_cupy = ModuleType("cupy")
+    fake_cupy.__dict__["cuda"] = SimpleNamespace(
+        Device=lambda: SimpleNamespace(mem_info=(123, 456))
+    )
+    monkeypatch.setitem(sys.modules, "cupy", fake_cupy)
+    monkeypatch.setattr(K, "is_cudf", lambda _: True)
+    assert K._pagerank_available_bytes(object()) == 123
+
+    class BrokenDevice:
+        def __init__(self):
+            raise RuntimeError("probe failed")
+
+    fake_cupy.__dict__["cuda"] = SimpleNamespace(Device=BrokenDevice)
+    assert K._pagerank_available_bytes(object()) is None
+
+
+def test_dfops_lazy_gpu_dispatch_without_gpu(monkeypatch):
+    fake_cupy = ModuleType("cupy")
+    fake_cupy.__dict__.update(
+        {"stack": lambda values: values, "asnumpy": lambda values: values}
+    )
+    fake_cudf = ModuleType("cudf")
+    fake_cudf.__dict__["Series"] = lambda values: ("cudf-series", values)
+    monkeypatch.setitem(sys.modules, "cupy", fake_cupy)
+    monkeypatch.setitem(sys.modules, "cudf", fake_cudf)
+    monkeypatch.setattr(D, "is_cudf", lambda _: True)
+
+    values = np.array([1.0, 2.0])
+
+    class FakeSeries:
+        pass
+
+    series = FakeSeries()
+    series.values = values
+    assert D.array_namespace(object()) is fake_cupy
+    assert D.series_to_array(series) is values
+    assert D.series_from_array(object(), values) == ("cudf-series", values)
+    assert D.to_host_floats([]) == ()
+
+    fake_scalar = type("FakeCupyScalar", (float,), {"__module__": "cupy"})
+    assert D.to_host_floats([fake_scalar(1.25), fake_scalar(2.5)]) == (1.25, 2.5)
+
+
+def test_pagerank_fast_dispatches_cudf_backend_without_gpu(monkeypatch):
+    edges = _edges([0], [1])
+    vectors = [pd.Series([0.5, 0.5]) for _ in range(4)]
+    expected = (pd.Series([0.25, 0.75]), True)
+    received = []
+
+    def cudf_fast(*args):
+        received.append(args)
+        return expected
+
+    monkeypatch.setattr(K, "is_cudf", lambda _: True)
+    monkeypatch.setattr(K, "_pagerank_cudf_fast", cudf_fast)
+    actual = K._pagerank_fast(
+        edges,
+        "s",
+        "d",
+        2,
+        None,
+        vectors[0],
+        vectors[1],
+        vectors[2],
+        vectors[3],
+        0.85,
+        100,
+        1.0e-5,
+        "convergence",
+    )
+
+    assert actual is expected
+    assert len(received) == 1
+    args = received[0]
+    assert args[0] is edges
+    assert args[1:5] == ("s", "d", 2, None)
+    assert all(
+        actual_vector is expected_vector
+        for actual_vector, expected_vector in zip(args[5:9], vectors)
+    )
+    assert args[9:] == (0.85, 100, 1.0e-5, "convergence")
 
 
 def test_cdlp_tie_breaks_to_smallest_label_and_oscillates():

--- a/graphistry/tests/compute/algorithms/test_std_kernels.py
+++ b/graphistry/tests/compute/algorithms/test_std_kernels.py
@@ -247,6 +247,24 @@ def test_pagerank_method_validation_and_chunk_contract():
         K.pagerank(edges, "s", "d", 3, method="fast", chunks=2)
 
 
+def test_pagerank_auto_memory_preflight(monkeypatch):
+    edges = _edges([0, 1, 2, 2], [1, 2, 0, 1])
+    fixed = 64 * 1024 * 1024
+    unweighted = K._pagerank_fast_estimated_bytes(edges, 3, False)
+    weighted = K._pagerank_fast_estimated_bytes(edges, 3, True)
+    assert unweighted == fixed + 64 * 3 + 8 * len(edges)
+    assert weighted == fixed + 64 * 3 + 24 * len(edges)
+
+    monkeypatch.setattr(K, "_pagerank_available_bytes", lambda _: 2 * unweighted)
+    assert K._pagerank_auto_uses_fast(edges, 3, False, 1) is True
+    assert K._pagerank_auto_uses_fast(edges, 3, False, 2) is False
+
+    monkeypatch.setattr(K, "_pagerank_available_bytes", lambda _: 2 * unweighted - 1)
+    assert K._pagerank_auto_uses_fast(edges, 3, False, 1) is False
+    monkeypatch.setattr(K, "_pagerank_available_bytes", lambda _: None)
+    assert K._pagerank_auto_uses_fast(edges, 3, False, 1) is False
+
+
 def test_cdlp_tie_breaks_to_smallest_label_and_oscillates():
     """Star 0--{1,2,3}: vertex 0 sees a 3-way tie and must pick the smallest.
 
@@ -395,8 +413,9 @@ def test_chunked_equals_unchunked_exactly(kernel):
     assert np.array_equal(run(1).values, run(4).values)
 
 
-def test_pagerank_chunking_drift_is_float_noise_only():
+def test_pagerank_chunking_drift_is_float_noise_only(monkeypatch):
     """Fast, bounded, and chunked reductions differ only by float noise."""
+    monkeypatch.setattr(K, "_pagerank_available_bytes", lambda _: 1 << 60)
     dense, _, v_count = _random_graph(7, 400, 3000)
     auto_fast = K.pagerank(dense, "s", "d", v_count, chunks=1).values
     explicit_fast = K.pagerank(


### PR DESCRIPTION
## Stack

Draft follow-up stacked on #2006. Review only the four commits in this PR; merge #2006 first.

## Summary

- add explicit `fast`, `bounded`, and conservative memory-aware `auto` execution modes to `graphistry.std.pagerank`
- keep the cuGraph-compatible signature/defaults plus Graphistry extras, direct/GFQL parity, original IDs, weighted/personalized/nstart/precomputed behavior, and shared convergence semantics
- preserve the dataframe chunked path for bounded memory and graph500-26-scale workloads
- use persistent compact NumPy/CuPy buffers for fit-in-memory execution; cuDF uses direct atomic scatter and fused rank update
- never silently delegate std execution to igraph or cuGraph

## Selection policy

`auto` is the default. With `chunks=1`, it selects fast only when a conservative calibrated scratch estimate is at most half detected free host/device memory. Unknown or tighter memory falls back to bounded. Explicit `fast` bypasses the estimate; explicit `bounded` preserves the chunkable dataframe path.

## Matched evidence

Directed unweighted `cit-Patents`, prepared solver calls, 3 samples / 1 warmup:

| backend | median | peak memory evidence |
|---|---:|---:|
| final std-pandas fast | 1.386604s | 372.05 MiB |
| igraph PRPACK | 1.449537s | baseline |
| final std-cuDF auto/fast | 0.164078s | 262.793 MiB RMM delta |
| cuGraph 26.02 | 0.035157s | baseline |

Final GPU samples: `[0.166276, 0.164078, 0.162755]`; std-cuDF is 4.67x cuGraph and clears the <=10x target. Rank mass is `1.0000000000000013`, maximum retained delta is `8.131516293641283e-20`, and top-10 IDs match. The prior std-cuDF baseline was 1.783722s / 979.153 MiB. The bounded graph500-26 memory result was preserved and cuGraph graph500-26 was not rerun.

Artifact SHA-256: `91b44ed81cb4b5b43beee6b341c2d8ce6369d4cedc0e7bde9f821adfc13ff53f`.

The final DGX runtime artifact was built from implementation commit `7022fe742573e4212339bb326ad887f29b03f518`; current PR head `ec039cdea784036229d66d43d7752751a1db1671` adds CPU-only coverage contracts and does not change runtime code.

## Validation

- scoped lint/hygiene: pass
- full configured mypy 2.3.1: pass, 337 source files
- local focused CPU: 62 passed, 1 explicitly gated cuDF skip
- exact CI-baseline changed-line coverage reproduction plus focused tests: 81.15% versus 80% gate
- guarded DGX semantic lane with `TEST_CUDF=1`: 56 passed, no skips
- guarded DGX matched performance/correctness/memory lane: pass

All Docker, GPU, dataset, profiling, and performance work ran only on `dgx-spark` through the perf lock and `safe_run.sh`, with one no-network container, RMM/cgroup caps, >=80 GiB host-memory floor, watchdog, and hard timeout. Companion benchmark PR: https://github.com/graphistry/pyg-bench/pull/194
