### PR TITLE
test(gfql): sibling-specialization sweep pins (#2051)

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -117,6 +117,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_engine_polars_narrow_combine.py
     graphistry/tests/compute/gfql/row/test_alias_prefilter_alignment_2020.py
     graphistry/tests/compute/gfql/lazy/engine/polars/test_chain_alias_column_collision_2039.py
+    graphistry/tests/compute/gfql/lazy/engine/polars/test_chain_duplicate_node_rows_2051.py
     graphistry/tests/compute/test_chain_alias_column_collision.py
     graphistry/tests/compute/gfql/test_engine_polars_semi_key_dedup.py
     graphistry/tests/compute/gfql/test_engine_polars_call_modality.py

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -118,6 +118,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/row/test_alias_prefilter_alignment_2020.py
     graphistry/tests/compute/gfql/lazy/engine/polars/test_chain_alias_column_collision_2039.py
     graphistry/tests/compute/gfql/lazy/engine/polars/test_chain_duplicate_node_rows_2051.py
+    graphistry/tests/compute/gfql/cypher/test_variable_column_collision.py
     graphistry/tests/compute/test_chain_alias_column_collision.py
     graphistry/tests/compute/gfql/test_engine_polars_semi_key_dedup.py
     graphistry/tests/compute/gfql/test_engine_polars_call_modality.py

--- a/graphistry/tests/compute/gfql/cypher/test_variable_column_collision.py
+++ b/graphistry/tests/compute/gfql/cypher/test_variable_column_collision.py
@@ -1,0 +1,74 @@
+"""A Cypher variable named like a frame column is served through every lane on every engine.
+
+The native chain's alias/column collision class (#2039) has a Cypher twin: a MATCH variable
+whose name equals a property the pattern filters on, an edge column, or the node binding.
+Pins: the seeded typed-hop and node-lookup lanes, the whole-entity return, the two-hop
+count lane and the lowered full path all return the pandas full-path rows on pandas, cuDF
+and polars, with and without resident indexes; the native rows route with a colliding alias
+does too.
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import e_forward, n, rows
+
+NODES = pd.DataFrame({"key": [1, 2, 3, 4], "id": [10, 20, 30, 40], "type": ["p", "p", "m", "m"], "w": [1, 2, 3, 4]})
+EDGES = pd.DataFrame({"s": [3, 3, 4, 1], "d": [1, 2, 1, 4], "type": ["HAS_CREATOR", "OTHER", "HAS_CREATOR", "OTHER"], "eid": [100, 101, 102, 103], "w": [5, 6, 7, 8]})
+ENGINES = ["pandas", "cudf", "polars"]
+
+
+def _graph(engine, indexed):
+    nodes, edges = NODES, EDGES
+    if engine == "polars":
+        pl = pytest.importorskip("polars")
+        nodes, edges = pl.from_pandas(nodes), pl.from_pandas(edges)
+    elif engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    g = graphistry.nodes(nodes, "key").edges(edges, "s", "d", "eid")
+    return g.gfql_index_all(engine=engine).gfql_index_node_props(["id"], engine=engine) if indexed else g
+
+
+def _rows(res):
+    df = res._nodes if hasattr(res, "_nodes") and not hasattr(res, "columns") else res
+    df = df.to_pandas() if hasattr(df, "to_pandas") else df
+    df = df.reindex(sorted(df.columns), axis=1)
+
+    def canon(v):
+        try:
+            f = float(v)
+            return "nan" if f != f else f
+        except (TypeError, ValueError):
+            return str(v)
+    return sorted(tuple(canon(v) for v in r) for r in df.values.tolist())
+
+
+QUERIES = {
+    "edge variable = filtered edge column": "MATCH (m {id: 30})-[type:HAS_CREATOR]->(p) RETURN p.id AS pid",
+    "edge variable = filtered column, projected": "MATCH (m {id: 30})-[type:HAS_CREATOR]->(p) RETURN p.id AS pid, type.w AS w",
+    "seed variable = its filtered property": "MATCH (id {id: 30})-[:HAS_CREATOR]->(p) RETURN p.id AS pid",
+    "destination variable = its filtered property": "MATCH (m {id: 30})-[:HAS_CREATOR]->(type {type: 'p'}) RETURN type.id AS pid",
+    "node-only variable = its filtered property": "MATCH (id {id: 30}) RETURN id.key AS k",
+    "whole entity with a colliding edge variable": "MATCH (m {id: 30})-[type:HAS_CREATOR]->(p) RETURN p",
+    "two-hop count with a colliding edge variable": "MATCH (a)-[type:HAS_CREATOR]->(b)-[e2]->(c) RETURN count(*) AS c",
+}
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("indexed", [False, True], ids=["scan", "indexed"])
+@pytest.mark.parametrize("name", list(QUERIES))
+def test_colliding_cypher_variables_match_the_pandas_full_path(engine, indexed, name):
+    q = QUERIES[name]
+    oracle = _rows(_graph("pandas", False).gfql(q, engine="pandas", index_policy="off"))
+    got = _rows(_graph(engine, indexed).gfql(q, engine=engine, index_policy="use" if indexed else "off"))
+    assert got == oracle
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("indexed", [False, True], ids=["scan", "indexed"])
+def test_rows_route_with_a_colliding_alias_matches_the_pandas_full_path(engine, indexed):
+    ops = [n({"id": 30}, name="m"), e_forward({"type": "HAS_CREATOR"}, name="type"), n(name="p"), rows(source="p")]
+    oracle = _rows(_graph("pandas", False).gfql(ops, engine="pandas", index_policy="off"))
+    got = _rows(_graph(engine, indexed).gfql(ops, engine=engine, index_policy="use" if indexed else "off"))
+    assert got == oracle

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/test_chain_duplicate_node_rows_2051.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/test_chain_duplicate_node_rows_2051.py
@@ -1,0 +1,54 @@
+"""The polars chain collapses duplicate node rows on every shape, as pandas' combine does.
+
+Sibling of #1993 (polars ``hop()`` de-dups its node table): the unnamed, untyped single-hop
+chain shape still keeps the duplicate (#2051, strict expected failure); the named, typed,
+multi-hop and undirected shapes and ``hop()`` already collapse it and are pinned green.
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import e_forward, e_undirected, n
+
+pl = pytest.importorskip("polars")
+
+
+def _graph():
+    nodes = pd.DataFrame({"key": [1, 2, 3, 4, 5], "id": [10, 20, 30, 40, 50]})
+    nodes = pd.concat([nodes, nodes.iloc[[0]]], ignore_index=True)
+    edges = pd.DataFrame({"s": [1, 1, 2, 3, 3, 4], "d": [2, 3, 3, 1, 1, 5],
+                          "type": ["KNOWS", "KNOWS", "LIKES", "KNOWS", "KNOWS", "LIKES"], "eid": range(6)})
+    g_pd = graphistry.nodes(nodes, "key").edges(edges, "s", "d", "eid")
+    g_pl = graphistry.nodes(pl.from_pandas(nodes), "key").edges(pl.from_pandas(edges), "s", "d", "eid")
+    return g_pd, g_pl
+
+
+COLLAPSED = {
+    "named single hop": [n({"key": 1}, name="a"), e_forward(name="e"), n(name="b")],
+    "typed single hop": [n({"key": 1}), e_forward({"type": "KNOWS"}), n()],
+    "hops=2": [n({"key": 1}), e_forward(hops=2), n()],
+    "undirected": [n({"key": 1}), e_undirected(), n()],
+    "seed only": [n({"key": 1})],
+}
+
+
+@pytest.mark.parametrize("shape", list(COLLAPSED))
+def test_shapes_that_collapse_the_duplicate_match_pandas(shape):
+    g_pd, g_pl = _graph()
+    ops = COLLAPSED[shape]
+    assert sorted(g_pl.gfql(ops, engine="polars")._nodes["key"].to_list()) == sorted(g_pd.gfql(ops, engine="pandas")._nodes["key"].tolist())
+
+
+def test_hop_collapses_the_duplicate():
+    g_pd, g_pl = _graph()
+    seeds_pd = g_pd._nodes[g_pd._nodes["key"] == 1]
+    seeds_pl = g_pl._nodes.filter(pl.col("key") == 1)
+    assert sorted(g_pl.hop(nodes=seeds_pl, hops=1, engine="polars")._nodes["key"].to_list()) == sorted(g_pd.hop(nodes=seeds_pd, hops=1)._nodes["key"].tolist()) == [1, 2, 3]
+
+
+@pytest.mark.parametrize("shape", ["unnamed untyped single hop", "unnamed single hop with destination filter"])
+@pytest.mark.xfail(strict=True, reason="graphistry/pygraphistry#2051")
+def test_unnamed_untyped_single_hop_collapses_the_duplicate(shape):
+    g_pd, g_pl = _graph()
+    ops = [n({"key": 1}), e_forward(), n()] if shape == "unnamed untyped single hop" else [n({"key": 1}), e_forward(), n({"id": 20})]
+    assert sorted(g_pl.gfql(ops, engine="polars")._nodes["key"].to_list()) == sorted(g_pd.gfql(ops, engine="pandas")._nodes["key"].tolist())


### PR DESCRIPTION
Test-only, stacked on #2046 (retargets to master when it lands).

Owner ask after #2046: a fix for one specialization may be needed on its siblings; audit the recent fixes. The sweep (25 merged fix PRs inventoried; the engine- or lane-specific ones re-probed on pandas, cuDF and polars × scan/indexed × native/Cypher/hop/multi-hop against the pandas full path; report in the campaign plan under `spec-sweep/`) found one more miss beyond the #2039 family already handled in #2046:

- **#2051** — sibling of #1993 (polars `hop()` de-dups its node table): the unnamed, untyped single-hop *chain* shape on polars keeps a duplicated node row; named, typed, `hops=2`, undirected and `hop()` collapse it as pandas does.

This PR pins that contract in the polars mirror directory: the collapsing shapes green against pandas, the two leaking shapes as strict expected failures that flip with the fix. Registered in the polars test lane.

Classes re-probed clean on every engine × policy: #1990 EXISTS with indexes, #2000/#1991 bag multiplicity, #2002/#1982 boolean aggregates, #1998 `IN`/equality over categorical (string predicates over categorical raise the same E302 on every engine — consistent, flagged as a usability question in the report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QztW7jYsDd66e8rb8pJNQA