### PR TITLE
ci: run the gfql lanes on chain-engine changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,11 +242,19 @@ jobs:
           '^graphistry/compute/gfql/' \
           '^graphistry/compute/gfql_validate\.py$' \
           '^graphistry/compute/gfql_unified\.py$' \
+          '^graphistry/compute/gfql_fast_paths\.py$' \
+          '^graphistry/compute/chain.*\.py$' \
+          '^graphistry/compute/hop\.py$' \
+          '^graphistry/compute/filter_by_dict\.py$' \
+          '^graphistry/compute/ast\.py$' \
+          '^graphistry/compute/predicates/' \
           '^graphistry/models/gfql/' \
           '^graphistry/Plottable\.py$' \
           '^graphistry/tests/benchmarks/gfql/' \
           '^graphistry/tests/compute/gfql/' \
           '^graphistry/tests/compute/test_gfql.*\.py$' \
+          '^graphistry/tests/compute/test_chain.*\.py$' \
+          '^graphistry/tests/compute/test_hop.*\.py$' \
           '^graphistry/tests/test_gfql_.*\.py$' \
           '^tests/gfql/'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Infrastructure
 
+- **CI: the gfql change filter now includes the chain engine** (`compute/chain*.py`, `hop.py`, `gfql_fast_paths.py`, `filter_by_dict.py`, `ast.py`, `predicates/`, and the chain/hop test files), so tck-gfql, the Cypher-frontend gates and the gfql benchmark lane run on a change to the chain engine; they were skipped on #2055.
 - **CI: `test-docs` runs on docs-only pull requests (#2018)**: the job needed `python-lint-types`, which a docs-only change skips, and GitHub skips a job whose prerequisite was skipped. The gate now accepts skipped prerequisites and refuses only failed or cancelled ones, so documentation changes are built and tested before merge.
 ### Tests
 


### PR DESCRIPTION
Draft for the owner's call (raised in the #2055 review).

The gfql change filter covered `compute/gfql/**`, `gfql_unified.py`, `gfql_validate.py` and the gfql test trees, but not the chain engine: `compute/chain.py`, `chain_fast_paths.py`, `hop.py`, `gfql_fast_paths.py`, `filter_by_dict.py`, `ast.py`, `predicates/`. #2055 (a `chain.py` fix) therefore ran with tck-gfql, the four Cypher-frontend gates and the gfql benchmark lane skipped, even after a rebase onto master.

This adds those product files and the `test_chain*.py` / `test_hop*.py` test files to the filter. Cost: those lanes now run on chain-engine PRs (tck-gfql is ~15 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QztW7jYsDd66e8rb8pJNQA