### PR TITLE
perf(gfql): memoize node dtype reads per frame (#2029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ All notable changes to the PyGraphistry are documented in this file. The PyGraph
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and all PyGraphistry-specific breaking changes are explictly noted here.
 
-## [0.59.0 - 2026-08-31]
+## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
+
+### Fixed
+
+* GFQL: every Cypher string query re-read the node table's dtypes to build its compile-cache key, and that read scans the values of every `object` column (the string-content gate for predicate pushdown). On a wide pandas node table this cost more than the query it keyed: an SNB SF0.1 seeded lookup on 327k nodes × 27 object columns spent 105 ms of 106 ms there. The read is now memoized per node frame (identity plus a length/columns fingerprint, the resident indexes' contract) and cleared by `gfql_clear_caches()`; the same lookup now takes 2 ms (#2029).
+
+## [0.59.0 - 2026-08-31]
 
 ### Breaking
 

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -79,6 +79,7 @@ POLARS_TEST_FILES=(
     # polars params (bound validation, hops=None run-to-closure, edges-only node output)
     # only ever run in this lane
     graphistry/tests/compute/gfql/test_hop_semantics_1918.py
+    graphistry/tests/compute/gfql/test_node_dtypes_memo_2029.py
     # #1882/#1913-f4/#1879 crash-family pins: the polars params (filter helpers on polars
     # frames, polars prune_self_edges, nodes-only typed-decline advice) only run here
     graphistry/tests/compute/gfql/test_crash_family_1882_1879.py

--- a/graphistry/compute/filter_by_dict.py
+++ b/graphistry/compute/filter_by_dict.py
@@ -5,6 +5,7 @@ from graphistry.Engine import EngineAbstract, POLARS_ENGINES, df_to_engine, reso
 from graphistry.util import setup_logger
 
 from graphistry.Plottable import Plottable
+from graphistry.compute.gfql.node_dtypes_memo import memo_get, memo_put
 from .predicates.ASTPredicate import ASTPredicate
 from .typing import DataFrameT, DType, NodeDtypes, SeriesT
 
@@ -345,11 +346,25 @@ def _read_node_dtypes(
     A pushed filter is schema-validated against the real column while the row residual
     evaluates leniently, so the planner needs dtypes to avoid turning a correct empty result
     into a type error. An unreadable schema yields an empty mapping, which fails every column
-    lookup and so falls back to the residual.
+    lookup and so falls back to the residual. Memoized per node frame: the read scans every
+    object column's values, and the compile cache key asks for it on every string query.
     """
     nodes = g._nodes
     if nodes is None:
         return {}
+    engine_name = str(getattr(engine, "value", engine))
+    cached = memo_get(nodes, engine_name)
+    if cached is not None:
+        return cached
+    dtypes = _read_node_dtypes_uncached(nodes, engine)
+    memo_put(nodes, engine_name, dtypes)
+    return dtypes
+
+
+def _read_node_dtypes_uncached(
+    nodes: DataFrameT,
+    engine: Union[EngineAbstract, str],
+) -> NodeDtypes:
     try:
         # Classify the frame the EXECUTOR will filter, not the one the caller handed in.
         # `filter_by_dict` validates post-materialization dtypes, so judging the pre-conversion

--- a/graphistry/compute/gfql/node_dtypes_memo.py
+++ b/graphistry/compute/gfql/node_dtypes_memo.py
@@ -1,0 +1,49 @@
+"""Per-frame memo for node dtype reads: the pushdown string-content gate is read once per node frame."""
+
+import weakref
+from collections import OrderedDict
+from typing import Any, Optional, Tuple
+
+from graphistry.compute.gfql.cache_registry import register_clearable_dict
+from graphistry.compute.typing import DataFrameT, NodeDtypes
+
+Fingerprint = Tuple[int, Tuple[str, ...]]
+
+#: (id(frame), engine) -> (weakref, (length, columns), dtypes); valid while the weakref is that object
+_NODE_DTYPES_MEMO: "OrderedDict[Tuple[int, str], Tuple[Any, Fingerprint, NodeDtypes]]" = OrderedDict()
+_NODE_DTYPES_MEMO_MAX = 32
+register_clearable_dict("_NODE_DTYPES_MEMO", _NODE_DTYPES_MEMO)
+
+
+def clear_node_dtypes_memo() -> None:
+    _NODE_DTYPES_MEMO.clear()
+
+
+def frame_fingerprint(nodes: DataFrameT) -> Fingerprint:
+    try:
+        return (int(nodes.shape[0]), tuple(str(c) for c in nodes.columns))
+    except Exception:
+        return (-1, ())
+
+
+def memo_get(nodes: DataFrameT, engine_name: str) -> Optional[NodeDtypes]:
+    key = (id(nodes), engine_name)
+    cached = _NODE_DTYPES_MEMO.get(key)
+    if cached is None:
+        return None
+    ref, fingerprint, dtypes = cached
+    if ref() is nodes and fingerprint == frame_fingerprint(nodes):
+        _NODE_DTYPES_MEMO.move_to_end(key)
+        return dict(dtypes)
+    del _NODE_DTYPES_MEMO[key]
+    return None
+
+
+def memo_put(nodes: DataFrameT, engine_name: str, dtypes: NodeDtypes) -> None:
+    try:
+        ref = weakref.ref(nodes)
+    except TypeError:
+        return
+    _NODE_DTYPES_MEMO[(id(nodes), engine_name)] = (ref, frame_fingerprint(nodes), dict(dtypes))
+    while len(_NODE_DTYPES_MEMO) > _NODE_DTYPES_MEMO_MAX:
+        _NODE_DTYPES_MEMO.popitem(last=False)

--- a/graphistry/tests/compute/gfql/test_node_dtypes_memo_2029.py
+++ b/graphistry/tests/compute/gfql/test_node_dtypes_memo_2029.py
@@ -1,0 +1,89 @@
+"""#2029: node dtype reads (the object-column string-content gate) are memoized per frame.
+
+The compile cache key asks for node dtypes on every string query; reading them scans every
+object column's values, which on a wide node table cost more than the query. The memo keys on
+frame identity plus a length/columns fingerprint (the resident indexes' contract).
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute import filter_by_dict as fbd
+from graphistry.compute.gfql import node_dtypes_memo as memo
+from graphistry.compute.gfql_unified import gfql_clear_caches
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    memo.clear_node_dtypes_memo()
+    yield
+    memo.clear_node_dtypes_memo()
+
+
+def _graph(rows=200):
+    nodes = pd.DataFrame({"id": range(rows), "name": [f"n{i}" for i in range(rows)],
+                          "mixed": [i if i % 2 else f"s{i}" for i in range(rows)], "type": "T"})
+    edges = pd.DataFrame({"s": range(rows - 1), "d": range(1, rows)})
+    return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
+
+
+def _count_scans(monkeypatch):
+    calls = {"n": 0}
+    real = fbd._object_column_holds_non_strings
+
+    def spy(frame, column, dtype):
+        calls["n"] += 1
+        return real(frame, column, dtype)
+
+    monkeypatch.setattr(fbd, "_object_column_holds_non_strings", spy)
+    return calls
+
+
+def test_second_read_of_the_same_frame_does_not_rescan(monkeypatch):
+    g = _graph()
+    calls = _count_scans(monkeypatch)
+    first = fbd._read_node_dtypes(g, "pandas")
+    scans = calls["n"]
+    assert scans > 0 and "mixed" not in first and "name" in first  # the gate still decides
+    again = fbd._read_node_dtypes(g, "pandas")
+    assert again == first and calls["n"] == scans, "memo hit must not rescan columns"
+
+
+def test_a_rebound_or_grown_frame_is_read_again(monkeypatch):
+    g = _graph()
+    calls = _count_scans(monkeypatch)
+    fbd._read_node_dtypes(g, "pandas")
+    scans = calls["n"]
+    g2 = g.nodes(g._nodes.copy(), "id")  # new frame object, same shape
+    fbd._read_node_dtypes(g2, "pandas")
+    assert calls["n"] > scans, "a different frame object is a memo miss"
+    scans = calls["n"]
+    g._nodes.drop(g._nodes.index[-1], inplace=True)  # same object, length changed
+    fbd._read_node_dtypes(g, "pandas")
+    assert calls["n"] > scans, "a changed fingerprint is a memo miss"
+
+
+def test_engines_have_separate_entries_and_clear_caches_empties_the_memo(monkeypatch):
+    pytest.importorskip("polars")
+    g = _graph()
+    calls = _count_scans(monkeypatch)
+    fbd._read_node_dtypes(g, "pandas")
+    fbd._read_node_dtypes(g, "polars")
+    assert len(memo._NODE_DTYPES_MEMO) == 2
+    gfql_clear_caches()
+    assert len(memo._NODE_DTYPES_MEMO) == 0
+    before = calls["n"]
+    fbd._read_node_dtypes(g, "pandas")
+    assert calls["n"] > before
+
+
+def test_string_queries_hit_the_memo_end_to_end(monkeypatch):
+    g = _graph()
+    calls = _count_scans(monkeypatch)
+    q = "MATCH (a {id: 3}) RETURN a.name AS name"
+    first = g.gfql(q, engine="pandas")
+    scans = calls["n"]
+    assert scans > 0
+    second = g.gfql(q, engine="pandas")
+    assert calls["n"] == scans
+    assert first._nodes["name"].tolist() == second._nodes["name"].tolist() == ["n3"]


### PR DESCRIPTION
Fixes #2029.

`_compile_string_query` keys the compile cache on the node dtypes, which forces `_LazyNodeDtypes` to materialize on every string query; `_read_node_dtypes` then runs `pd.api.types.infer_dtype` over the full values of every `object` column (the string-content gate for predicate pushdown). On the LDBC SNB SF0.1 node table as pyg-bench binds it (327,588 rows × 32 columns, 27 object), that scan was 305 ms of a 319 ms 3-call profile; the seeded typed-hop fast path it gates ran in 12 ms.

Change: `_read_node_dtypes` memoizes per node frame — keyed on `(id(frame), engine)`, valid while a weakref still resolves to the same object and the (length, columns) fingerprint matches (the resident indexes' identity contract), bounded to 32 entries, registered with `cache_registry` so `gfql_clear_caches()` empties it. No semantic change: the gate still scans on the first read of any frame.

Measured on the real SF0.1 graph (pandas, index resident, warm median of 5):

| query | before | after |
|---|---|---|
| official IS5 (`MATCH (m:Message {id})-[:HAS_CREATOR]->(p:Person) RETURN p.id, p.firstName, p.lastName`) | 105.9 ms | **1.95 ms** |
| official IS1 (two-alias, 8-column projection; no fast path) | 126.3 ms | 22.4 ms |
| `MATCH (p:Person {id}) RETURN p.firstName, p.lastName` | 115.6 ms | 13.7 ms |

polars is unaffected (no object-dtype inference). Tests: memo hit does not rescan, rebound/grown frame rescans, per-engine entries, `gfql_clear_caches()` empties it, end-to-end string queries. Lint/type-hygiene/comment guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwMmVFo44ADiRRj5cxh7i1