### PR TITLE
ci: run test-docs on docs-only pull requests (#2018)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2046,8 +2046,10 @@ jobs:
 
   test-docs:
     needs: [changes, python-lint-types, docs-latex-unicode-guard]
-    # Run if docs changed OR Python changed OR infrastructure changed OR manual/scheduled run
-    if: ${{ (needs.changes.outputs.docs == 'true' && needs.changes.outputs.narrow_python_only != 'true') || (needs.changes.outputs.python == 'true' && needs.changes.outputs.narrow_python_only != 'true') || needs.changes.outputs.docs_test == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    # Run if docs changed OR Python changed OR infrastructure changed OR manual/scheduled run.
+    # A docs-only PR skips python-lint-types; that skip must not skip this job (#2018), so the
+    # gate accepts skipped prerequisites and refuses only failed or cancelled ones.
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.python-lint-types.result != 'failure' && needs.docs-latex-unicode-guard.result != 'failure' && ((needs.changes.outputs.docs == 'true' && needs.changes.outputs.narrow_python_only != 'true') || (needs.changes.outputs.python == 'true' && needs.changes.outputs.narrow_python_only != 'true') || needs.changes.outputs.docs_test == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+
+### Infrastructure
+
+- **CI: `test-docs` runs on docs-only pull requests (#2018)**: the job needed `python-lint-types`, which a docs-only change skips, and GitHub skips a job whose prerequisite was skipped. The gate now accepts skipped prerequisites and refuses only failed or cancelled ones, so documentation changes are built and tested before merge.
 ### Tests
 
 * GFQL: `test_gfql_latency_contract.py` pins the low-latency contract for basic Cypher shapes on a wide 300k-node, 30-object-column table across pandas, polars and cuDF: a seeded typed hop with projections or a whole-entity return must be served by a fast path and cost at most 12x the plain frame ops for the same lookup (an id mask plus one join), measured interleaved; the node-only seeded lookup with projections is a recorded gap (strict xfail) so closing it flips the pin.


### PR DESCRIPTION
`test-docs` needs `python-lint-types`, which a docs-only change skips, and GitHub skips a job whose prerequisite was skipped, so documentation-only PRs never built or tested the docs (#2018, found on #2017). The gate now uses `!cancelled()` plus explicit prerequisite results: skipped prerequisites are accepted, failed or cancelled ones still block, and the original change filters are unchanged.

This PR touches the workflow, so every lane runs here; the docs-only behavior is verified by the next docs-only push to #2017 after this lands (its `test-docs` check must appear as run, not skipped).

Fixes #2018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QztW7jYsDd66e8rb8pJNQA