### PR TITLE
perf(gfql): SNB point-query levers — index-hit verify, numpy hop tail, row-call trims, no edge-index scaffold for row calls

### DIFF
--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -86,6 +86,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_hop_scaling_pin.py
     graphistry/tests/compute/gfql/test_seeded_node_lookup_fastpath.py
     graphistry/tests/compute/gfql/test_native_seed_resolution_2027.py
+    graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
     graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
     graphistry/tests/compute/chain_specializations/test_native_admission.py

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1228,6 +1228,9 @@ def _chain_impl(
             if added_edge_index:
                 final_edges_df = g_out._edges.drop(columns=[g._edge])
                 g_out = self.nodes(g_out._nodes).edges(final_edges_df, edge=original_edge)
+            else:
+                from .gfql.exec_context import clear_row_exec_context
+                g_out = clear_row_exec_context(g_out)  # the row context must not escape on a result
             success = True
         else:
             # Phase 2: Backward pass to propagate downstream constraints.

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -33,7 +33,7 @@ logger = setup_logger(__name__)
 
 
 def _filter_edges_by_endpoint(
-    edges_df: DataFrameT, nodes_df: Optional[DataFrameT], node_id: str, edge_col: str
+    edges_df: DataFrameT, nodes_df: Optional[DataFrameT], node_id: Optional[str], edge_col: Optional[str]
 ) -> DataFrameT:
     if nodes_df is None or not node_id or not edge_col or edge_col not in edges_df.columns:
         return edges_df
@@ -189,8 +189,7 @@ def combine_steps(
     Collect nodes and edges, taking care to deduplicate and tag any names
     """
 
-    id = getattr(g, '_node' if kind == 'nodes' else '_edge')
-    df_fld = '_nodes' if kind == 'nodes' else '_edges'
+    id = (g._node if kind == 'nodes' else g._edge)
     op_type = ASTNode if kind == 'nodes' else ASTEdge
 
     if id is None:
@@ -198,10 +197,10 @@ def combine_steps(
 
     logger.debug('combine_steps ops pre: %s', [op for (op, _) in steps])
     if kind == 'edges':
-        node_id = getattr(g, '_node')
-        src_col = getattr(g, '_source')
-        dst_col = getattr(g, '_destination')
-        full_nodes = getattr(g, '_nodes', None)
+        node_id = g._node
+        src_col = g._source
+        dst_col = g._destination
+        full_nodes = g._nodes
 
         has_multihop = any(
             isinstance(op, ASTEdge) and not op.is_simple_single_hop()
@@ -228,7 +227,7 @@ def combine_steps(
 
                 prev_nodes = label_steps[idx - 1][1]._nodes if label_steps and idx > 0 else g._nodes
                 next_nodes = label_steps[idx + 1][1]._nodes if label_steps and idx + 1 < len(label_steps) else None
-                direction = getattr(op, 'direction', 'forward') if isinstance(op, ASTEdge) else 'forward'
+                direction = op.direction if isinstance(op, ASTEdge) else 'forward'
 
                 if direction == 'undirected' and prev_nodes is not None and next_nodes is not None and node_id:
                     # isin() dedups internally -> the .unique() pass is redundant
@@ -253,8 +252,8 @@ def combine_steps(
     def apply_output_slice(op: ASTObject, op_label: ASTObject, df):
         if not isinstance(op_label, ASTEdge):
             return df
-        out_min = getattr(op, 'output_min_hops', None) or getattr(op_label, 'output_min_hops', None)
-        out_max = getattr(op, 'output_max_hops', None) or getattr(op_label, 'output_max_hops', None)
+        out_min = (op.output_min_hops if isinstance(op, ASTEdge) else None) or op_label.output_min_hops
+        out_max = (op.output_max_hops if isinstance(op, ASTEdge) else None) or op_label.output_max_hops
         if out_min is None and out_max is None:
             return df
         label_col = op_label.label_node_hops if kind == 'nodes' else op_label.label_edge_hops
@@ -273,19 +272,19 @@ def combine_steps(
 
     dfs_to_concat = []
     extra_step_dfs = []
-    base_cols = set(getattr(g, df_fld).columns)
+    base_cols = set((g._nodes if kind == "nodes" else g._edges).columns)
     for idx, (op, g_step) in enumerate(steps):
         op_label = label_steps[idx][0] if idx < len(label_steps) else op
-        step_df = apply_output_slice(op, op_label, getattr(g_step, df_fld))
+        step_df = apply_output_slice(op, op_label, (g_step._nodes if kind == "nodes" else g_step._edges))
         if id not in step_df.columns:
-            step_id = getattr(g_step, '_node' if kind == 'nodes' else '_edge')
+            step_id = (g_step._node if kind == "nodes" else g_step._edge)
             raise ValueError(f"Column '{id}' not found in {kind} step DataFrame. "
                            f"Step has id='{step_id}', available columns: {list(step_df.columns)}. "
                            f"Operation: {op}")
         dfs_to_concat.append(step_df[[id]])
 
     for _, (_, g_step) in enumerate(label_steps):
-        step_df = getattr(g_step, df_fld)
+        step_df = (g_step._nodes if kind == "nodes" else g_step._edges)
         if id not in step_df.columns:
             continue
         extra_cols = [c for c in step_df.columns if c != id and c not in base_cols and 'hop' in c]
@@ -321,9 +320,9 @@ def combine_steps(
             out_df = apply_output_slice(op, op_label, out_df)
 
     if kind == 'nodes' and label_cols:
-        label_seeds_requested = any(isinstance(op, ASTEdge) and getattr(op, 'label_seeds', False) for op, _ in label_steps)
+        label_seeds_requested = any(isinstance(op, ASTEdge) and op.label_seeds for op, _ in label_steps)
         if label_seeds_requested and label_steps:
-            seed_df = getattr(label_steps[0][1], df_fld)
+            seed_df = (label_steps[0][1]._nodes if kind == "nodes" else label_steps[0][1]._edges)
             if seed_df is not None and id in seed_df.columns:
                 seed_ids = seed_df[[id]].drop_duplicates()
                 if resolve_engine(EngineAbstract.AUTO, seed_ids) != resolve_engine(EngineAbstract.AUTO, out_df):
@@ -364,7 +363,7 @@ def combine_steps(
     for idx, (op, g_step) in enumerate(steps):
         if op._name is not None and isinstance(op, op_type):
             logger.debug('tagging kind [%s] name %s', op_type, op._name)
-            step_df = getattr(g_step, df_fld)[[id, op._name]]
+            step_df = (g_step._nodes if kind == "nodes" else g_step._edges)[[id, op._name]]
             out_df = safe_merge(out_df, step_df, on=id, how='left', engine=engine)
             x_name, y_name = f'{op._name}_x', f'{op._name}_y'
             if x_name in out_df.columns and y_name in out_df.columns:
@@ -403,8 +402,8 @@ def combine_steps(
     if kind == 'nodes':
         hop_cols = [c for c in out_df.columns if 'hop' in c.lower()]
         edge_ops = [op for op, _ in steps if isinstance(op, ASTEdge)]
-        has_output_min = any(getattr(op, 'output_min_hops', None) is not None for op in edge_ops)
-        has_output_max = any(getattr(op, 'output_max_hops', None) is not None for op in edge_ops)
+        has_output_min = any(op.output_min_hops is not None for op in edge_ops)
+        has_output_max = any(op.output_max_hops is not None for op in edge_ops)
         if (has_output_min or has_output_max) and hop_cols:
             hop_col = hop_cols[0]
             has_na = out_df[hop_col].isna()
@@ -422,7 +421,7 @@ def combine_steps(
                         pass
                 out_df = out_df[~has_na | has_tag]
 
-    g_df = getattr(g, df_fld)
+    g_df = (g._nodes if kind == "nodes" else g._edges)
     # slice 5 (#1755): a seeded result attaches the full node/edge frame via a
     # how='left' merge whose big side (g_df) is scanned in full even for a 1-row
     # out_df. Pre-shrink g_df to the ids actually present (unmatched rows are
@@ -436,7 +435,7 @@ def combine_steps(
     if kind == 'nodes' and label_cols:
         seeds_df = label_steps[0][1]._nodes if label_steps and label_steps[0][1]._nodes is not None else None
         seed_ids = seeds_df[[id]].drop_duplicates() if seeds_df is not None and id in seeds_df.columns else None
-        label_seeds_true = any(isinstance(op, ASTEdge) and getattr(op, 'label_seeds', False) for op, _ in label_steps)
+        label_seeds_true = any(isinstance(op, ASTEdge) and op.label_seeds for op, _ in label_steps)
         if seed_ids is not None:
             if label_seeds_true:
                 seeds_with_labels = seed_ids.copy()
@@ -454,7 +453,7 @@ def combine_steps(
         if hop_cols:
             hop_maps = []
             for _, g_step in label_steps:
-                step_df = getattr(g_step, df_fld)
+                step_df = (g_step._nodes if kind == "nodes" else g_step._edges)
                 if id in step_df.columns:
                     for hc in hop_cols:
                         if hc in step_df.columns:
@@ -524,7 +523,7 @@ def combine_steps(
     # never coalesced into the marker (mixed bool/user dtypes also crash cuDF).
     alias_marker_names = {
         op._name for op, _ in steps
-        if isinstance(op, op_type) and isinstance(getattr(op, '_name', None), str)
+        if isinstance(op, op_type) and isinstance(op._name, str)
     }
     for c in cols:
         if c.endswith('_x'):
@@ -756,7 +755,7 @@ def _handle_boundary_calls(
         )
         if (
             middle
-            and any(getattr(op, "_name", None) is not None for op in middle)
+            and any(op._name is not None for op in middle)
             and isinstance(suffix[0], ASTCall)
             and suffix[0].function == "rows"
             and suffix[0].params.get("binding_ops") is None
@@ -849,13 +848,13 @@ def reject_alias_named_like_binding(
     polars answered ``True``. Neither is a usable result; decline the same way on both.
     """
     from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
-    node_id = getattr(g, "_node", None)
+    node_id = g._node
     endpoint_cols = {
-        col for col in (getattr(g, "_source", None), getattr(g, "_destination", None), getattr(g, "_edge", None))
+        col for col in (g._source, g._destination, g._edge)
         if isinstance(col, str)
     }
     for op in chain_obj.chain:
-        if isinstance(node_id, str) and isinstance(op, ASTNode) and getattr(op, "_name", None) == node_id:
+        if isinstance(node_id, str) and isinstance(op, ASTNode) and op._name == node_id:
             raise GFQLValidationError(
                 ErrorCode.E108,
                 "A node alias cannot be named after the node-ID binding column",
@@ -869,13 +868,13 @@ def reject_alias_named_like_binding(
         if (
             include_edge_endpoint_aliases
             and isinstance(op, ASTEdge)
-            and getattr(op, "_name", None) in endpoint_cols
+            and op._name in endpoint_cols
         ):
             raise GFQLValidationError(
                 ErrorCode.E108,
                 "An edge alias cannot be named after an edge endpoint binding column",
                 field="chain.name",
-                value=getattr(op, "_name", None),
+                value=op._name,
                 suggestion=(
                     "The alias flag is materialized as a column named like the edge "
                     "source, destination or edge-ID binding, which would overwrite it. "
@@ -1014,7 +1013,7 @@ _NODE_ROW_CALLS = ("rows", "select", "with_")
 
 
 def _calls_only_on_node_rows(ops: List[ASTObject]) -> bool:
-    """True when every op is a plain row-table call (a node or edge table, no binding rows), which never reads edge identity."""
+    """Whether all operations use row tables without binding rows or edge identity."""
     if not ops:
         return False
     for op in ops:
@@ -1141,7 +1140,7 @@ def _chain_impl(
             )
 
         if g._edges is None or _calls_only_on_node_rows(ops):
-            added_edge_index = False  # row-table calls on the node table never read edge identity
+            added_edge_index = False
         elif g._edge is None:
             GFQL_EDGE_INDEX = generate_safe_column_name('edge_index', g._edges, prefix='__gfql_', suffix='__')
 
@@ -1230,7 +1229,7 @@ def _chain_impl(
                 g_out = self.nodes(g_out._nodes).edges(final_edges_df, edge=original_edge)
             else:
                 from .gfql.exec_context import clear_row_exec_context
-                g_out = clear_row_exec_context(g_out)  # the row context must not escape on a result
+                g_out = clear_row_exec_context(g_out)
             success = True
         else:
             # Phase 2: Backward pass to propagate downstream constraints.

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1009,6 +1009,24 @@ def _chain_with_strictness(
         return _chain_impl(self, ops, engine, validate_schema, policy, context, start_nodes)
 
 
+
+_NODE_ROW_CALLS = ("rows", "select", "with_")
+
+
+def _calls_only_on_node_rows(ops: List[ASTObject]) -> bool:
+    """True when every op is a plain row-table call (a node or edge table, no binding rows), which never reads edge identity."""
+    if not ops:
+        return False
+    for op in ops:
+        if not isinstance(op, ASTCall) or op.function not in _NODE_ROW_CALLS:
+            return False
+        if op.function == "rows" and (
+            op.params.get("binding_ops") is not None or op.params.get("alias_endpoints") is not None
+        ):
+            return False
+    return True
+
+
 def _chain_impl(
     self: Plottable,
     ops: Union[List[ASTObject], Chain],
@@ -1122,8 +1140,8 @@ def _chain_impl(
                 suggestion='Bind edges via g.edges(df, source, destination), or use a node-only pattern'
             )
 
-        if g._edges is None:
-            added_edge_index = False
+        if g._edges is None or _calls_only_on_node_rows(ops):
+            added_edge_index = False  # row-table calls on the node table never read edge identity
         elif g._edge is None:
             GFQL_EDGE_INDEX = generate_safe_column_name('edge_index', g._edges, prefix='__gfql_', suffix='__')
 

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -20,27 +20,7 @@ def _tag_fast_path_aliases(
     alias_n0: Optional[str], alias_e1: Optional[str], alias_n2: Optional[str],
     src: str, dst: str, node: str, direction: Direction,
 ) -> Plottable:
-    """Attach the alias flag columns the full path's ``combine_steps`` would have merged in.
-
-    The chain fast path's gate used to reject ANY named op, so a named
-    `g.gfql([n(name=..), e(..), n(name=..)])` fell to the full two-pass machinery purely
-    because the ops carried names — measured ~25.2 -> ~2.3 ms (medians of 5 paired runs) on
-    a 200-node graph where data-proportional work is ~0. Naming is a PROJECTION concern,
-    not a traversal one, so it should not change which engine path runs. NOTE the scope: this is the NATIVE chain
-    surface. The Cypher `MATCH ... RETURN` shapes on the graph benchmark are served
-    earlier by `gfql_fast_paths.py` and never reach here (measured, both engines).
-
-    Why deriving the tags from the RETURNED EDGES matches the full path: `combine_steps`
-    tags a node with an alias iff it matched that step in the BACKWARD-PRUNED frame, i.e.
-    iff it still participates in a surviving edge. The edges this function receives are
-    exactly the surviving ones — the fast path has already applied the node filters, the
-    edge_match and the endpoint validation — so ``isin`` over their endpoint columns is the
-    same predicate, computed without the join.
-
-    A seed whose edges all fail the type filter yields an empty edge frame, so it is tagged
-    False rather than True: that is the dead-end case, and it is why the tag keys on the
-    edges rather than on the node filter.
-    """
+    """Tag nodes by surviving edge endpoints and mark matching edges."""
     if alias_n0 is None and alias_e1 is None and alias_n2 is None:
         return res
     nodes: Optional[DataFrameT] = res._nodes
@@ -48,7 +28,7 @@ def _tag_fast_path_aliases(
     if nodes is None or edges is None:
         return res
     from_col, to_col = (src, dst) if direction == "forward" else (dst, src)
-    tagged = _tag_fast_path_aliases_pandas(nodes, edges, alias_n0, alias_e1, alias_n2, from_col, to_col, node)
+    tagged = _tag_fast_path_aliases_eager(nodes, edges, alias_n0, alias_e1, alias_n2, from_col, to_col, node)
     if tagged is not None:
         return res.nodes(tagged[0]).edges(tagged[1])
     node_flags: Dict[str, SeriesT] = {}
@@ -76,36 +56,41 @@ def _tag_fast_path_aliases(
     return res.nodes(nodes).edges(edges)
 
 
-def _tag_fast_path_aliases_pandas(
+def _tag_fast_path_aliases_eager(
     nodes: DataFrameT, edges: DataFrameT,
     alias_n0: Optional[str], alias_e1: Optional[str], alias_n2: Optional[str],
     from_col: str, to_col: str, node: str,
 ) -> Optional[Tuple[DataFrameT, DataFrameT]]:
-    """The pandas-only equivalent of the generic tagging below: same columns, order, dtypes
-    and RangeIndex, built with one frame copy and in-place column inserts instead of the
-    assign / reorder / reset_index copies. None when a shape the in-place inserts cannot
-    reproduce (binding column not first, or a colliding alias) needs the generic path."""
+    """Insert noncolliding alias columns without reordering the whole frame."""
     import numpy as np
     import pandas as pd
-    if not (isinstance(nodes, pd.DataFrame) and isinstance(edges, pd.DataFrame)):
-        return None
+    pandas_frames = isinstance(nodes, pd.DataFrame) and isinstance(edges, pd.DataFrame)
+    if not pandas_frames:
+        from graphistry.Engine import Engine, resolve_engine
+        if resolve_engine("auto", nodes) != Engine.CUDF or resolve_engine("auto", edges) != Engine.CUDF:
+            return None
     if alias_e1 is not None and alias_e1 in edges.columns:
         return None
     wanted = [a for a in (alias_n0, alias_n2) if a is not None]
     if wanted:
         if nodes.columns[0] != node or any(a in nodes.columns for a in wanted):
             return None
-        ids = nodes[node].to_numpy()
-        ends = (edges[from_col].to_numpy(), edges[to_col].to_numpy())
-        if any(a.dtype.kind not in "iub" for a in (ids, *ends)):
-            return None  # float/object ids: pandas isin's NaN and mixed-type rules, not numpy's
+        if len(set(wanted)) != len(wanted):
+            return None
+        if pandas_frames:
+            ids = nodes[node].to_numpy()
+            ends = (edges[from_col].to_numpy(), edges[to_col].to_numpy())
+            if any(a.dtype.kind not in "iub" or a.dtype != ids.dtype for a in (ids, *ends)):
+                return None
         out_nodes = nodes.reset_index(drop=True)
         pos = 1
         if alias_n0 is not None:
-            out_nodes.insert(pos, alias_n0, np.isin(ids, ends[0]))
+            seed_flags = np.isin(ids, ends[0]) if pandas_frames else nodes[node].isin(edges[from_col]).reset_index(drop=True)
+            out_nodes.insert(pos, alias_n0, seed_flags)
             pos += 1
         if alias_n2 is not None:
-            out_nodes.insert(pos, alias_n2, np.isin(ids, ends[1]))
+            tail_flags = np.isin(ids, ends[1]) if pandas_frames else nodes[node].isin(edges[to_col]).reset_index(drop=True)
+            out_nodes.insert(pos, alias_n2, tail_flags)
         nodes = out_nodes
     if alias_e1 is not None:
         out_edges = edges.reset_index(drop=True)
@@ -333,8 +318,7 @@ def _seed_node_rows(
 def _verify_scalar_filters_on_hit(
     seed: DataFrameT, n0f: Dict[str, object], engine: "Engine",
 ) -> Optional[DataFrameT]:
-    """Re-check the resolved scalar equalities on the few rows an index hit returned, with the
-    canonical filter's typed errors but none of its per-call overhead; None defers to it."""
+    """Check residual equalities on index hits, preserving typed filter errors."""
     from graphistry.Engine import Engine
     from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError
     from graphistry.compute.filter_by_dict import _is_numeric_dtype_safe, _is_string_dtype_safe
@@ -357,16 +341,17 @@ def _verify_scalar_filters_on_hit(
         mask = hit if mask is None else (mask & hit)
     if mask is None:
         return seed
-    if bool(mask.all()):
+    import pandas as pd
+    if engine == Engine.CUDF and mask.null_count:
+        mask = mask.fillna(False)
+    all_match = mask.all(skipna=False)
+    if all_match is not pd.NA and bool(all_match):
         return seed
     return seed[mask]
 
 
 def _index_answered_whole_filter(effective: Dict[str, object], n0f: Dict[str, object]) -> bool:
-    """True when the index hit already applied the entire filter: one scalar equality on
-    the served column, written on that column (no ``label__`` rewrite). The indexes hold
-    integer keys and decline mismatched value families, so the gathered rows equal the
-    canonical filter's rows and its typed errors cannot arise on this shape."""
+    """Whether one unrewritten equality was fully answered by the index."""
     if len(effective) != 1 or len(n0f) != 1:
         return False
     (col, val), = effective.items()

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -48,6 +48,9 @@ def _tag_fast_path_aliases(
     if nodes is None or edges is None:
         return res
     from_col, to_col = (src, dst) if direction == "forward" else (dst, src)
+    tagged = _tag_fast_path_aliases_pandas(nodes, edges, alias_n0, alias_e1, alias_n2, from_col, to_col, node)
+    if tagged is not None:
+        return res.nodes(tagged[0]).edges(tagged[1])
     node_flags: Dict[str, SeriesT] = {}
     if alias_n0 is not None:
         node_flags[alias_n0] = nodes[node].isin(edges[from_col])
@@ -71,6 +74,44 @@ def _tag_fast_path_aliases(
         edges = edges.reset_index(drop=True)
 
     return res.nodes(nodes).edges(edges)
+
+
+def _tag_fast_path_aliases_pandas(
+    nodes: DataFrameT, edges: DataFrameT,
+    alias_n0: Optional[str], alias_e1: Optional[str], alias_n2: Optional[str],
+    from_col: str, to_col: str, node: str,
+) -> Optional[Tuple[DataFrameT, DataFrameT]]:
+    """The pandas-only equivalent of the generic tagging below: same columns, order, dtypes
+    and RangeIndex, built with one frame copy and in-place column inserts instead of the
+    assign / reorder / reset_index copies. None when a shape the in-place inserts cannot
+    reproduce (binding column not first, or a colliding alias) needs the generic path."""
+    import numpy as np
+    import pandas as pd
+    if not (isinstance(nodes, pd.DataFrame) and isinstance(edges, pd.DataFrame)):
+        return None
+    if alias_e1 is not None and alias_e1 in edges.columns:
+        return None
+    wanted = [a for a in (alias_n0, alias_n2) if a is not None]
+    if wanted:
+        if nodes.columns[0] != node or any(a in nodes.columns for a in wanted):
+            return None
+        ids = nodes[node].to_numpy()
+        ends = (edges[from_col].to_numpy(), edges[to_col].to_numpy())
+        if any(a.dtype.kind not in "iub" for a in (ids, *ends)):
+            return None  # float/object ids: pandas isin's NaN and mixed-type rules, not numpy's
+        out_nodes = nodes.reset_index(drop=True)
+        pos = 1
+        if alias_n0 is not None:
+            out_nodes.insert(pos, alias_n0, np.isin(ids, ends[0]))
+            pos += 1
+        if alias_n2 is not None:
+            out_nodes.insert(pos, alias_n2, np.isin(ids, ends[1]))
+        nodes = out_nodes
+    if alias_e1 is not None:
+        out_edges = edges.reset_index(drop=True)
+        out_edges.insert(0, alias_e1, True)
+        edges = out_edges
+    return nodes, edges
 
 
 def _seeded_scalar_filters(fd: Optional[Dict[str, Any]], df: DataFrameT) -> Optional[Dict[str, Any]]:

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -279,7 +279,21 @@ def _seed_node_rows(
             how = "property_index"
     if seed is None:
         seed = nodes_df
-    return _filter_frame(seed, filter_dict if filter_dict is not None else n0f, engine), how
+    effective = filter_dict if filter_dict is not None else n0f
+    if how != "scan" and _index_answered_whole_filter(effective, n0f):
+        return seed, how
+    return _filter_frame(seed, effective, engine), how
+
+
+def _index_answered_whole_filter(effective: Dict[str, object], n0f: Dict[str, object]) -> bool:
+    """True when the index hit already applied the entire filter: one scalar equality on
+    the served column, written on that column (no ``label__`` rewrite). The indexes hold
+    integer keys and decline mismatched value families, so the gathered rows equal the
+    canonical filter's rows and its typed errors cannot arise on this shape."""
+    if len(effective) != 1 or len(n0f) != 1:
+        return False
+    (col, val), = effective.items()
+    return col in n0f and n0f[col] is val
 
 
 def _record_native_seed_lane(

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -323,7 +323,43 @@ def _seed_node_rows(
     effective = filter_dict if filter_dict is not None else n0f
     if how != "scan" and _index_answered_whole_filter(effective, n0f):
         return seed, how
+    if how != "scan":
+        verified = _verify_scalar_filters_on_hit(seed, n0f, engine)
+        if verified is not None:
+            return verified, how
     return _filter_frame(seed, effective, engine), how
+
+
+def _verify_scalar_filters_on_hit(
+    seed: DataFrameT, n0f: Dict[str, object], engine: "Engine",
+) -> Optional[DataFrameT]:
+    """Re-check the resolved scalar equalities on the few rows an index hit returned, with the
+    canonical filter's typed errors but none of its per-call overhead; None defers to it."""
+    from graphistry.Engine import Engine
+    from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError
+    from graphistry.compute.filter_by_dict import _is_numeric_dtype_safe, _is_string_dtype_safe
+    if engine not in (Engine.PANDAS, Engine.CUDF) or len(seed) == 0 or not n0f:
+        return seed if len(seed) == 0 else None
+    mask = None
+    for col, val in n0f.items():
+        if col not in seed.columns or isinstance(val, (list, tuple, set)):
+            return None
+        col_dtype = seed[col].dtype
+        if _is_numeric_dtype_safe(col_dtype) and isinstance(val, str):
+            raise GFQLSchemaError(
+                ErrorCode.E302, f'Type mismatch: column "{col}" is numeric but filter value is string',
+                field=col, value=val, column_type=str(col_dtype), suggestion=f'Use a numeric value like {col}=123')
+        if _is_string_dtype_safe(col_dtype) and isinstance(val, (int, float)) and not isinstance(val, bool):
+            raise GFQLSchemaError(
+                ErrorCode.E302, f'Type mismatch: column "{col}" is string but filter value is numeric',
+                field=col, value=val, column_type=str(col_dtype), suggestion=f'Use a string value like {col}="value"')
+        hit = seed[col] == val
+        mask = hit if mask is None else (mask & hit)
+    if mask is None:
+        return seed
+    if bool(mask.all()):
+        return seed
+    return seed[mask]
 
 
 def _index_answered_whole_filter(effective: Dict[str, object], n0f: Dict[str, object]) -> bool:

--- a/graphistry/compute/chain_specializations/hotpaths.py
+++ b/graphistry/compute/chain_specializations/hotpaths.py
@@ -127,30 +127,43 @@ def _seeded_typed_hop_pandas_cudf(
 def _seeded_hop_tail_numeric(
     cand: DataFrameT, edges: DataFrameT, n2f: Dict[str, object], src: str, dst: str, to_col: str, node: str,
 ) -> Optional[Tuple[DataFrameT, DataFrameT]]:
-    """The endpoint validation and destination filter on the few gathered rows, as numpy array ops on
-    pandas frames with numeric id columns; None keeps the engine-generic Series path."""
-    import numpy as np
+    """Validate numeric endpoints using arrays native to the frame backend."""
     import pandas as pd
-    if not isinstance(cand, pd.DataFrame) or not isinstance(edges, pd.DataFrame):
+    from graphistry.Engine import resolve_engine
+    from graphistry.compute.gfql.index.engine_arrays import array_namespace
+
+    pandas_frames = isinstance(cand, pd.DataFrame) and isinstance(edges, pd.DataFrame)
+    if pandas_frames:
+        xp, _ = array_namespace(Engine.PANDAS)
+        ids = cand[node].to_numpy()
+        es, ed = edges[src].to_numpy(), edges[dst].to_numpy()
+    else:
+        if resolve_engine("auto", cand) != Engine.CUDF or resolve_engine("auto", edges) != Engine.CUDF:
+            return None
+        if any(column.null_count for column in (cand[node], edges[src], edges[dst])):
+            return None
+        if any(column.dtype.kind not in "iuf" for column in (cand[node], edges[src], edges[dst])):
+            return None
+        xp, _ = array_namespace(Engine.CUDF)
+        ids = cand[node].values
+        es, ed = edges[src].values, edges[dst].values
+    if not all(a.dtype.kind in "iuf" and a.dtype == ids.dtype for a in (ids, es, ed)):
         return None
-    ids = cand[node].to_numpy()
-    es, ed = edges[src].to_numpy(), edges[dst].to_numpy()
-    if not all(a.dtype.kind in "iuf" for a in (ids, es, ed)):
-        return None
-    n2_mask = np.ones(len(cand), dtype=bool)
+    n2_mask = xp.ones(len(cand), dtype=bool)
     for k, v in n2f.items():
         col = cand[k]
         if col.dtype.kind not in "iufb" and not isinstance(v, str):
             return None
-        n2_mask &= (col.to_numpy() == v)
-    valid = ids[~np.isnan(ids)] if ids.dtype.kind == "f" else ids
+        matches = (col == v).fillna(False)
+        n2_mask &= matches.to_numpy(dtype=bool) if pandas_frames else matches.values
+    valid = ids[~xp.isnan(ids)] if ids.dtype.kind == "f" else ids
     n2_ok = ids[n2_mask]
-    n2_ok = n2_ok[~np.isnan(n2_ok)] if n2_ok.dtype.kind == "f" else n2_ok
+    n2_ok = n2_ok[~xp.isnan(n2_ok)] if n2_ok.dtype.kind == "f" else n2_ok
     to_vals = es if to_col == src else ed
-    keep = np.isin(es, valid) & np.isin(ed, valid) & np.isin(to_vals, n2_ok)
+    keep = xp.isin(es, valid) & xp.isin(ed, valid) & xp.isin(to_vals, n2_ok)
     edges = edges[keep]
-    kept = np.concatenate([es[keep], ed[keep]])
-    cand = cand[np.isin(ids, kept)]
+    kept = xp.concatenate([es[keep], ed[keep]])
+    cand = cand[xp.isin(ids, kept)]
     return cand, edges
 
 

--- a/graphistry/compute/chain_specializations/hotpaths.py
+++ b/graphistry/compute/chain_specializations/hotpaths.py
@@ -3,7 +3,7 @@ and the seeded typed RETURN-destination reduction. Each lane sits next to its ad
 predicate (``admission.py``); ``chain.py`` only dispatches."""
 # ruff: noqa: E501
 
-from typing import List, Optional, Sequence, Tuple, TYPE_CHECKING, cast
+from typing import Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, cast
 
 from graphistry.Engine import Engine, EngineAbstract, df_concat
 from graphistry.Plottable import Plottable
@@ -106,6 +106,10 @@ def _seeded_typed_hop_pandas_cudf(
     if served_via_index:
         _record_native_seed_lane(nodes_df, seam="native_seeded_hop", reason="served", hop_count=1,
                                  public_seed_scan=node not in n0f)
+    tail = _seeded_hop_tail_numeric(cand, edges, n2f, src, dst, to_col, node)
+    if tail is not None:
+        cand, edges = tail
+        return g.nodes(cand).edges(edges)
     if n2f:  # destination-node filter (to-side)
         n2_cand = cand
         for k, v in n2f.items():
@@ -118,6 +122,36 @@ def _seeded_typed_hop_pandas_cudf(
     edges = edges[keep]
     cand = cand[cand[node].isin(edges[src]) | cand[node].isin(edges[dst])]
     return g.nodes(cand).edges(edges)
+
+
+def _seeded_hop_tail_numeric(
+    cand: DataFrameT, edges: DataFrameT, n2f: Dict[str, object], src: str, dst: str, to_col: str, node: str,
+) -> Optional[Tuple[DataFrameT, DataFrameT]]:
+    """The endpoint validation and destination filter on the few gathered rows, as numpy array ops on
+    pandas frames with numeric id columns; None keeps the engine-generic Series path."""
+    import numpy as np
+    import pandas as pd
+    if not isinstance(cand, pd.DataFrame) or not isinstance(edges, pd.DataFrame):
+        return None
+    ids = cand[node].to_numpy()
+    es, ed = edges[src].to_numpy(), edges[dst].to_numpy()
+    if not all(a.dtype.kind in "iuf" for a in (ids, es, ed)):
+        return None
+    n2_mask = np.ones(len(cand), dtype=bool)
+    for k, v in n2f.items():
+        col = cand[k]
+        if col.dtype.kind not in "iufb" and not isinstance(v, str):
+            return None
+        n2_mask &= (col.to_numpy() == v)
+    valid = ids[~np.isnan(ids)] if ids.dtype.kind == "f" else ids
+    n2_ok = ids[n2_mask]
+    n2_ok = n2_ok[~np.isnan(n2_ok)] if n2_ok.dtype.kind == "f" else n2_ok
+    to_vals = es if to_col == src else ed
+    keep = np.isin(es, valid) & np.isin(ed, valid) & np.isin(to_vals, n2_ok)
+    edges = edges[keep]
+    kept = np.concatenate([es[keep], ed[keep]])
+    cand = cand[np.isin(ids, kept)]
+    return cand, edges
 
 
 def _seeded_typed_return_dst_pandas_cudf(

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -468,17 +468,7 @@ def _apply_node_names(out: "pl.LazyFrame", g: "_LazyShim",
                     on=node_col, how="semi")
         if idx + 1 < len(step_list):
             next_op, next_step = step_list[idx + 1]
-            # Cardinality guard, restated against a fact that SURVIVES lazification. The old
-            # spelling was `is_lazy(df) or df.height > 0`, and `_apply_node_names` is always
-            # called with lazified steps — so `is_lazy` short-circuited True and the height
-            # test was unreachable. That is the identical silent death this commit fixes one
-            # function above; leaving a second copy of it here is how the bug recurs.
-            # Unlike the edges combine this one is SEMANTIC, not a cost guard: an empty next
-            # edge step must not empty `named` via the gate below.
-            # Plain attribute read, not getattr: `next_step` is a `_LazyShim`, which declares
-            # `edges_empty` in __slots__ with a real `Optional[bool]` annotation, so the
-            # tri-state is part of the type and a typo here is a checker error rather than a
-            # silent None (which would have re-armed the very gate this guard disarms).
+            # Empty next-edge steps must not filter node aliases.
             next_edges_empty = next_step.edges_empty
             if (isinstance(next_op, ASTEdge) and next_step._edges is not None
                     and next_edges_empty is not True):
@@ -573,7 +563,7 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
     #    the generic chain routes schema-changers straight to execute_call.)
     from graphistry.compute.ast import ASTCall
     from graphistry.compute.gfql.row.pipeline import is_row_pipeline_call
-    from graphistry.compute.exceptions import ErrorCode, GFQLTypeError, GFQLValidationError
+    from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError, GFQLTypeError, GFQLValidationError
     for op in calls:
         if not isinstance(op, ASTCall):
             raise NotImplementedError(
@@ -586,6 +576,8 @@ def _run_calls_polars(g_cur, calls, start_nodes, base_graph, middle):
         except GFQLTypeError:
             raise
         except GFQLValidationError as validation_error:
+            if isinstance(validation_error, GFQLSchemaError) and validation_error.code == ErrorCode.E301:
+                raise
             # Same wrapping `execute_call` applies (gfql/call/executor.py): a kernel that
             # raises a validation error surfaces as GFQLTypeError(E303) with this message
             # shape. The native attempt runs BEFORE execute_call, so without this the SAME
@@ -766,7 +758,7 @@ def chain_polars(self: Plottable, ops, start_nodes: Optional[Any] = None) -> Plo
     for _alias_type in (ASTNode, ASTEdge):
         _seen: dict = {}
         for _idx, _op in enumerate(ops):
-            _name = getattr(_op, "_name", None)
+            _name = _op._name
             if _name is not None and isinstance(_op, _alias_type):
                 if _name in _seen:
                     from graphistry.compute.exceptions import GFQLValidationError, ErrorCode
@@ -918,9 +910,6 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
 
     edge_src, edge_dst = _bound_edge_endpoints(self)
 
-    # Node-only shape: single MATCH (n). Result is just the filtered node table + empty edges,
-    # so skip forward/backward/combine. Byte-identical: the one-node-step combine yields filtered
-    # g._nodes in order + empty edges + the alias flag on every matched node.
     if polars_single_node_admits(ops, start_nodes):
         single = _single_node_polars(self, ops, start_nodes)
         if single is not None:

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -18,9 +18,8 @@ from graphistry.compute.endpoint_utils import drop_null_endpoint_edges
 
 from graphistry.Plottable import Plottable
 from graphistry.compute.ast import ASTObject, ASTNode, ASTEdge
-from graphistry.compute.chain_specializations.hotpaths import _single_node_rows_via_index_or_filter
-from .chain_specializations.admission import polars_plain_single_hop_admits
-from .chain_specializations.hotpaths import _plain_seeded_index_hop_polars, _plain_single_hop_polars, _try_seeded_chain_polars
+from .chain_specializations.admission import polars_plain_single_hop_admits, polars_single_node_admits
+from .chain_specializations.hotpaths import _plain_seeded_index_hop_polars, _plain_single_hop_polars, _single_node_polars, _try_seeded_chain_polars
 
 if TYPE_CHECKING:
     import polars as pl
@@ -922,20 +921,10 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
     # Node-only shape: single MATCH (n). Result is just the filtered node table + empty edges,
     # so skip forward/backward/combine. Byte-identical: the one-node-step combine yields filtered
     # g._nodes in order + empty edges + the alias flag on every matched node.
-    if len(ops) == 1 and isinstance(ops[0], ASTNode) and ops[0].query is None:
-        op0 = ops[0]
-        g0 = ensure_nodes_polars(self)
-        nc = g0._node
-        assert nc is not None
-        from graphistry.Engine import EngineAbstract
-        nodes = _single_node_rows_via_index_or_filter(g0, op0, EngineAbstract.POLARS)
-        if start_nodes is not None:
-            from graphistry.Engine import Engine as _E, df_to_engine as _d2e
-            seed = _align_seed_dtype(_d2e(start_nodes, _E.POLARS), nc, g0._nodes)
-            nodes = _semi(nodes, seed, nc, nc)
-        if op0._name is not None:
-            nodes = nodes.with_columns(pl.lit(True).alias(op0._name))
-        return g0.nodes(nodes, nc).edges(g0._edges.clear(), edge_src, edge_dst)
+    if polars_single_node_admits(ops, start_nodes):
+        single = _single_node_polars(self, ops, start_nodes)
+        if single is not None:
+            return single
 
     if isinstance(ops[0], ASTEdge):
         ops = [ASTNode()] + ops

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py
@@ -42,8 +42,7 @@ def polars_plain_single_hop_admits(ops: Sequence[ASTObject], start_nodes: Option
 
 
 def polars_single_node_admits(ops: Sequence[ASTObject], start_nodes: Optional[object]) -> bool:
-    """A lone node op without ``query``: the node table answers it directly (index gather or filter,
-    then a semi join on ``start_nodes`` when seeded), with no lazy plan to build or collect."""
+    """Admit one node operation without a query, with or without start nodes."""
     if len(ops) != 1:
         return False
     n0 = ops[0]

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py
@@ -41,6 +41,15 @@ def polars_plain_single_hop_admits(ops: Sequence[ASTObject], start_nodes: Option
     return "skip-combine" if (unconstrained or directed) else None
 
 
+def polars_single_node_admits(ops: Sequence[ASTObject], start_nodes: Optional[object]) -> bool:
+    """A lone node op without ``query``: the node table answers it directly (index gather or filter,
+    then a semi join on ``start_nodes`` when seeded), with no lazy plan to build or collect."""
+    if len(ops) != 1:
+        return False
+    n0 = ops[0]
+    return isinstance(n0, ASTNode) and n0.query is None
+
+
 def polars_seeded_lane_admits(ops: Sequence[ASTObject]) -> bool:
     """Whether the polars seeded lane's shape gate admits ``ops``: a 3-op directed simple
     single hop whose seed node carries a filter, with no node queries, endpoint matches,

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
@@ -19,12 +19,35 @@ from graphistry.compute.typing import ArrayLike, ArrayNamespace, DataFrameT
 from graphistry.compute.gfql.lazy.engine.polars.dtypes import endpoint_ids
 from graphistry.compute.gfql.lazy.engine.polars.hop_eager import ensure_nodes_polars
 from graphistry.compute.gfql.lazy.engine.polars.predicates import filter_by_dict_polars
-from .admission import polars_seeded_lane_admits
+from .admission import polars_seeded_lane_admits, polars_single_node_admits
 
 if TYPE_CHECKING:
     import polars as pl
     from graphistry.compute.gfql.index.registry import AdjacencyIndex, NodeIdIndex
     from graphistry.compute.gfql.lazy.engine.polars.dtypes import PolarsFrame
+
+
+def _single_node_polars(g: Plottable, ops: Sequence[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
+    """Serve a lone node op from the polars node table: the resident node-id / property index when it
+    covers the seed, else a direct filter; a seeded call semi-joins on ``start_nodes``; the alias
+    marker takes its name as the chain does."""
+    import polars as pl
+    from graphistry.Engine import Engine, EngineAbstract, df_to_engine
+    from graphistry.compute.chain_specializations.hotpaths import _single_node_rows_via_index_or_filter
+    from graphistry.compute.gfql.lazy.engine.polars.chain import _align_seed_dtype, _bound_edge_endpoints, _semi
+    op0 = ops[0]
+    assert isinstance(op0, ASTNode)  # the predicate admitted this shape
+    g0 = ensure_nodes_polars(g)
+    nc = g0._node
+    assert nc is not None
+    edge_src, edge_dst = _bound_edge_endpoints(g)
+    nodes = _single_node_rows_via_index_or_filter(g0, op0, EngineAbstract.POLARS)
+    if start_nodes is not None:
+        seed = _align_seed_dtype(df_to_engine(start_nodes, Engine.POLARS), nc, g0._nodes)
+        nodes = _semi(nodes, seed, nc, nc)
+    if op0._name is not None:
+        nodes = nodes.with_columns(pl.lit(True).alias(op0._name))
+    return g0.nodes(nodes, nc).edges(g0._edges.clear(), edge_src, edge_dst)
 
 
 def _plain_seeded_index_hop_polars(g: Plottable, ops: Sequence[ASTObject]) -> Optional[Plottable]:

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
@@ -19,7 +19,7 @@ from graphistry.compute.typing import ArrayLike, ArrayNamespace, DataFrameT
 from graphistry.compute.gfql.lazy.engine.polars.dtypes import endpoint_ids
 from graphistry.compute.gfql.lazy.engine.polars.hop_eager import ensure_nodes_polars
 from graphistry.compute.gfql.lazy.engine.polars.predicates import filter_by_dict_polars
-from .admission import polars_seeded_lane_admits, polars_single_node_admits
+from .admission import polars_seeded_lane_admits
 
 if TYPE_CHECKING:
     import polars as pl
@@ -28,15 +28,13 @@ if TYPE_CHECKING:
 
 
 def _single_node_polars(g: Plottable, ops: Sequence[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
-    """Serve a lone node op from the polars node table: the resident node-id / property index when it
-    covers the seed, else a direct filter; a seeded call semi-joins on ``start_nodes``; the alias
-    marker takes its name as the chain does."""
+    """Select node rows, intersect start nodes, and attach the node alias marker."""
     import polars as pl
     from graphistry.Engine import Engine, EngineAbstract, df_to_engine
     from graphistry.compute.chain_specializations.hotpaths import _single_node_rows_via_index_or_filter
     from graphistry.compute.gfql.lazy.engine.polars.chain import _align_seed_dtype, _bound_edge_endpoints, _semi
     op0 = ops[0]
-    assert isinstance(op0, ASTNode)  # the predicate admitted this shape
+    assert isinstance(op0, ASTNode)
     g0 = ensure_nodes_polars(g)
     nc = g0._node
     assert nc is not None

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -659,6 +659,11 @@ def lower_expr(node: ExprNode, columns: Sequence[str]) -> Optional[pl.Expr]:
             src = _resolve_property(node.value.name, node.property, columns)
             if src is not None:
                 return pl.col(src)
+            if (_NODE_ID.get() in columns
+                    and _SCHEMA.get().get(node.value.name) == pl.Boolean):
+                from graphistry.compute.gfql.row.pipeline import RowPipelineMixin
+                RowPipelineMixin._gfql_report_absent_property(f"{node.value.name}.{node.property}")
+                return pl.lit(None)
         return None
     if isinstance(node, BinaryOp):
         if node.op == "in" and isinstance(node.right, ListLiteral):

--- a/graphistry/compute/gfql/row/frame_ops.py
+++ b/graphistry/compute/gfql/row/frame_ops.py
@@ -46,7 +46,7 @@ def _empty_like(df: Any) -> Any:
     """Zero-row copy preserving schema, for pandas/cuDF and polars frames."""
     if _is_polars(df):
         return df.clear()
-    return df.iloc[0:0].copy()
+    return df.iloc[0:0]  # a zero-row slice is already a new frame
 
 
 def _alias_true_mask(table_df: Any, source: str) -> Any:
@@ -54,6 +54,8 @@ def _alias_true_mask(table_df: Any, source: str) -> Any:
     polars equivalent expr is ``pl.col(source).fill_null(False).cast(pl.Boolean)``).
     Shared by ``rows``/``count_table`` so the null handling can't diverge."""
     mask = table_df[source]
+    if str(getattr(mask, "dtype", "")) == "bool":
+        return mask  # a bool column holds no null
     if hasattr(mask, "isna") and hasattr(mask, "where"):
         mask = mask.where(~mask.isna(), False)
     elif hasattr(mask, "fillna"):
@@ -276,8 +278,8 @@ def rows(
             table_df = _empty_like(ctx._edges)
         else:
             table_df = empty_frame(ctx)
-    elif not _is_polars(table_df):
-        table_df = table_df.copy()
+    elif not _is_polars(table_df) and source is None:
+        table_df = table_df.copy()  # a mask filter below yields a fresh frame on its own
 
     if source is not None:
         if source not in table_df.columns:

--- a/graphistry/compute/gfql/row/frame_ops.py
+++ b/graphistry/compute/gfql/row/frame_ops.py
@@ -46,7 +46,7 @@ def _empty_like(df: Any) -> Any:
     """Zero-row copy preserving schema, for pandas/cuDF and polars frames."""
     if _is_polars(df):
         return df.clear()
-    return df.iloc[0:0]  # a zero-row slice is already a new frame
+    return df.iloc[0:0]
 
 
 def _alias_true_mask(table_df: Any, source: str) -> Any:
@@ -54,8 +54,8 @@ def _alias_true_mask(table_df: Any, source: str) -> Any:
     polars equivalent expr is ``pl.col(source).fill_null(False).cast(pl.Boolean)``).
     Shared by ``rows``/``count_table`` so the null handling can't diverge."""
     mask = table_df[source]
-    if str(getattr(mask, "dtype", "")) == "bool":
-        return mask  # a bool column holds no null
+    if isinstance(mask, pd.Series) and mask.dtype == bool:
+        return mask
     if hasattr(mask, "isna") and hasattr(mask, "where"):
         mask = mask.where(~mask.isna(), False)
     elif hasattr(mask, "fillna"):
@@ -279,7 +279,7 @@ def rows(
         else:
             table_df = empty_frame(ctx)
     elif not _is_polars(table_df) and source is None:
-        table_df = table_df.copy()  # a mask filter below yields a fresh frame on its own
+        table_df = table_df.copy()
 
     if source is not None:
         if source not in table_df.columns:

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -3696,14 +3696,12 @@ class RowPipelineMixin:
 
     @staticmethod
     def _gfql_node_alias_lookup_frame(lookup_source: Any, node_id: str, alias: str) -> Any:
-        lookup = lookup_source[[node_id]].copy()
-        lookup[alias] = lookup_source[node_id]
-        lookup[f"{alias}.{node_id}"] = lookup_source[node_id]
-        for col in lookup_source.columns:
-            if col == node_id:
-                continue
-            lookup[f"{alias}.{col}"] = lookup_source[col]
-        return lookup
+        """``[node_id, alias, alias.node_id, alias.<col>...]`` for a left merge on the alias ids, built in three frame ops rather than one per column."""
+        other = [col for col in lookup_source.columns if col != node_id]
+        renamed = lookup_source.rename(columns={col: f"{alias}.{col}" for col in other})
+        ids = lookup_source[node_id]
+        lookup = renamed.assign(**{alias: ids, f"{alias}.{node_id}": ids})
+        return lookup[[node_id, alias, f"{alias}.{node_id}", *[f"{alias}.{col}" for col in other]]]
 
     @staticmethod
     def _gfql_node_filter_has_label(filter_dict: Any) -> bool:

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -4826,6 +4826,8 @@ class RowPipelineMixin:
 
         if cudf_row_table and any(isinstance(value, pd.Series) for value in projected.values()):
             out_df = _gfql_projected_values_to_pandas_frame(projected, len(table_df))
+        elif isinstance(table_df, pd.DataFrame) and all(isinstance(v, pd.Series) for v in projected.values()):
+            out_df = pd.DataFrame(projected, index=table_df.index)  # same rows and order as assign-then-subset, without copying the table
         else:
             out_df = table_df.assign(**projected)[list(projected.keys())]
         return self._gfql_row_table(out_df)

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -3696,7 +3696,7 @@ class RowPipelineMixin:
 
     @staticmethod
     def _gfql_node_alias_lookup_frame(lookup_source: Any, node_id: str, alias: str) -> Any:
-        """``[node_id, alias, alias.node_id, alias.<col>...]`` for a left merge on the alias ids, built in three frame ops rather than one per column."""
+        """Build node IDs and alias-qualified properties for a left merge."""
         other = [col for col in lookup_source.columns if col != node_id]
         renamed = lookup_source.rename(columns={col: f"{alias}.{col}" for col in other})
         ids = lookup_source[node_id]
@@ -4825,7 +4825,7 @@ class RowPipelineMixin:
         if cudf_row_table and any(isinstance(value, pd.Series) for value in projected.values()):
             out_df = _gfql_projected_values_to_pandas_frame(projected, len(table_df))
         elif isinstance(table_df, pd.DataFrame) and all(isinstance(v, pd.Series) for v in projected.values()):
-            out_df = pd.DataFrame(projected, index=table_df.index)  # same rows and order as assign-then-subset, without copying the table
+            out_df = pd.DataFrame(projected, index=table_df.index)
         else:
             out_df = table_df.assign(**projected)[list(projected.keys())]
         return self._gfql_row_table(out_df)

--- a/graphistry/compute/typing.py
+++ b/graphistry/compute/typing.py
@@ -173,6 +173,9 @@ class ArrayNamespace(Protocol):
     def unique(self, a: ArrayLike) -> ArrayLike:
         ...
 
+    def isin(self, element: ArrayLike, test_elements: ArrayLike) -> ArrayLike:
+        ...
+
     def isnan(self, a: ArrayLike) -> ArrayLike:
         ...
 

--- a/graphistry/tests/compute/gfql/routes/switch.py
+++ b/graphistry/tests/compute/gfql/routes/switch.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 from typing import Iterable, Iterator, List, Tuple
 
-ROUTES = ("native-fast", "polars-seeded", "polars-plain", "index-hop", "indexed-kernel", "cypher-fast")
+ROUTES = ("native-fast", "polars-single-node", "polars-seeded", "polars-plain", "index-hop", "indexed-kernel", "cypher-fast")
 
 
 def _none(*a, **k):
@@ -22,6 +22,8 @@ def _targets(routes: Iterable[str]) -> List[Tuple[object, str]]:
     out: List[Tuple[object, str]] = []
     if "native-fast" in routes:
         out.append((chain_mod, "_try_chain_fast_path"))
+    if "polars-single-node" in routes:
+        out.append((pchain, "_single_node_polars"))
     if "polars-seeded" in routes:
         out.append((pchain, "_try_seeded_chain_polars"))
     if "polars-plain" in routes:

--- a/graphistry/tests/compute/gfql/routes/test_route_harness.py
+++ b/graphistry/tests/compute/gfql/routes/test_route_harness.py
@@ -18,6 +18,7 @@ from graphistry.Engine import Engine
 from graphistry.compute.ast import ASTObject
 from graphistry.compute.chain_specializations.admission import native_fast_path_admits
 from graphistry.compute.gfql.lazy.engine.polars.chain_specializations.admission import (
+    polars_single_node_admits,
     polars_plain_single_hop_admits, polars_seeded_lane_admits,
 )
 from graphistry.tests.compute.gfql.routes.registry import REGISTRY, Shape, graph_for
@@ -40,6 +41,9 @@ ROUTES = [
     Route("native-fast", ("pandas", "cudf"),
           lambda ops, engine: native_fast_path_admits(ops, Engine(engine), None) is not None,
           (chain_mod, "_try_chain_fast_path"), False),
+    Route("polars-single-node", ("polars",),
+          lambda ops, engine: polars_single_node_admits(ops, None),
+          (pchain, "_single_node_polars"), False),
     Route("polars-plain", ("polars",),
           lambda ops, engine: polars_plain_single_hop_admits(ops, None) is not None,
           (pchain, "_plain_single_hop_polars"), False),
@@ -50,6 +54,9 @@ ROUTES = [
 
 KNOWN: Dict[Tuple[str, str], str] = {  # (route, tag) -> issue: strict xfail until it lands (non-strict on frame variants, where a shape may coincide)
     ("native-fast", "#2034"): "graphistry/pygraphistry#2034",
+    ("polars-single-node", "#2034"): "graphistry/pygraphistry#2034",
+    ("polars-single-node", "dup-ids"): "graphistry/pygraphistry#2034",
+    ("polars-single-node", "null-ids"): "graphistry/pygraphistry#2071",
     ("polars-plain", "#2034"): "graphistry/pygraphistry#2034",
     ("polars-seeded", "#2034"): "graphistry/pygraphistry#2034",
 }
@@ -158,7 +165,7 @@ def test_admitted_shape_is_served_and_matches_the_general_path(case: Case, reque
         pytest.xfail(f"{case.id}: admitted by the predicate, declined by the lane body (attenuation ledger)")
 
 
-@pytest.mark.route_engaged("native-fast", "polars-plain", "polars-seeded")
+@pytest.mark.route_engaged("native-fast", "polars-single-node", "polars-plain", "polars-seeded")
 def test_every_route_serves_most_of_what_it_admits(monkeypatch):
     """A lane that declines most admitted shapes has a predicate that no longer describes it."""
     per_route: Dict[str, List[int]] = {}

--- a/graphistry/tests/compute/gfql/test_aggregate_identity_row_semantics.py
+++ b/graphistry/tests/compute/gfql/test_aggregate_identity_row_semantics.py
@@ -358,11 +358,8 @@ def test_post_aggregate_where_over_a_nonempty_stream_uses_the_real_value(query, 
 # ===========================================================================
 # 6. polars declines pandas serves (#1909 item 5) -- pinned, not invisible
 # ===========================================================================
-# All three are the same root cause: the polars row pipeline has no native
-# cypher expression engine, so `with_` / `order_by` over a projected expression
-# raise NotImplementedError (parity-or-error by design). Serving them is the
-# general native-polars row-expression work, not a local fix -- pinned strict so
-# they flip loudly when that lands.
+# Whole-entity grouping and ordering nested collections remain pinned below.
+# Missing-property counts now use native null projection and return zero.
 
 
 @pytest.mark.parametrize("query,expected", [
@@ -381,10 +378,9 @@ def test_pandas_serves_the_polars_decline_families(query, expected):
 @polars_only
 @pytest.mark.parametrize("query", [
     "MATCH (m) RETURN m, count(*) AS c",
-    "MATCH (m) RETURN count(m.nosuch) AS c",
     "MATCH (m) WITH m.city AS city, collect(m.name) AS names "
     "RETURN collect(names) AS nested ORDER BY nested",
-], ids=["whole_entity_grouping", "missing_property_aggregate", "order_by_collect_of_collect"])
+], ids=["whole_entity_grouping", "order_by_collect_of_collect"])
 @pytest.mark.xfail(strict=True, raises=NotImplementedError,
                    reason="#1909 item 5: polars row pipeline has no native cypher expression "
                           "engine for with_/order_by; pandas serves these correctly")
@@ -393,14 +389,11 @@ def test_polars_declines_these_aggregate_shapes(query):
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_missing_property_aggregate_value_is_zero_on_pandas(engine):
-    """Hand oracle for the decline family above: count() over a property no node
-    has counts zero non-null values -- it is not an error."""
-    if engine == "polars":
-        with pytest.raises(NotImplementedError):
-            _run("MATCH (m) RETURN count(m.nosuch) AS c", "polars")
-        return
-    assert _records(_run("MATCH (m) RETURN count(m.nosuch) AS c", engine)) == [{"c": 0}]
+@pytest.mark.parametrize("predicate", ["", " WHERE m.name = 'Zed'"])
+def test_missing_property_aggregate_value_is_zero(engine, predicate):
+    """count() ignores nulls and retains one identity row on an empty stream."""
+    query = f"MATCH (m){predicate} RETURN count(m.nosuch) AS c"
+    assert _records(_run(query, engine)) == [{"c": 0}]
 
 
 # ===========================================================================

--- a/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
+++ b/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
@@ -21,23 +21,23 @@ def _res(nodes, edges):
 
 def _both(res, aliases, direction="forward"):
     a0, a1, a2 = aliases
-    real = cfp._tag_fast_path_aliases_pandas
+    real = cfp._tag_fast_path_aliases_eager
     branch = {"n": 0}
 
     def spy(*a, **k):
         r = real(*a, **k)
         branch["n"] += r is not None
         return r
-    cfp._tag_fast_path_aliases_pandas = spy
+    cfp._tag_fast_path_aliases_eager = spy
     try:
         fast = cfp._tag_fast_path_aliases(res, a0, a1, a2, "s", "d", "k", direction)
     finally:
-        cfp._tag_fast_path_aliases_pandas = real
-    cfp._tag_fast_path_aliases_pandas = lambda *a, **k: None
+        cfp._tag_fast_path_aliases_eager = real
+    cfp._tag_fast_path_aliases_eager = lambda *a, **k: None
     try:
         generic = cfp._tag_fast_path_aliases(res, a0, a1, a2, "s", "d", "k", direction)
     finally:
-        cfp._tag_fast_path_aliases_pandas = real
+        cfp._tag_fast_path_aliases_eager = real
     return fast, generic, branch["n"]
 
 
@@ -106,3 +106,47 @@ def test_end_to_end_named_seeded_hop_matches_the_full_path():
     pd.testing.assert_frame_equal(key(served._nodes), key(full._nodes), check_dtype=False)
     pd.testing.assert_frame_equal(key(served._edges), key(full._edges), check_dtype=False)
     assert list(served._nodes.columns) == list(full._nodes.columns)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize("direction", ["forward", "reverse"])
+@pytest.mark.parametrize("empty", [False, True])
+@pytest.mark.parametrize("shape", list(SHAPES))
+def test_eager_alias_tags_keep_backend_and_inputs(engine, direction, empty, shape):
+    nodes, edges = NODES.copy(), EDGES.iloc[:0].copy() if empty else EDGES.copy()
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    fast, generic, served = _both(_res(nodes, edges), SHAPES[shape], direction)
+    assert served == 1
+    for actual, expected in [(fast._nodes, generic._nodes), (fast._edges, generic._edges)]:
+        assert type(actual) is type(expected) is type(nodes)
+        if engine == "cudf":
+            actual, expected = actual.to_pandas(), expected.to_pandas()
+        pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(nodes.to_pandas() if engine == "cudf" else nodes, NODES)
+    pd.testing.assert_frame_equal(edges.to_pandas() if engine == "cudf" else edges,
+                                  EDGES.iloc[:0] if empty else EDGES)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+def test_repeated_node_alias_uses_generic_overwrite_semantics(engine):
+    nodes, edges = NODES.copy(), EDGES.copy()
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    fast, generic, served = _both(_res(nodes, edges), ("m", "e", "m"))
+    assert served == 0
+    actual, expected = fast._nodes, generic._nodes
+    if engine == "cudf":
+        actual, expected = actual.to_pandas(), expected.to_pandas()
+    pd.testing.assert_frame_equal(actual, expected)
+    assert actual["m"].tolist() == [False, True, True, False]
+
+
+def test_mixed_integer_width_aliases_decline_before_lossy_array_membership():
+    nodes = pd.DataFrame({"k": pd.Series([2**63, 2**63 + 1], dtype="uint64")})
+    edges = pd.DataFrame({"s": pd.Series([2**63 - 1], dtype="int64"),
+                          "d": pd.Series([2**63 - 1], dtype="int64")})
+    result = cfp._tag_fast_path_aliases_eager(nodes, edges, "m", None, "p", "s", "d", "k")
+    assert result is None

--- a/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
+++ b/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
@@ -1,0 +1,108 @@
+"""The pandas alias-tagging branch is frame-identical to the generic tagging it shortcuts.
+
+``_tag_fast_path_aliases`` attaches the alias flag columns a named seeded hop carries; on
+pandas it now builds them with one copy and in-place inserts. Pins: for every alias shape
+the pandas branch returns exactly (columns, order, dtypes, index of every touched frame) what the generic
+path returns, and the shapes it cannot reproduce in place (binding column not first, colliding
+alias names, float or object ids) decline to the generic path.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+import graphistry
+import graphistry.compute.chain_fast_paths as cfp
+from graphistry.compute.ast import e_forward, n
+
+
+def _res(nodes, edges):
+    return graphistry.nodes(nodes, "k").edges(edges, "s", "d")
+
+
+def _both(res, aliases, direction="forward"):
+    a0, a1, a2 = aliases
+    real = cfp._tag_fast_path_aliases_pandas
+    branch = {"n": 0}
+
+    def spy(*a, **k):
+        r = real(*a, **k)
+        branch["n"] += r is not None
+        return r
+    cfp._tag_fast_path_aliases_pandas = spy
+    try:
+        fast = cfp._tag_fast_path_aliases(res, a0, a1, a2, "s", "d", "k", direction)
+    finally:
+        cfp._tag_fast_path_aliases_pandas = real
+    cfp._tag_fast_path_aliases_pandas = lambda *a, **k: None
+    try:
+        generic = cfp._tag_fast_path_aliases(res, a0, a1, a2, "s", "d", "k", direction)
+    finally:
+        cfp._tag_fast_path_aliases_pandas = real
+    return fast, generic, branch["n"]
+
+
+NODES = pd.DataFrame({"k": [3, 1, 2, 9], "x": ["a", "b", "c", "d"], "w": [1.5, 2.5, 3.5, 4.5]}, index=[10, 11, 12, 13])
+EDGES = pd.DataFrame({"s": [3, 1], "d": [1, 2], "t": ["A", "B"]}, index=[7, 8])
+
+SHAPES = {
+    "all named": ("m", "e", "p"),
+    "seed only": ("m", None, None),
+    "edge only": (None, "e", None),
+    "destination only": (None, None, "p"),
+    "nodes only": ("m", None, "p"),
+}
+
+
+@pytest.mark.parametrize("shape", list(SHAPES))
+@pytest.mark.parametrize("direction", ["forward", "reverse"])
+def test_pandas_branch_is_frame_identical_to_generic_tagging(shape, direction):
+    fast, generic, branch = _both(_res(NODES, EDGES), SHAPES[shape], direction)
+    assert branch == 1
+    pd.testing.assert_frame_equal(fast._nodes, generic._nodes)
+    pd.testing.assert_frame_equal(fast._edges, generic._edges)
+    a0, a1, a2 = SHAPES[shape]
+    if a0 is not None or a2 is not None:
+        assert isinstance(fast._nodes.index, pd.RangeIndex)
+    if a1 is not None:
+        assert isinstance(fast._edges.index, pd.RangeIndex)
+
+
+def test_dead_end_seed_is_tagged_false_on_both_paths():
+    fast, generic, branch = _both(_res(NODES, EDGES.iloc[:0]), ("m", "e", "p"))
+    assert branch == 1
+    pd.testing.assert_frame_equal(fast._nodes, generic._nodes)
+    assert not fast._nodes["m"].any() and not fast._nodes["p"].any()
+
+
+DECLINE_SHAPES = {
+    "binding column not first": (NODES[["x", "k", "w"]], EDGES, ("m", "e", "p")),
+    "colliding node alias": (NODES.assign(m=0), EDGES, ("m", "e", "p")),
+    "colliding edge alias": (NODES, EDGES.assign(e=0), ("m", "e", "p")),
+    "float ids": (NODES.assign(k=NODES["k"].astype(float)), EDGES, ("m", None, "p")),
+    "object ids": (NODES.assign(k=NODES["k"].astype(str)), EDGES.assign(s=EDGES["s"].astype(str), d=EDGES["d"].astype(str)), ("m", None, "p")),
+}
+
+
+@pytest.mark.parametrize("shape", list(DECLINE_SHAPES))
+def test_shapes_the_inplace_branch_cannot_reproduce_take_the_generic_path(shape):
+    nodes, edges, aliases = DECLINE_SHAPES[shape]
+    fast, generic, branch = _both(_res(nodes, edges), aliases)
+    assert branch == 0
+    pd.testing.assert_frame_equal(fast._nodes, generic._nodes)
+    pd.testing.assert_frame_equal(fast._edges, generic._edges)
+
+
+def test_end_to_end_named_seeded_hop_matches_the_full_path():
+    rng = np.random.default_rng(5)
+    nodes = pd.DataFrame({"k": np.arange(300), "id": np.arange(300) + 100, "label__P": np.arange(300) % 2 == 0})
+    edges = pd.DataFrame({"s": rng.integers(0, 300, 900), "d": rng.integers(0, 300, 900), "type": "T"})
+    g = graphistry.nodes(nodes, "k").edges(edges, "s", "d").gfql_index_all(engine="pandas").gfql_index_node_props(["id"], engine="pandas")
+    ops = [n({"id": 142}, name="m"), e_forward({"type": "T"}, name="e"), n(name="p")]
+    served = g.gfql(ops, engine="pandas", index_policy="use")
+    full = g.gfql(ops, engine="pandas", index_policy="off")
+
+    def key(df):
+        return df.sort_values(list(df.columns)).reset_index(drop=True)
+    pd.testing.assert_frame_equal(key(served._nodes), key(full._nodes), check_dtype=False)
+    pd.testing.assert_frame_equal(key(served._edges), key(full._edges), check_dtype=False)
+    assert list(served._nodes.columns) == list(full._nodes.columns)

--- a/graphistry/tests/compute/gfql/test_gfql_unified_routing_contracts.py
+++ b/graphistry/tests/compute/gfql/test_gfql_unified_routing_contracts.py
@@ -181,7 +181,7 @@ def _assert_declines_rather_than_raising(graph, query, marker, expected):
     except ImportError:
         assert not HAS_CUDF_POLARS
         return
-    assert out._nodes.to_dicts() == expected
+    assert sorted(out._nodes.to_dicts(), key=repr) == sorted(expected, key=repr)
 
 
 def test_gpu_fast_path_not_implemented_error_declines_to_the_generic_route(monkeypatch):

--- a/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
@@ -228,3 +228,70 @@ def test_polars_seed_path_is_unchanged_by_the_residual_verify():
     g = g.gfql_index_all(engine="polars").gfql_index_node_props(["id"], engine="polars")
     ops = [n({"id": 10_007, "label__Person": True}, name="a"), e_forward(), n(name="b")]
     assert _keys(g.gfql(ops, engine="polars")) == _keys(_full_path(g, ops, "polars"))
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("values,expected", [([None], []), ([None, 4], [1]), ([3, 4], [1])])
+def test_index_hit_residual_nulls_never_count_as_matches(engine, values, expected):
+    from graphistry.Engine import Engine
+    from graphistry.compute.chain_fast_paths import _verify_scalar_filters_on_hit
+    frame = pd.DataFrame({"id": range(len(values)), "value": pd.Series(values, dtype="Int64")})
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        frame = cudf.from_pandas(frame)
+    result = _verify_scalar_filters_on_hit(frame, {"value": 4}, Engine(engine))
+    actual = result.to_pandas() if engine == "cudf" else result
+    assert actual["id"].tolist() == expected
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("direction", ["forward", "reverse"])
+@pytest.mark.parametrize("dtype,values,target", [("Int64", [0, None, 4], 4), ("string", ["x", None, "y"], "y")])
+def test_numeric_tail_nullable_residual_rejects_null_without_error(engine, direction, dtype, values, target):
+    from graphistry.compute.chain_specializations.hotpaths import _seeded_hop_tail_numeric
+    nodes = pd.DataFrame({"id": [0, 1, 2], "value": pd.Series(values, dtype=dtype)})
+    edges = pd.DataFrame({"s": [0, 0, 0], "d": [1, 2, 2]})
+    if direction == "reverse":
+        edges = edges.rename(columns={"s": "d", "d": "s"})
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    result = _seeded_hop_tail_numeric(nodes, edges, {"value": target}, "s", "d",
+                                      "d" if direction == "forward" else "s", "id")
+    assert result is not None
+    output = result[0].to_pandas() if engine == "cudf" else result[0]
+    assert output["id"].tolist() == [0, 2]
+    assert len(result[1]) == 2
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("count", [0, 1, 2, 129])
+@pytest.mark.parametrize("direction", ["forward", "reverse"])
+def test_numeric_tail_keeps_edge_bag_and_rejects_dangling_endpoints(engine, count, direction):
+    from graphistry.compute.chain_specializations.hotpaths import _seeded_hop_tail_numeric
+    nodes = pd.DataFrame({"id": [0, 1, 2]})
+    edges = pd.DataFrame({"s": [0] * count + [0, 99], "d": [2] * count + [99, 2]})
+    if direction == "reverse":
+        edges = edges.rename(columns={"s": "d", "d": "s"})
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    result = _seeded_hop_tail_numeric(nodes, edges, {}, "s", "d",
+                                      "d" if direction == "forward" else "s", "id")
+    assert result is not None
+    assert type(result[0]) is type(nodes) and type(result[1]) is type(edges)
+    actual = result[0].to_pandas() if engine == "cudf" else result[0]
+    assert actual["id"].tolist() == ([0, 2] if count else [])
+    assert len(result[1]) == count
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_numeric_tail_mixed_id_dtypes_decline(engine):
+    from graphistry.compute.chain_specializations.hotpaths import _seeded_hop_tail_numeric
+    nodes = pd.DataFrame({"id": pd.Series([2**63], dtype="uint64")})
+    edges = pd.DataFrame({"s": pd.Series([2**63 - 1], dtype="int64"),
+                          "d": pd.Series([2**63 - 1], dtype="int64")})
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    assert _seeded_hop_tail_numeric(nodes, edges, {}, "s", "d", "d", "id") is None

--- a/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
@@ -96,12 +96,25 @@ def test_exact_index_hit_skips_the_refilter_with_parity(engine, shape):
     assert refilters == 0, "an exact single-predicate index hit must not re-filter its rows"
 
 
-REFILTER_SHAPES = {
+VERIFIED_SHAPES = {  # an index hit plus residual scalar equalities: verified on the hit rows, never re-filtered
     "two predicates": lambda: [n({"id": 10_007, "label__Person": True})],
     "two predicates hop": lambda: [n({"id": 50_007, "label__Message": True}), e_forward({"type": "HAS_CREATOR"}), n()],
+}
+
+REFILTER_SHAPES = {  # no index hit (the index declines a float on an integer property): the canonical filter runs
     "label only": lambda: [n({"label__Person": True})],
     "float on property": lambda: [n({"id": 10_007.0})],
 }
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("shape", list(VERIFIED_SHAPES))
+def test_an_index_hit_with_residual_scalar_predicates_is_verified_not_refiltered(engine, shape):
+    g = _graph(engine)
+    ops = VERIFIED_SHAPES[shape]()
+    _assert_parity(g, ops, engine)
+    _, refilters = _run(g, ops, engine, "use")
+    assert refilters == 0, "residual scalar equalities are verified on the hit rows, not re-filtered"
 
 
 @pytest.mark.parametrize("engine", ENGINES)
@@ -111,7 +124,7 @@ def test_every_other_shape_still_runs_the_canonical_filter(engine, shape):
     ops = REFILTER_SHAPES[shape]()
     _assert_parity(g, ops, engine)
     _, refilters = _run(g, ops, engine, "use")
-    assert refilters >= 1, "only an exact single-predicate index hit may skip the canonical filter"
+    assert refilters >= 1, "without an index hit the canonical filter runs"
 
 
 def test_bool_on_integer_column_is_never_index_served():
@@ -149,3 +162,69 @@ def test_no_resident_index_still_filters(engine):
     full, _ = _run(plain, ops, engine, "off")
     pd.testing.assert_frame_equal(_canon(served._nodes), _canon(full._nodes))
     assert refilters >= 1
+
+
+# ---- residual verify on an index hit (the multi-predicate seed) ----
+
+def _full_path(g, ops, engine):
+    from graphistry.tests.compute.gfql.routes.switch import routes_off, ROUTES
+    with routes_off(ROUTES):
+        return g.gfql(ops, engine=engine)
+
+
+def _keys(res):
+    nn = res._nodes.to_pandas() if hasattr(res._nodes, "to_pandas") else res._nodes
+    return sorted(nn["key"].tolist())
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("ops", [
+    [n({"id": 10_007, "label__Person": True})],
+    [n({"id": 10_007, "label__Person": True}, name="a"), e_forward(), n(name="b")],
+    [n({"id": 50_003, "label__Message": True}, name="m"), e_forward({"type": "HAS_CREATOR"}), n({"label__Person": True}, name="p")],
+])
+def test_two_predicate_seed_on_an_index_hit_matches_the_full_path(engine, ops):
+    if engine == "cudf":
+        pytest.importorskip("cudf")
+    g = _graph(engine)
+    assert _keys(g.gfql(ops, engine=engine)) == _keys(_full_path(g, ops, engine))
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_index_hit_whose_residual_predicate_fails_answers_empty_like_the_full_path(engine):
+    if engine == "cudf":
+        pytest.importorskip("cudf")
+    g = _graph(engine)
+    ops = [n({"id": 10_007, "label__Message": True})]  # the id is a Person
+    assert _keys(g.gfql(ops, engine=engine)) == [] == _keys(_full_path(g, ops, engine))
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_index_hit_keeps_the_typed_error_of_the_canonical_filter(engine):
+    if engine == "cudf":
+        pytest.importorskip("cudf")
+    g = _graph(engine)
+    with pytest.raises(GFQLSchemaError):
+        g.gfql([n({"id": 10_007, "name": 5})], engine=engine)  # string column, numeric value
+    with pytest.raises(GFQLSchemaError):
+        _full_path(g, [n({"id": 10_007, "name": 5})], engine)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_index_hit_with_a_null_residual_column_matches_the_full_path(engine):
+    if engine == "cudf":
+        pytest.importorskip("cudf")
+    g = _graph(engine)
+    ops = [n({"id": 50_003, "name": "p1"})]  # messages carry a null name
+    assert _keys(g.gfql(ops, engine=engine)) == [] == _keys(_full_path(g, ops, engine))
+    ops = [n({"id": 10_001, "name": "p1"})]
+    assert _keys(g.gfql(ops, engine=engine)) == [1] == _keys(_full_path(g, ops, engine))
+
+
+def test_polars_seed_path_is_unchanged_by_the_residual_verify():
+    pl = pytest.importorskip("polars")
+    g = _graph("pandas")
+    g = graphistry.nodes(pl.from_pandas(g._nodes), "key").edges(pl.from_pandas(g._edges), "s", "d")
+    g = g.gfql_index_all(engine="polars").gfql_index_node_props(["id"], engine="polars")
+    ops = [n({"id": 10_007, "label__Person": True}, name="a"), e_forward(), n(name="b")]
+    assert _keys(g.gfql(ops, engine="polars")) == _keys(_full_path(g, ops, "polars"))

--- a/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
@@ -1,0 +1,151 @@
+"""An exact index hit answers a one-predicate seed without re-filtering the candidates.
+
+The node-id and node-property indexes hold integer keys, verify membership after the
+searchsorted probe (a float id promotes exactly as the scan's ``==`` does), and decline
+mismatched value families back to the scan, so for a
+filter that is exactly one scalar equality on the served column the gathered rows are
+already the canonical filter's rows. Pins: that shape skips the re-filter with parity to
+the full path on every engine; every other shape (two predicates, ``label__`` rewrite,
+bool/str values, float on a property, no index) still runs the canonical filter, keeps its typed error,
+and stays value-identical.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+import graphistry
+import graphistry.compute.gfql.index.bindings as bindings_mod
+from graphistry.compute.ast import e_forward, n
+from graphistry.compute.exceptions import GFQLSchemaError
+
+ENGINES = ["pandas", "cudf"]
+
+
+def _graph(engine, n_persons=500, n_messages=1500):
+    rng = np.random.default_rng(3)
+    persons = pd.DataFrame({"key": np.arange(n_persons), "id": np.arange(n_persons) + 10_000,
+                            "label__Person": True, "label__Message": False,
+                            "name": [f"p{i}" for i in range(n_persons)]})
+    messages = pd.DataFrame({"key": np.arange(n_persons, n_persons + n_messages),
+                             "id": np.arange(n_messages) + 50_000,
+                             "label__Person": False, "label__Message": True, "name": None})
+    nodes = pd.concat([persons, messages], ignore_index=True)
+    edges = pd.DataFrame({"s": np.arange(n_persons, n_persons + n_messages),
+                          "d": rng.integers(0, n_persons, n_messages), "type": "HAS_CREATOR"})
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    g = graphistry.nodes(nodes, "key").edges(edges, "s", "d")
+    return g.gfql_index_all(engine=engine).gfql_index_node_props(["id"], engine=engine)
+
+
+def _canon(frame):
+    df = frame.to_pandas() if hasattr(frame, "to_pandas") else pd.DataFrame(frame)
+    df = df.copy()
+    for c in df.columns:
+        if pd.api.types.is_numeric_dtype(df[c]) and not pd.api.types.is_bool_dtype(df[c]):
+            df[c] = df[c].astype("float64")
+    df.columns = [str(c) for c in df.columns]
+    cols = list(df.columns)
+    return df.sort_values(cols).reset_index(drop=True) if len(df) else df
+
+
+def _run(g, ops, engine, policy):
+    real = bindings_mod._filter_frame
+    calls = {"n": 0}
+
+    def spy(frame, filter_dict, eng):
+        calls["n"] += 1
+        return real(frame, filter_dict, eng)
+    bindings_mod._filter_frame = spy
+    try:
+        return g.gfql(ops, engine=engine, index_policy=policy), calls["n"]
+    finally:
+        bindings_mod._filter_frame = real
+
+
+def _assert_parity(g, ops, engine):
+    served, _ = _run(g, ops, engine, "use")
+    full, _ = _run(g, ops, engine, "off")
+    pd.testing.assert_frame_equal(_canon(served._nodes), _canon(full._nodes))
+    pd.testing.assert_frame_equal(_canon(served._edges), _canon(full._edges))
+    return served
+
+
+SKIP_SHAPES = {
+    "node-id single": lambda: [n({"key": 7})],
+    "node-id single named": lambda: [n({"key": 7}, name="p")],
+    "property single": lambda: [n({"id": 10_007})],
+    "property single named": lambda: [n({"id": 10_007}, name="p")],
+    "node-id seeded hop": lambda: [n({"key": 700}), e_forward({"type": "HAS_CREATOR"}), n()],
+    "property seeded hop named": lambda: [n({"id": 50_007}, name="m"), e_forward({"type": "HAS_CREATOR"}, name="e"), n(name="p")],
+    "node-id no match": lambda: [n({"key": 99_999})],
+    "integral float on node id": lambda: [n({"key": 7.0})],
+    "non-integral float on node id": lambda: [n({"key": 7.5})],
+    "property no match": lambda: [n({"id": 1})],
+}
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("shape", list(SKIP_SHAPES))
+def test_exact_index_hit_skips_the_refilter_with_parity(engine, shape):
+    g = _graph(engine)
+    ops = SKIP_SHAPES[shape]()
+    _assert_parity(g, ops, engine)
+    _, refilters = _run(g, ops, engine, "use")
+    assert refilters == 0, "an exact single-predicate index hit must not re-filter its rows"
+
+
+REFILTER_SHAPES = {
+    "two predicates": lambda: [n({"id": 10_007, "label__Person": True})],
+    "two predicates hop": lambda: [n({"id": 50_007, "label__Message": True}), e_forward({"type": "HAS_CREATOR"}), n()],
+    "label only": lambda: [n({"label__Person": True})],
+    "float on property": lambda: [n({"id": 10_007.0})],
+}
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("shape", list(REFILTER_SHAPES))
+def test_every_other_shape_still_runs_the_canonical_filter(engine, shape):
+    g = _graph(engine)
+    ops = REFILTER_SHAPES[shape]()
+    _assert_parity(g, ops, engine)
+    _, refilters = _run(g, ops, engine, "use")
+    assert refilters >= 1, "only an exact single-predicate index hit may skip the canonical filter"
+
+
+def test_bool_on_integer_column_is_never_index_served():
+    g = _graph("pandas")
+    ops = [n({"id": True})]
+    _assert_parity(g, ops, "pandas")
+    _, refilters = _run(g, ops, "pandas", "use")
+    assert refilters >= 1
+
+
+def test_bool_on_integer_column_raises_the_same_way_on_cudf_either_policy():
+    pytest.importorskip("cudf")
+    import pyarrow
+    g = _graph("cudf")
+    for policy in ("use", "off"):
+        with pytest.raises(pyarrow.lib.ArrowTypeError):
+            g.gfql([n({"id": True})], engine="cudf", index_policy=policy)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("ops", [[n({"key": "7"})], [n({"id": "10007"})]], ids=["node-id", "property"])
+def test_string_on_integer_column_keeps_the_typed_error_on_both_policies(engine, ops):
+    g = _graph(engine)
+    for policy in ("use", "off"):
+        with pytest.raises(GFQLSchemaError):
+            g.gfql(ops, engine=engine, index_policy=policy)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_no_resident_index_still_filters(engine):
+    g = _graph(engine)
+    plain = graphistry.nodes(g._nodes, "key").edges(g._edges, "s", "d")
+    ops = [n({"key": 7})]
+    served, refilters = _run(plain, ops, engine, "use")
+    full, _ = _run(plain, ops, engine, "off")
+    pd.testing.assert_frame_equal(_canon(served._nodes), _canon(full._nodes))
+    assert refilters >= 1

--- a/graphistry/tests/compute/gfql/test_node_row_calls_skip_edge_index.py
+++ b/graphistry/tests/compute/gfql/test_node_row_calls_skip_edge_index.py
@@ -1,0 +1,61 @@
+"""A chain made only of plain row-table calls does not scaffold the internal edge index.
+
+Pins: the node rows and the edge frame are identical with and without the scaffolding (routes off is the
+oracle); no ``__gfql_edge_index__`` column reaches the result; a call over the edge table still runs the
+path without the scaffold too, and no longer leaks the index column into its row table.
+"""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import e_forward, n, rows, select
+from graphistry.compute.chain import _calls_only_on_node_rows
+
+NODES = pd.DataFrame({"id": [1, 2, 3], "kind": ["p", "p", "c"], "w": [10, 20, 30]})
+EDGES = pd.DataFrame({"s": [1, 2], "d": [3, 3], "type": ["IN", "IN"]})
+ENGINES = ["pandas", "cudf"]
+
+
+def _graph(engine):
+    nodes, edges = NODES, EDGES
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
+
+
+def _pd(df):
+    return df.to_pandas() if hasattr(df, "to_pandas") else df
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("ops", [
+    [n({"id": 1}, name="a"), rows(source="a")],
+    [n({"id": 1}, name="a"), e_forward({"type": "IN"}), n(name="b"), rows(source="b"), select([("cid", "id"), ("k", "kind")])],
+])
+def test_node_row_calls_answer_identically_without_the_edge_index(engine, ops):
+    from graphistry.tests.compute.gfql.routes.switch import routes_off, ROUTES
+    g = _graph(engine)
+    served = g.gfql(ops, engine=engine)
+    with routes_off(ROUTES):
+        general = g.gfql(ops, engine=engine)
+    assert _pd(served._nodes).to_dict("records") == _pd(general._nodes).to_dict("records")
+    assert not any(str(c).startswith("__gfql_") for c in served._nodes.columns)
+    assert not any(str(c).startswith("__gfql_") for c in served._edges.columns)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_edge_row_calls_answer_without_the_index_column(engine):
+    g = _graph(engine)
+    out = g.gfql([rows(table="edges")], engine=engine)
+    assert sorted(_pd(out._nodes)[["s", "d"]].values.tolist()) == [[1, 3], [2, 3]]
+    assert not any(str(c).startswith("__gfql_") for c in out._nodes.columns)
+
+
+def test_the_predicate_names_exactly_the_node_row_calls():
+    assert _calls_only_on_node_rows([rows(source="a")])
+    assert _calls_only_on_node_rows([rows(source="a"), select([("x", "id")])])
+    assert _calls_only_on_node_rows([rows(table="edges")])
+    assert not _calls_only_on_node_rows([rows(binding_ops=[])])
+    assert not _calls_only_on_node_rows([n({"id": 1}), rows(source="a")])
+    assert not _calls_only_on_node_rows([])

--- a/graphistry/tests/compute/gfql/test_rewrite_param_discard.py
+++ b/graphistry/tests/compute/gfql/test_rewrite_param_discard.py
@@ -204,11 +204,7 @@ def test_indexed_bypass_table_edges_survives_a_projection(engine: str) -> None:
     "pandas",
     "cudf",
     "polars",
-    pytest.param("polars-gpu", marks=pytest.mark.xfail(
-        strict=True,
-        reason="#1803: the indexed bindings bypass excludes Engine.POLARS_GPU "
-               "(index/bindings.py gate), so polars-gpu always takes the scan path",
-    )),
+    "polars-gpu",
 ])
 @pytest.mark.route_engaged("indexed-kernel")
 def test_indexed_bypass_still_serves_a_bare_rows(engine: str) -> None:
@@ -218,14 +214,7 @@ def test_indexed_bypass_still_serves_a_bare_rows(engine: str) -> None:
     retiring the indexed bindings path. Asserted on the trace, not on the answer — the
     answer is identical either way, which is precisely why the regression would be quiet.
 
-    ``polars-gpu`` STRICT-xfails, and that is the point of adding the parameter (#1802). The
-    native polars chain hands `Engine.POLARS_GPU` to `try_indexed_connected_bindings_state`
-    whenever the GPU target is active, but that function's first gate admits only
-    `(PANDAS, CUDF, POLARS)` — so the bypass reports `served: False,
-    reason: 'unsupported_engine'` and polars-gpu silently runs the canonical scan. Values are
-    unaffected (every other case in this file passes on polars-gpu); what is lost is the
-    optimization, with no signal. A strict xfail rather than a skip so that whoever widens the
-    gate is told to delete the marker instead of leaving a stale "known gap" behind.
+    GPU execution must also report an actual served indexed traversal.
     """
     _require(engine)
     from graphistry.compute.gfql.index import index_trace

--- a/graphistry/tests/compute/gfql/test_row_pipeline_ops.py
+++ b/graphistry/tests/compute/gfql/test_row_pipeline_ops.py
@@ -2787,3 +2787,22 @@ class TestRelationshipAliasInRowExpression:
         return_vals = _safe_series_to_list(return_result._nodes["rel"])
         assert select_vals == ["[:WORKS_AT {workFrom: 2010}]"]
         assert select_vals == return_vals
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf"])
+@pytest.mark.parametrize("values", [[True, False], [True, None, False], [None, None]])
+def test_alias_marker_mask_replaces_null_with_false(engine, values):
+    from graphistry.compute.gfql.row.frame_ops import _alias_true_mask
+
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        frame = cudf.DataFrame({"alias": cudf.Series(values, dtype="bool")})
+    else:
+        dtype = "boolean" if None in values else "bool"
+        frame = pd.DataFrame({"alias": pd.Series(values, dtype=dtype)})
+
+    mask = _alias_true_mask(frame, "alias")
+    actual = mask.to_pandas() if engine == "cudf" else mask
+    assert actual.tolist() == [value is True for value in values]
+    assert not actual.isna().any()
+    assert actual.dtype == bool

--- a/graphistry/tests/compute/gfql/test_strictness_levels.py
+++ b/graphistry/tests/compute/gfql/test_strictness_levels.py
@@ -608,3 +608,20 @@ def test_leniency_does_not_swallow_errors_unrelated_to_absence() -> None:
         assert absent_warnings == [], (
             f"level={level} reported an unrelated TypeError as an absent column"
         )
+
+
+@pytest.mark.parametrize("level", ["strict", "warn", "quiet"])
+def test_native_polars_row_projection_absent_property(level: StrictLevel) -> None:
+    from graphistry.compute.ast import n, rows, select
+    graph = _graph("polars")
+    ops = [n(name="n"), rows(source="n"), select([("c", "n.nope_col")])]
+    if level == "strict":
+        with pytest.raises(GFQLSchemaError):
+            graph.gfql(ops, engine="polars", strict=level)
+    else:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = graph.gfql(ops, engine="polars", strict=level)
+        assert _rows(out) == [{"c": None}] * 3
+        messages = [item for item in caught if "GFQL:" in str(item.message)]
+        assert len(messages) == (1 if level == "warn" else 0)


### PR DESCRIPTION
## Objective
Indexed seed lookup, message creator, and message content queries repeatedly filter small results and rebuild intermediate frames. This PR removes that overhead while preserving validation, fallback behavior, and supported query results.

## Changes
1. **An exact index hit answers a one-predicate seed without re-filtering**.
2. **Alias tagging on the seeded hop builds its flag columns in place on pandas and cuDF**.
3. **An index hit verifies its residual scalar predicates on the hit rows** instead of running the canonical filter (~0.3 ms of fixed overhead on a one-row frame); the typed E302 errors are kept.
4. **The seeded typed hop validates endpoints on its gathered rows with native NumPy or CuPy arrays** on pandas and cuDF numeric IDs. Null and incompatible ID cases retain the generic path.
5. **`rows()` / `select` on pandas skip the copies and null handling a one-row projection does not need** (bool marker mask short-circuit; no copy before a mask filter; the projection frame built directly; zero-row edge slice without copy).
6. **A chain of plain row-table calls skips the edge-index scaffolding** (an O(E) column write and drop per call). This also fixes a leaked `__gfql_edge_index__` column on an edge row table.
7. **The alias lookup frame for binding rows is built in three frame ops** rather than one per column (joined-rows route 15 → 13 ms locally); the no-scaffold result drops the row context.
8. **The polars single-node branch is a route** (admission predicate, lane body, routes-off target, harness parity). No behavior change; the harness then showed the polars *general* path dropping null-id rows and collapsing duplicate ids on node-only op lists where the lane and the pandas oracle keep them: filed as #2071 (with #2034), ledgered as known divergences of that route.

## Review fixes at e5f67a7ce
- Declared graph and AST state uses direct attributes. Optional endpoint annotations match the existing guards; backend capability checks remain where needed.
- cuDF alias insertion and endpoint filtering use native masks and arrays. Nullable residual predicates reject nulls correctly. Alias collisions and duplicate requests retain generic handling.
- GPU strictness and count corrections are included. Redundant comments were removed.
- Added 81 review-driven tests covering backend agreement, nulls, aliases, input preservation, mixed ID widths, empty/repeated edges, dangling endpoints, and both directions.

The [review response](https://github.com/graphistry/pygraphistry/pull/2070#issuecomment-5597770199) maps the changes to the inline and overall review comments.

## Historical benchmark measurements
These measurements accompanied the earlier implementation, before the final review revision. They are retained as historical evidence and are not exact-head e5f67a7ce measurements. DGX Spark, indexed pandas, median of three runs in milliseconds; competitor cells are from the published board.
| query | SF0.1 now (was) | SF1 now (was) | Kuzu SF0.1 / SF1 | Memgraph | Neo4j |
|---|---|---|---|---|---|
| seed_lookup | 3.06 (3.86) | 3.19 (4.14) | 2.33 / 2.52 | 0.59 / 0.52 | 3.50 / 2.88 |
| message_creator | 1.77 (2.33) | 1.71 (2.41) | 1.43 / 1.51 | 0.60 / 0.31 | 2.63 / 1.67 |
| message_content | 1.12 (1.66) | 1.08 (1.68) | 0.72 / 0.67 | 0.49 / 0.29 | 2.26 / 2.44 |

W/T/L on the point queries, pandas-idx: vs Neo4j SF0.1 3/0/0, SF1 1/2/0 (was 1/1/2 and 1/0/2); vs Kuzu 0/0/3 at both scales (0.62–0.88×, up from 0.40–0.63×); vs Memgraph 0/0/3 (0.16–0.43×). These historical comparisons measure the pandas changes.

Sentinel at 7eec9cc9e: gate ok against the master baseline; pandas points 8–28% faster (node-only-props 0.57 → 0.41 ms).

## Remaining performance work
The remaining 1–3 ms per call is orchestration: two chain entries per op list, the call executor, and Plottable rebinds. Memgraph answers these in 0.3–0.6 ms. Reaching that needs a dedicated point-lookup route (index gather → row table → projection in one pass) and, for seed_lookup, a one-call arm; both are follow-ups under the same objective. The polars point shapes decline the seeded lane and take the full chain; they need their own pass.

## Validation at e5f67a7ce
- DGX RAPIDS 26.02: 13,947 passed, 55 skipped, 67 expected failures, and eight non-strict unexpected passes. A real Polars GPU collect preflight passed.
- Local suites: 422 focused tests, 1,733 shared tests, 568 strictness/aggregate/row-pipeline tests, and 149 Polars admission/route tests passed. These suites overlap and are not summed.
- TCK: 4,143 tests passed. Repository lint and ten-source-file type checks passed.
- [Hosted CI](https://github.com/graphistry/pygraphistry/actions/runs/34322676723) succeeded; all 84 reported checks passed on the reviewed head.

The reviewed revision is pushed. Owner review and merge remain pending.
