### PR TITLE
fix(gfql): preserve Polars across graph CALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 - **The 30M-edge GPlus filter/PageRank page now reports the completed Neo4j + GDS lane**: a locked twelve-slot follow-up produced a direct 354.47 s median-of-slot-medians with exact selected-node parity. The page and regenerated chart read the value from the vendored pyg-bench document. They publish no GFQL-vs-Neo4j ratio because Neo4j includes server round trips and a per-iteration GDS projection rebuild while GFQL retains resident frames.
+- **Polars graph-preserving Cypher CALLs retain their requested engine**: a CALL inside a compound `GRAPH ... USE ... CALL` query could return pandas frames after an igraph analytic even when the query requested `engine="polars"`. CALL-based graph constructors now restore the requested dataframe engine before returning, with value-parity and node/edge frame-type regression coverage.
 - **GFQL benchmark docs now enforce the benchmark contract v3 boundary**: the vendored pyg-bench artifact and contract suppress invalid cross-profile ratios. Filter/PageRank no longer divides resident in-process GFQL timings by a per-iteration Neo4j projection rebuild, and the GraphBench q1–q9 board no longer divides reused GFQL bindings by Kuzu's execute-text-per-call profile or treats cache-contaminated q8 values as results. The pages and generated charts retain direct timings and same-profile ratios only, and independently re-verify ratio operands, profiles, disclosure propagation, and derived-cell strength before rendering.
 
 ### Added

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -34,6 +34,7 @@ from graphistry.compute.gfql.same_path_types import (
     parse_where_json,
 )
 from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
+from graphistry.compute.engine_coercion import ensure_engine_match
 from graphistry.compute.gfql.cypher.ast import CypherParams
 from graphistry.compute.gfql.cypher.parser import parse_cypher
 from graphistry.compute.gfql.exec_context import attach_row_exec_context, clear_row_exec_context
@@ -62,7 +63,7 @@ from graphistry.compute.gfql.cypher.reentry.execution import (
     reentry_validation_error as _reentry_validation_error,
     union_scalar_reentry_results as _union_scalar_reentry_results,
 )
-from graphistry.compute.gfql.cypher.call_procedures import execute_cypher_call
+from graphistry.compute.gfql.cypher.call_procedures import CompiledCypherProcedureCall, execute_cypher_call
 from graphistry.compute.gfql.cypher.result_postprocess import (
     apply_result_projection,
     entity_projection_meta_entry as _entity_projection_meta_entry,
@@ -985,7 +986,7 @@ def _execute_graph_constructor_compiled(
     base_graph: Plottable,
     chain: Chain,
     *,
-    procedure_call: Any = None,
+    procedure_call: Optional[CompiledCypherProcedureCall] = None,
     graph_residual_filters: Tuple[CompiledGraphResidualFilter, ...] = (),
     engine: Union[EngineAbstract, str],
     policy: Optional[PolicyDict],
@@ -993,7 +994,12 @@ def _execute_graph_constructor_compiled(
 ) -> Plottable:
     """Execute a compiled graph constructor (MATCH-based or CALL-based)."""
     if procedure_call is not None:
-        return execute_cypher_call(base_graph, procedure_call)
+        result = execute_cypher_call(base_graph, procedure_call)
+        requested_engine = resolve_engine(
+            engine if isinstance(engine, EngineAbstract) else EngineAbstract(engine),
+            base_graph,
+        )
+        return ensure_engine_match(result, requested_engine)
     filtered_graph = _apply_graph_residual_filters(
         base_graph, graph_residual_filters, engine=engine
     )

--- a/graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
@@ -140,6 +140,23 @@ def test_hypergraph_auto_bridges_under_polars():
     assert len(out._nodes) > 0 and len(out._edges) > 0
 
 
+def test_compound_graph_call_auto_returns_polars():
+    g = _selfedge_graph()
+    query = (
+        "GRAPH g1 = GRAPH { MATCH (n)-[e]-(m) } "
+        "GRAPH { USE g1 CALL graphistry.igraph.pagerank.write() }"
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = g.gfql(query, engine="polars")
+        oracle = g.gfql(query, engine="pandas")
+    assert out._nodes is not None and out._edges is not None
+    assert "polars" in type(out._nodes).__module__
+    assert "polars" in type(out._edges).__module__
+    assert _val_sig(out._nodes) == _val_sig(oracle._nodes)
+    assert _val_sig(out._edges) == _val_sig(oracle._edges)
+
+
 # --------------------------------------------------------------------------- strict decline
 def test_prune_self_edges_strict_declines():
     """call_mode='strict' declines the off-engine bridge with NotImplementedError (no hidden

--- a/graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
@@ -141,6 +141,7 @@ def test_hypergraph_auto_bridges_under_polars():
 
 
 def test_compound_graph_call_auto_returns_polars():
+    pytest.importorskip("igraph", reason="PageRank CALL requires optional python-igraph")
     g = _selfedge_graph()
     query = (
         "GRAPH g1 = GRAPH { MATCH (n)-[e]-(m) } "

--- a/graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
@@ -140,7 +140,7 @@ def test_hypergraph_auto_bridges_under_polars():
     assert len(out._nodes) > 0 and len(out._edges) > 0
 
 
-def test_compound_graph_call_auto_returns_polars():
+def test_compound_graph_call_auto_returns_polars() -> None:
     pytest.importorskip("igraph", reason="PageRank CALL requires optional python-igraph")
     g = _selfedge_graph()
     query = (
@@ -151,6 +151,39 @@ def test_compound_graph_call_auto_returns_polars():
         warnings.simplefilter("ignore")
         out = g.gfql(query, engine="polars")
         oracle = g.gfql(query, engine="pandas")
+    assert out._nodes is not None and out._edges is not None
+    assert oracle._nodes is not None and oracle._edges is not None
+    assert "polars" in type(out._nodes).__module__
+    assert "polars" in type(out._edges).__module__
+    assert "pandas" in type(oracle._nodes).__module__
+    assert "pandas" in type(oracle._edges).__module__
+    assert _val_sig(out._nodes) == _val_sig(oracle._nodes)
+    assert _val_sig(out._edges) == _val_sig(oracle._edges)
+
+
+def test_standalone_graph_call_auto_uses_resident_polars_engine() -> None:
+    pytest.importorskip("igraph", reason="PageRank CALL requires optional python-igraph")
+    g = _selfedge_graph()
+    match_query = "GRAPH { MATCH (n)-[e]-(m) }"
+    call_query = "GRAPH { CALL graphistry.igraph.pagerank.write() }"
+    resident_polars = g.gfql(match_query, engine="polars")
+    resident_pandas = g.gfql(match_query, engine="pandas")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = resident_polars.gfql(call_query, engine="auto")
+        oracle = resident_pandas.gfql(call_query, engine="pandas")
+    assert out._nodes is not None and out._edges is not None
+    assert "polars" in type(out._nodes).__module__
+    assert "polars" in type(out._edges).__module__
+    assert _val_sig(out._nodes) == _val_sig(oracle._nodes)
+    assert _val_sig(out._edges) == _val_sig(oracle._edges)
+
+
+def test_match_graph_constructor_without_call_preserves_polars() -> None:
+    g = _selfedge_graph()
+    query = "GRAPH { MATCH (n)-[e]-(m) }"
+    out = g.gfql(query, engine="polars")
+    oracle = g.gfql(query, engine="pandas")
     assert out._nodes is not None and out._edges is not None
     assert "polars" in type(out._nodes).__module__
     assert "polars" in type(out._edges).__module__


### PR DESCRIPTION
## Summary

- preserve the requested dataframe engine after graph-preserving Cypher CALL execution
- narrow the compiled procedure-call type from `Any` to `Optional[CompiledCypherProcedureCall]`
- add Polars node/edge frame and pandas-value parity regression coverage

PR #2011 is landed on `develop` as merge commit `94189b04d`. This branch was rebased onto that exact commit; its binary feature-diff fingerprint is unchanged.

The igraph analytic still runs through the explicit pandas bridge. This fix restores the requested output engine and does not claim native Polars PageRank.

## Validation

- 20 focused Polars CALL/schema-effect tests passed
- focused Ruff and mypy passed
- credential, added-comment, forbidden typing/reflection, and diff checks passed
- full exact-head Actions and Read the Docs required before merge

## Dependency

Landing this PR on `develop` satisfies the pygraphistry gate for graphistry/pyg-bench#200.