### PR TITLE
perf(gfql): materialize indexed point-query rows directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1598,19 +1598,18 @@ jobs:
         ./bin/test-graphviz.sh
 
   gfql-routes-off:
-    # Non-blocking ledger: replays the GFQL suites with one hot path declined per cell
+    # Required replay: run the GFQL suites with one hot path declined per cell
     # (GFQL_ROUTES_OFF); engagement pins are skipped via the route_engaged marker, so the
     # uploaded lists hold route-vs-general result divergences only.
     needs: [changes, test-gfql-core, generate-lockfiles]
     if: ${{ needs.changes.outputs.gfql == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 45
 
     strategy:
       fail-fast: false
       matrix:
-        mode: [native-fast, polars-seeded, polars-plain, index-hop, indexed-kernel, cypher-fast, all-off]
+        mode: [polars-point-rows, point-rows, native-fast, polars-single-node, polars-seeded, polars-plain, index-hop, indexed-kernel, cypher-fast, all-off]
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-* GFQL: indexed scalar node and directed single-hop queries followed by `rows(source=...)` and optional `select(...)` now produce row tables without chain execution on pandas and cuDF.
+* GFQL: indexed scalar node and directed single-hop queries followed by `rows(source=...)` and optional `select(...)` now produce row tables directly on pandas, cuDF, and Polars. Joined property projections preserve repeated edge matches without constructing full traversal results.
+* GFQL: indexed scalar equality filters no longer retain null-valued rows when the comparison produces a nullable boolean mask.
 
 * GFQL: a native chain whose edge alias is named like the source, destination or edge-ID binding column silently overwrote that binding on pandas and cuDF (the seed's edges vanished, or the edge ids became `True`) and raised a raw polars `SchemaError`; it is now the same typed decline (E108) the node-ID collision already gets, on every engine, before execution — the rule the Cypher route already applied (#2050).
 * GFQL polars: a colliding alias no longer leaves the internal `__gfql_shadow_restore__<alias>__` column on op-list results; the chain keeps the shadowed values under that name only while a compiled Cypher pipeline runs (its row pipeline reads them back), and on `gfql([...])` / `chain([...])` the marker simply shadows the column as on pandas and cuDF. Nothing is stripped from results: user-defined columns and pipelines composed from successive `gfql` calls are untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+* GFQL: indexed scalar node and directed single-hop queries followed by `rows(source=...)` and optional `select(...)` now produce row tables without chain execution on pandas and cuDF.
+
 * GFQL: a native chain whose edge alias is named like the source, destination or edge-ID binding column silently overwrote that binding on pandas and cuDF (the seed's edges vanished, or the edge ids became `True`) and raised a raw polars `SchemaError`; it is now the same typed decline (E108) the node-ID collision already gets, on every engine, before execution — the rule the Cypher route already applied (#2050).
 * GFQL polars: a colliding alias no longer leaves the internal `__gfql_shadow_restore__<alias>__` column on op-list results; the chain keeps the shadowed values under that name only while a compiled Cypher pipeline runs (its row pipeline reads them back), and on `gfql([...])` / `chain([...])` the marker simply shadows the column as on pandas and cuDF. Nothing is stripped from results: user-defined columns and pipelines composed from successive `gfql` calls are untouched.
 

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -134,6 +134,8 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/test_gfql_op_list_hides_internal_columns.py
     graphistry/tests/compute/gfql/routes/test_route_harness.py
     graphistry/tests/compute/gfql/routes/test_point_boundaries.py
+    graphistry/tests/compute/gfql/routes/test_has_collision_contract.py
+    graphistry/tests/compute/gfql/routes/test_node_selection_rows.py
     graphistry/tests/compute/gfql/test_join_backend_contracts.py
     graphistry/tests/compute/test_chain_validation_execution.py
     graphistry/tests/compute/gfql/test_engine_polars_semi_key_dedup.py

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -133,6 +133,9 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/test_chain_alias_column_collision.py
     graphistry/tests/compute/test_gfql_op_list_hides_internal_columns.py
     graphistry/tests/compute/gfql/routes/test_route_harness.py
+    graphistry/tests/compute/gfql/routes/test_point_boundaries.py
+    graphistry/tests/compute/gfql/test_join_backend_contracts.py
+    graphistry/tests/compute/test_chain_validation_execution.py
     graphistry/tests/compute/gfql/test_engine_polars_semi_key_dedup.py
     graphistry/tests/compute/gfql/test_engine_polars_call_modality.py
     graphistry/tests/compute/gfql/test_engine_polars_gpu.py

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -89,6 +89,8 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
     graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
+    graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
+    graphistry/tests/compute/gfql/test_polars_indexed_join_helpers.py
     graphistry/tests/compute/chain_specializations/test_native_admission.py
     graphistry/tests/compute/chain_specializations/test_point_rows.py
     graphistry/tests/compute/gfql/test_undirected_pairs_2026.py

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -107,6 +107,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_polars_rows_entity_groupby.py
     graphistry/tests/compute/gfql/test_seeded_typed_hop_fastpath.py
     graphistry/tests/compute/gfql/test_residual_polars_native.py
+    graphistry/tests/compute/gfql/index/test_engine_arrays.py
     graphistry/tests/compute/gfql/index/test_auto_engine_agreement.py
     graphistry/tests/compute/gfql/index/test_degree_consult.py
     graphistry/tests/compute/gfql/test_single_alias_cache_key.py

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -91,6 +91,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
     graphistry/tests/compute/gfql/lazy/engine/polars/test_predicates.py
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
+    graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_hotpaths.py
     graphistry/tests/compute/gfql/test_polars_indexed_join_helpers.py
     graphistry/tests/compute/chain_specializations/test_native_admission.py
     graphistry/tests/compute/chain_specializations/test_point_rows.py

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -90,6 +90,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
     graphistry/tests/compute/chain_specializations/test_native_admission.py
+    graphistry/tests/compute/chain_specializations/test_point_rows.py
     graphistry/tests/compute/gfql/test_undirected_pairs_2026.py
     graphistry/tests/compute/gfql/test_native_seed_lane_explain.py
     # #1882/#1913-f4/#1879 crash-family pins: the polars params (filter helpers on polars

--- a/bin/test-polars.sh
+++ b/bin/test-polars.sh
@@ -89,6 +89,7 @@ POLARS_TEST_FILES=(
     graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
     graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
+    graphistry/tests/compute/gfql/lazy/engine/polars/test_predicates.py
     graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
     graphistry/tests/compute/gfql/test_polars_indexed_join_helpers.py
     graphistry/tests/compute/chain_specializations/test_native_admission.py

--- a/bin/test-routes-off.sh
+++ b/bin/test-routes-off.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 # Replay the GFQL suites with each hot path declined (GFQL_ROUTES_OFF, see graphistry/tests/conftest.py).
 # Engagement pins carry the route_engaged marker and are skipped, so every remaining failure is a
-# route-vs-general result divergence. Non-blocking ledger: always exits 0; per-mode logs + id lists in $OUT.
+# route-vs-general result divergence. Fail on any failed replay; retain per-mode logs and id lists.
 set -uo pipefail
 cd "$(dirname "$0")/.."
-MODES=${MODES:-native-fast polars-seeded polars-plain index-hop indexed-kernel cypher-fast all-off}
+# One registry drives forcing and replay: new routes automatically join all-off.
+ALL_ROUTES=$(python -c 'from graphistry.tests.compute.gfql.routes.switch import ROUTES; print(",".join(ROUTES))') || exit $?
+MODES=${MODES:-${ALL_ROUTES//,/ } all-off}
 SUITES=${SUITES:-graphistry/tests/compute/test_chain.py graphistry/tests/compute/test_hop.py graphistry/tests/compute/test_gfql.py graphistry/tests/compute/gfql}
 OUT=${OUT:-build/routes-off}
 mkdir -p "$OUT"
+status=0
 for mode in $MODES; do
-  if [ "$mode" = all-off ]; then routes=native-fast,polars-seeded,polars-plain,index-hop,indexed-kernel,cypher-fast; else routes=$mode; fi
-  GFQL_ROUTES_OFF=$routes python -m pytest $SUITES -q -p no:cacheprovider -o addopts="" -rfE > "$OUT/$mode.log" 2>&1
+  if [ "$mode" = all-off ]; then routes=$ALL_ROUTES; else routes=$mode; fi
+  GFQL_ROUTES_OFF=$routes python -m pytest $SUITES -q -p no:cacheprovider -o addopts="" -rfE > "$OUT/$mode.log" 2>&1 || status=1
   grep -E "^(FAILED|ERROR) " "$OUT/$mode.log" | sed 's/ - .*//' | sort -u > "$OUT/$mode.divergences"
   echo "$mode: $(wc -l < "$OUT/$mode.divergences") divergence id(s); $(tail -1 "$OUT/$mode.log")"
 done
-exit 0
+exit "$status"

--- a/graphistry/Engine.py
+++ b/graphistry/Engine.py
@@ -138,6 +138,12 @@ def resolve_engine(
             except ImportError:
                 pass
 
+        type_module = type(g_or_df).__module__
+        if 'dask' in type_module and 'cudf' not in type_module:
+            import dask.dataframe as dd
+            if isinstance(g_or_df, dd.DataFrame):
+                return Engine.PANDAS
+
         if 'cudf.core.dataframe' in str(getmodule(g_or_df)):
             has_cudf_dependancy_, _, _ = lazy_cudf_import()
             if has_cudf_dependancy_:

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -981,7 +981,8 @@ def _chain_with_strictness(
         # POLARS_GPU = the same lazy engine with the GPU execution target.
         # (Dependency guards for polars / cudf_polars are above, pre-coercion.)
         if validate_schema:
-            Chain(ops if not isinstance(ops, Chain) else ops.chain, validate=False).validate(collect_all=False)
+            # Construct a fresh validator: the constructor validates children once.
+            Chain(ops if not isinstance(ops, Chain) else ops.chain)
             validate_graph_shape(self, ops, collect_all=False)  # pandas gets this via validate_chain_schema (#1889)
         from graphistry.compute.gfql.lazy.engine.polars.chain import chain_polars
         from graphistry.compute.gfql.lazy import target_mode, ExecutionTarget
@@ -1050,7 +1051,8 @@ def _chain_impl(
         ops = ops.chain
 
     if validate_schema:
-        Chain(ops, validate=False).validate(collect_all=False)
+        # Revalidate mutable operations on every execution, including reused Chains.
+        Chain(ops)
 
     from graphistry.compute.ast import ASTCall
 

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1259,7 +1259,11 @@ def _chain_impl(
             if synthesized_empty_edges:
                 g_out = self.nodes(g_out._nodes, g._node)
             elif added_edge_index:
-                g_out = g_out.edges(g_out._edges.drop(columns=[g._edge]), edge=original_edge)
+                g_out = self.nodes(g_out._nodes, g._node).edges(
+                    g_out._edges.drop(columns=[g._edge]), edge=original_edge)
+            elif g._edge is not None:
+                edge_cols = [g._edge, *[c for c in g_out._edges.columns if c != g._edge]]
+                g_out = g_out.edges(g_out._edges[edge_cols])
             success = True
         else:
             # Phase 2: Backward pass to propagate downstream constraints.

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -547,6 +547,9 @@ def combine_steps(
                     out_df[base] = out_df[c_x].where(out_df[c_x].notna(), out_df[c])
                 out_df = out_df.drop(columns=[c, c_x])
 
+    # Empty pandas merges can move the binding column behind aliases or properties.
+    if out_df.columns[0] != id:
+        out_df = out_df[[id, *[column for column in out_df.columns if column != id]]]
     return out_df
 
 

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -1244,6 +1244,23 @@ def _chain_impl(
                 from .gfql.exec_context import clear_row_exec_context
                 g_out = clear_row_exec_context(g_out)
             success = True
+        elif len(ops) == 1 and isinstance(ops[0], ASTNode):
+            # A node selection preserves each source row. Rejoining node IDs in
+            # the traversal combine would multiply duplicate rows and properties.
+            g_out = g_stack[0]
+            alias = ops[0]._name
+            if alias is not None:
+                cols = [c for c in g_out._nodes.columns if c != alias]
+                if g._node in cols:
+                    cols = [g._node, *[c for c in cols if c != g._node]]
+                cols = ([*cols, alias] if alias in g._nodes.columns
+                        else [*cols[:1], alias, *cols[1:]])
+                g_out = g_out.nodes(g_out._nodes[cols].reset_index(drop=True))
+            if synthesized_empty_edges:
+                g_out = self.nodes(g_out._nodes, g._node)
+            elif added_edge_index:
+                g_out = g_out.edges(g_out._edges.drop(columns=[g._edge]), edge=original_edge)
+            success = True
         else:
             # Phase 2: Backward pass to propagate downstream constraints.
             g_stack_reverse : List[Plottable] = []

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -12,6 +12,7 @@ from .ast import ASTObject, ASTNode, ASTEdge, ASTCall, Direction, from_json as A
 from .typing import DataFrameT, SeriesT
 from .util import generate_safe_column_name
 from .chain_specializations.hotpaths import _try_chain_fast_path
+from .chain_specializations.point_rows import _try_point_rows
 from graphistry.compute.validate.validate_schema import validate_chain_schema, validate_graph_shape
 from graphistry.compute.gfql.strictness import StrictInput
 from graphistry.compute.gfql.same_path_types import (
@@ -1005,6 +1006,10 @@ def _chain_with_strictness(
         finally:
             call_thread_local.policy = old_policy
     else:
+        point_ops = ops.chain if isinstance(ops, Chain) else ops
+        point_result = _try_point_rows(self, point_ops, engine_concrete_early, start_nodes, validate_schema)
+        if point_result is not None:
+            return point_result
         return _chain_impl(self, ops, engine, validate_schema, policy, context, start_nodes)
 
 

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -13,6 +13,7 @@ from .typing import DataFrameT, SeriesT
 from .util import generate_safe_column_name
 from .chain_specializations.hotpaths import _try_chain_fast_path
 from .chain_specializations.point_rows import _try_point_rows
+from .engine_coercion import ensure_local_engine_match
 from graphistry.compute.validate.validate_schema import validate_chain_schema, validate_graph_shape
 from graphistry.compute.gfql.strictness import StrictInput
 from graphistry.compute.gfql.same_path_types import (
@@ -970,6 +971,8 @@ def _chain_with_strictness(
                     "Install RAPIDS/cudf_polars, or use engine='polars' for native CPU execution."
                 )
     self = _coerce_input_formats(self, engine_concrete_early)
+    if engine_concrete_early == Engine.PANDAS:
+        self = ensure_local_engine_match(self, engine_concrete_early)
 
     if engine_concrete_early in POLARS_ENGINES:
         # Native polars chain lives in a dedicated dispatched module so the

--- a/graphistry/compute/chain.py
+++ b/graphistry/compute/chain.py
@@ -981,7 +981,7 @@ def _chain_with_strictness(
         # POLARS_GPU = the same lazy engine with the GPU execution target.
         # (Dependency guards for polars / cudf_polars are above, pre-coercion.)
         if validate_schema:
-            Chain(ops if not isinstance(ops, Chain) else ops.chain).validate(collect_all=False)
+            Chain(ops if not isinstance(ops, Chain) else ops.chain, validate=False).validate(collect_all=False)
             validate_graph_shape(self, ops, collect_all=False)  # pandas gets this via validate_chain_schema (#1889)
         from graphistry.compute.gfql.lazy.engine.polars.chain import chain_polars
         from graphistry.compute.gfql.lazy import target_mode, ExecutionTarget
@@ -1050,7 +1050,7 @@ def _chain_impl(
         ops = ops.chain
 
     if validate_schema:
-        Chain(ops).validate(collect_all=False)
+        Chain(ops, validate=False).validate(collect_all=False)
 
     from graphistry.compute.ast import ASTCall
 

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Literal, Optional, Sequence, Tuple, TYPE_CHECKING,
 from graphistry.Plottable import Plottable
 from graphistry.Engine import is_polars_series
 from .ast import Direction
-from .typing import ArrayLike, ArrayNamespace, DataFrameT, SeriesT
+from .typing import ArrayLike, ArrayNamespace, DataFrameT, FilterDict, ScalarFilterDict, SeriesT
 
 if TYPE_CHECKING:
     from graphistry.Engine import Engine
@@ -115,7 +115,7 @@ def _tag_fast_path_aliases_eager(
     return nodes, edges
 
 
-def _seeded_scalar_filters(fd: Optional[Dict[str, Any]], df: DataFrameT) -> Optional[Dict[str, Any]]:
+def _seeded_scalar_filters(fd: Optional[FilterDict], df: DataFrameT) -> Optional[ScalarFilterDict]:
     """Resolve a filter dict to plain scalar column==value pairs, or None to bail
     to the general path. Mirrors filter_by_dict.resolve_filter_column exactly for
     the shapes it accepts: the cypher ``label__X: True`` form maps to ``type``
@@ -127,7 +127,7 @@ def _seeded_scalar_filters(fd: Optional[Dict[str, Any]], df: DataFrameT) -> Opti
     if not fd:
         return {}
     cols = set(df.columns)
-    out: Dict[str, Any] = {}
+    out: ScalarFilterDict = {}
     for k, v in fd.items():
         if not isinstance(v, (int, float, str, bool)):
             return None  # predicate / non-scalar -> bail to the general path
@@ -272,7 +272,7 @@ def _resident_node_id_index(
 
 
 def _seed_rows_via_prop_index_frame(
-    g: Plottable, nodes_df: DataFrameT, n0f: Dict[str, object], engine: "Engine",
+    g: Plottable, nodes_df: DataFrameT, n0f: ScalarFilterDict, engine: "Engine",
 ) -> Optional[DataFrameT]:
     """Candidate seed rows through a resident node PROPERTY index covering one of the
     scalar predicates, else None (the caller re-applies the whole filter either way)."""
@@ -299,9 +299,9 @@ SeededReturn = Tuple[DataFrameT, DataFrameT, DataFrameT, bool]
 
 
 def _seed_node_rows(
-    g: Plottable, nodes_df: DataFrameT, n0f: Dict[str, object], node: str,
+    g: Plottable, nodes_df: DataFrameT, n0f: ScalarFilterDict, node: str,
     nid_ctx: Optional[Tuple["NodeIdIndex", ArrayNamespace, "Engine"]],
-    filter_dict: Optional[Dict[str, object]] = None,
+    filter_dict: Optional[FilterDict] = None,
 ) -> Tuple[DataFrameT, SeedRowsHow]:
     """Rows matching the scalar seed filter: node-id index when the predicate is on the
     binding column, else a resident property index, else a scan. The canonical filter
@@ -318,9 +318,9 @@ def _seed_node_rows(
 
 
 def _seed_node_rows_from_index(
-    g: Plottable, nodes_df: DataFrameT, n0f: Dict[str, object], node: str,
+    g: Plottable, nodes_df: DataFrameT, n0f: ScalarFilterDict, node: str,
     nid_ctx: Optional[Tuple["NodeIdIndex", ArrayNamespace, "Engine"]],
-    filter_dict: Optional[Dict[str, object]] = None,
+    filter_dict: Optional[FilterDict] = None,
 ) -> Optional[Tuple[DataFrameT, SeedRowsHow]]:
     from graphistry.compute.gfql.index.bindings import _filter_frame
     engine = _frame_engine(nodes_df)
@@ -349,7 +349,7 @@ def _seed_node_rows_from_index(
 
 
 def _verify_scalar_filters_on_hit(
-    seed: DataFrameT, n0f: Dict[str, object], engine: "Engine",
+    seed: DataFrameT, n0f: ScalarFilterDict, engine: "Engine",
 ) -> Optional[DataFrameT]:
     """Check residual equalities on index hits, preserving typed filter errors."""
     from graphistry.Engine import Engine
@@ -398,7 +398,7 @@ def _verify_scalar_filters_on_hit(
     return seed[mask]
 
 
-def _index_answered_whole_filter(effective: Dict[str, object], n0f: Dict[str, object]) -> bool:
+def _index_answered_whole_filter(effective: FilterDict, n0f: ScalarFilterDict) -> bool:
     """Whether one unrewritten equality was fully answered by the index."""
     if len(effective) != 1 or len(n0f) != 1:
         return False

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -6,6 +6,8 @@ lanes in ``gfql_fast_paths.py``. This module imports only leaf modules (no back-
 
 from typing import Any, Dict, Literal, Optional, Sequence, Tuple, TYPE_CHECKING, Union, cast
 
+import pandas as pd
+
 from graphistry.Plottable import Plottable
 from graphistry.Engine import is_polars_series
 from .ast import Direction
@@ -195,6 +197,10 @@ def _ids_to_key_array(
         elif is_polars_series(vals):
             # Nullable integers become floats in NumPy unless nulls are removed first.
             raw = (vals.drop_nulls() if vals.null_count() else vals).to_numpy()
+        elif isinstance(vals, pd.Series):
+            vals = vals.dropna()
+            dtype = vals.dtype
+            raw = vals.to_numpy(dtype=f"{dtype.kind}{dtype.itemsize}") if dtype.kind in "iu" else vals.to_numpy()
         elif hasattr(vals, "to_numpy"):
             raw = vals.to_numpy()
         else:

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -7,6 +7,7 @@ lanes in ``gfql_fast_paths.py``. This module imports only leaf modules (no back-
 from typing import Any, Dict, Literal, Optional, Sequence, Tuple, TYPE_CHECKING, Union, cast
 
 from graphistry.Plottable import Plottable
+from graphistry.Engine import is_polars_series
 from .ast import Direction
 from .typing import ArrayLike, ArrayNamespace, DataFrameT, SeriesT
 
@@ -191,6 +192,9 @@ def _ids_to_key_array(
         if 'cudf' in str(type(vals).__module__):
             vals = vals.dropna()  # type: ignore[union-attr]  # cudf Series by module check
             raw = vals.values  # type: ignore[union-attr]  # device array; to_numpy() raises on nulls + round-trips host
+        elif is_polars_series(vals):
+            # Nullable integers become floats in NumPy unless nulls are removed first.
+            raw = (vals.drop_nulls() if vals.null_count() else vals).to_numpy()
         elif hasattr(vals, "to_numpy"):
             raw = vals.to_numpy()
         else:

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -27,10 +27,20 @@ def _tag_fast_path_aliases(
     edges: Optional[DataFrameT] = res._edges
     if nodes is None or edges is None:
         return res
+    nodes, edges = _tag_fast_path_alias_frames(
+        nodes, edges, alias_n0, alias_e1, alias_n2, src, dst, node, direction)
+    return res.nodes(nodes).edges(edges)
+
+
+def _tag_fast_path_alias_frames(
+    nodes: DataFrameT, edges: DataFrameT,
+    alias_n0: Optional[str], alias_e1: Optional[str], alias_n2: Optional[str],
+    src: str, dst: str, node: str, direction: Direction,
+) -> Tuple[DataFrameT, DataFrameT]:
     from_col, to_col = (src, dst) if direction == "forward" else (dst, src)
     tagged = _tag_fast_path_aliases_eager(nodes, edges, alias_n0, alias_e1, alias_n2, from_col, to_col, node)
     if tagged is not None:
-        return res.nodes(tagged[0]).edges(tagged[1])
+        return tagged
     node_flags: Dict[str, SeriesT] = {}
     if alias_n0 is not None:
         node_flags[alias_n0] = nodes[node].isin(edges[from_col])
@@ -53,7 +63,7 @@ def _tag_fast_path_aliases(
             edges = edges[[alias_e1, *[c for c in edges.columns if c != alias_e1]]]
         edges = edges.reset_index(drop=True)
 
-    return res.nodes(nodes).edges(edges)
+    return nodes, edges
 
 
 def _tag_fast_path_aliases_eager(
@@ -289,6 +299,21 @@ def _seed_node_rows(
     (``filter_dict`` as written, or the resolved scalars) is re-applied to the candidates,
     so every branch keeps the full path's typed-error and comparison semantics."""
     from graphistry.compute.gfql.index.bindings import _filter_frame
+    indexed = _seed_node_rows_from_index(g, nodes_df, n0f, node, nid_ctx, filter_dict)
+    if indexed is not None:
+        return indexed
+    engine = _frame_engine(nodes_df)
+    if engine is None:
+        raise TypeError(f"unsupported node frame type {type(nodes_df).__name__}")
+    return _filter_frame(nodes_df, filter_dict if filter_dict is not None else n0f, engine), "scan"
+
+
+def _seed_node_rows_from_index(
+    g: Plottable, nodes_df: DataFrameT, n0f: Dict[str, object], node: str,
+    nid_ctx: Optional[Tuple["NodeIdIndex", ArrayNamespace, "Engine"]],
+    filter_dict: Optional[Dict[str, object]] = None,
+) -> Optional[Tuple[DataFrameT, SeedRowsHow]]:
+    from graphistry.compute.gfql.index.bindings import _filter_frame
     engine = _frame_engine(nodes_df)
     if engine is None:
         raise TypeError(f"unsupported node frame type {type(nodes_df).__name__}")
@@ -304,14 +329,13 @@ def _seed_node_rows(
         if seed is not None:
             how = "property_index"
     if seed is None:
-        seed = nodes_df
+        return None
     effective = filter_dict if filter_dict is not None else n0f
-    if how != "scan" and _index_answered_whole_filter(effective, n0f):
+    if _index_answered_whole_filter(effective, n0f):
         return seed, how
-    if how != "scan":
-        verified = _verify_scalar_filters_on_hit(seed, n0f, engine)
-        if verified is not None:
-            return verified, how
+    verified = _verify_scalar_filters_on_hit(seed, n0f, engine)
+    if verified is not None:
+        return verified, how
     return _filter_frame(seed, effective, engine), how
 
 

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -94,7 +94,10 @@ def _tag_fast_path_aliases_eager(
                 return None
         out_nodes = nodes.reset_index(drop=True)
         if out_nodes.columns[0] != node:
-            out_nodes.insert(0, node, out_nodes.pop(node))
+            if pandas_frames:
+                out_nodes.insert(0, node, out_nodes.pop(node))
+            else:
+                out_nodes = out_nodes[[node, *[c for c in out_nodes.columns if c != node]]]
         pos = 1
         if alias_n0 is not None:
             seed_flags = np.isin(ids, ends[0]) if pandas_frames else nodes[node].isin(edges[from_col]).reset_index(drop=True)

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -350,6 +350,9 @@ def _verify_scalar_filters_on_hit(
     """Check residual equalities on index hits, preserving typed filter errors."""
     from graphistry.Engine import Engine
     from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError
+    if engine == Engine.POLARS:
+        from graphistry.compute.gfql.lazy.engine.polars.predicates import _filter_singleton_equalities
+        return _filter_singleton_equalities(seed, n0f)
     from graphistry.compute.filter_by_dict import _is_numeric_dtype_safe, _is_string_dtype_safe
     if engine not in (Engine.PANDAS, Engine.CUDF) or len(seed) == 0 or not n0f:
         return seed if len(seed) == 0 else None

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -83,7 +83,7 @@ def _tag_fast_path_aliases_eager(
         return None
     wanted = [a for a in (alias_n0, alias_n2) if a is not None]
     if wanted:
-        if nodes.columns[0] != node or any(a in nodes.columns for a in wanted):
+        if any(a in nodes.columns for a in wanted):
             return None
         if len(set(wanted)) != len(wanted):
             return None
@@ -93,6 +93,8 @@ def _tag_fast_path_aliases_eager(
             if any(a.dtype.kind not in "iub" or a.dtype != ids.dtype for a in (ids, *ends)):
                 return None
         out_nodes = nodes.reset_index(drop=True)
+        if out_nodes.columns[0] != node:
+            out_nodes.insert(0, node, out_nodes.pop(node))
         pos = 1
         if alias_n0 is not None:
             seed_flags = np.isin(ids, ends[0]) if pandas_frames else nodes[node].isin(edges[from_col]).reset_index(drop=True)
@@ -348,6 +350,9 @@ def _verify_scalar_filters_on_hit(
     from graphistry.compute.filter_by_dict import _is_numeric_dtype_safe, _is_string_dtype_safe
     if engine not in (Engine.PANDAS, Engine.CUDF) or len(seed) == 0 or not n0f:
         return seed if len(seed) == 0 else None
+    import pandas as pd
+    single_pandas = engine == Engine.PANDAS and len(seed) == 1
+    scalar_match = True
     mask = None
     for col, val in n0f.items():
         if col not in seed.columns or isinstance(val, (list, tuple, set)):
@@ -361,11 +366,20 @@ def _verify_scalar_filters_on_hit(
             raise GFQLSchemaError(
                 ErrorCode.E302, f'Type mismatch: column "{col}" is string but filter value is numeric',
                 field=col, value=val, column_type=str(col_dtype), suggestion=f'Use a string value like {col}="value"')
+        if single_pandas and isinstance(val, (str, int, float, bool)):
+            value = seed[col].array[0]
+            if value is None or value is pd.NA:
+                scalar_match = False
+                continue
+            if col_dtype.kind in "biuf" or isinstance(value, str):
+                scalar_match = scalar_match and bool(value == val)
+                continue
         hit = seed[col] == val
         mask = hit if mask is None else (mask & hit)
+    if not scalar_match:
+        return seed.iloc[:0]
     if mask is None:
         return seed
-    import pandas as pd
     if engine == Engine.CUDF and mask.null_count:
         mask = mask.fillna(False)
     all_match = mask.all(skipna=False)

--- a/graphistry/compute/chain_fast_paths.py
+++ b/graphistry/compute/chain_fast_paths.py
@@ -355,8 +355,8 @@ def _verify_scalar_filters_on_hit(
     from graphistry.Engine import Engine
     from graphistry.compute.exceptions import ErrorCode, GFQLSchemaError
     if engine == Engine.POLARS:
-        from graphistry.compute.gfql.lazy.engine.polars.predicates import _filter_singleton_equalities
-        return _filter_singleton_equalities(seed, n0f)
+        from graphistry.compute.gfql.lazy.engine.polars.predicates import _filter_small_equalities
+        return _filter_small_equalities(seed, n0f)
     from graphistry.compute.filter_by_dict import _is_numeric_dtype_safe, _is_string_dtype_safe
     if engine not in (Engine.PANDAS, Engine.CUDF) or len(seed) == 0 or not n0f:
         return seed if len(seed) == 0 else None

--- a/graphistry/compute/chain_specializations/admission.py
+++ b/graphistry/compute/chain_specializations/admission.py
@@ -3,11 +3,11 @@ consult the same predicates, so a test that filters a shape corpus with them exe
 what the dispatcher admits."""
 # ruff: noqa: E501
 
-from typing import Dict, Literal, Optional, Sequence, Tuple, TYPE_CHECKING
+from typing import Literal, Optional, Sequence, Tuple, TYPE_CHECKING
 
 from graphistry.compute.ast import ASTObject, ASTNode, ASTEdge, ASTCall
 from graphistry.compute.chain_fast_paths import SeedRowsHow
-from graphistry.compute.typing import ArrayNamespace, DataFrameT
+from graphistry.compute.typing import ArrayNamespace, DataFrameT, ScalarFilterDict
 
 if TYPE_CHECKING:
     from graphistry.Engine import Engine
@@ -55,13 +55,14 @@ def native_fast_path_admits(
 
 
 def _indexed_kernel_admits(
-    seed_nodes: DataFrameT, gathered_edges: Optional[DataFrameT], n0f: Dict[str, object],
+    seed_nodes: DataFrameT, gathered_edges: Optional[DataFrameT], n0f: ScalarFilterDict,
     node: str, how: SeedRowsHow, ctx: Tuple["NodeIdIndex", "AdjacencyIndex", ArrayNamespace, "Engine"],
     n_nodes: int, n_edges: int,
 ) -> bool:
     """Whether the indexed connected-bindings kernel would have served this seeded 1-hop:
     its seed admission (binding-column integer seed, property-index hit, or a scan on a
     graph with fewer nodes than edges) and its frontier and gather cost gates."""
+    from graphistry.Engine import POLARS_ENGINES, is_polars_df
     from numbers import Integral
     from graphistry.compute.gfql.index.cost import cost_gate_frac
     _, adj, _, engine = ctx
@@ -70,11 +71,13 @@ def _indexed_kernel_admits(
     if not (seeded_on_binding or how == "property_index" or n_nodes < n_edges):
         return False
     frac = cost_gate_frac(engine)
-    if not hasattr(seed_nodes, "get_column"):
-        n_frontier = int(seed_nodes[node].nunique())
-    else:
+    if engine in POLARS_ENGINES:
+        import polars as pl
+        assert is_polars_df(seed_nodes) and isinstance(seed_nodes, pl.DataFrame)
         seed_ids = seed_nodes.get_column(node)
         n_frontier = len(seed_ids) if len(seed_ids) <= 1 else int(seed_ids.n_unique())
+    else:
+        n_frontier = int(seed_nodes[node].nunique())
     if n_frontier >= frac * adj.n_keys:
         return False
     return gathered_edges is not None and len(gathered_edges) < frac * n_edges

--- a/graphistry/compute/chain_specializations/admission.py
+++ b/graphistry/compute/chain_specializations/admission.py
@@ -70,8 +70,11 @@ def _indexed_kernel_admits(
     if not (seeded_on_binding or how == "property_index" or n_nodes < n_edges):
         return False
     frac = cost_gate_frac(engine)
-    n_frontier = int(seed_nodes[node].nunique()) if not hasattr(seed_nodes, "get_column") \
-        else int(seed_nodes.get_column(node).n_unique())
+    if not hasattr(seed_nodes, "get_column"):
+        n_frontier = int(seed_nodes[node].nunique())
+    else:
+        seed_ids = seed_nodes.get_column(node)
+        n_frontier = len(seed_ids) if len(seed_ids) <= 1 else int(seed_ids.n_unique())
     if n_frontier >= frac * adj.n_keys:
         return False
     return gathered_edges is not None and len(gathered_edges) < frac * n_edges

--- a/graphistry/compute/chain_specializations/admission.py
+++ b/graphistry/compute/chain_specializations/admission.py
@@ -99,9 +99,10 @@ def point_rows_admits(
         return None
     table, source = row.params.get("table"), row.params.get("source")
     kind = ASTNode if table == "nodes" else ASTEdge if table == "edges" else None
-    if kind is None or not isinstance(source, str) or not any(
+    joined = boundary == 3 and table == "nodes" and source is None and len(ops) == 5
+    if not joined and (kind is None or not isinstance(source, str) or not any(
         isinstance(op, kind) and op._name == source for op in ops[:boundary]
-    ):
+    )):
         return None
     if len(ops) > boundary + 1:
         projection = ops[-1]

--- a/graphistry/compute/chain_specializations/admission.py
+++ b/graphistry/compute/chain_specializations/admission.py
@@ -5,7 +5,7 @@ what the dispatcher admits."""
 
 from typing import Dict, Literal, Optional, Sequence, Tuple, TYPE_CHECKING
 
-from graphistry.compute.ast import ASTObject, ASTNode, ASTEdge
+from graphistry.compute.ast import ASTObject, ASTNode, ASTEdge, ASTCall
 from graphistry.compute.chain_fast_paths import SeedRowsHow
 from graphistry.compute.typing import ArrayNamespace, DataFrameT
 
@@ -75,3 +75,36 @@ def _indexed_kernel_admits(
     if n_frontier >= frac * adj.n_keys:
         return False
     return gathered_edges is not None and len(gathered_edges) < frac * n_edges
+
+
+def point_rows_admits(
+    ops: Sequence[ASTObject], engine: "Engine", start_nodes: Optional[DataFrameT],
+) -> Optional[int]:
+    boundary = 1 if len(ops) in (2, 3) else 3 if len(ops) in (4, 5) else None
+    if boundary is None or native_fast_path_admits(ops[:boundary], engine, start_nodes) is None:
+        return None
+    first = ops[0]
+    if not isinstance(first, ASTNode) or not first.filter_dict:
+        return None
+    for op in ops[:boundary]:
+        filters = op.filter_dict if isinstance(op, ASTNode) else op.edge_match if isinstance(op, ASTEdge) else None
+        if filters and any(not isinstance(v, (str, int, float, bool)) for v in filters.values()):
+            return None
+    if boundary == 3:
+        edge = ops[1]
+        if not isinstance(edge, ASTEdge) or edge.direction == "undirected":
+            return None
+    row = ops[boundary]
+    if not isinstance(row, ASTCall) or row.function != "rows" or set(row.params) - {"table", "source"}:
+        return None
+    table, source = row.params.get("table"), row.params.get("source")
+    kind = ASTNode if table == "nodes" else ASTEdge if table == "edges" else None
+    if kind is None or not isinstance(source, str) or not any(
+        isinstance(op, kind) and op._name == source for op in ops[:boundary]
+    ):
+        return None
+    if len(ops) > boundary + 1:
+        projection = ops[-1]
+        if not isinstance(projection, ASTCall) or projection.function != "select" or set(projection.params) != {"items"}:
+            return None
+    return boundary

--- a/graphistry/compute/chain_specializations/hotpaths.py
+++ b/graphistry/compute/chain_specializations/hotpaths.py
@@ -211,6 +211,12 @@ def _seeded_typed_return_dst_pandas_cudf(
         # destination nodes: real nodes that are to-endpoints of the surviving edges
         dstn = nodes_df[nodes_df[node].isin(edges[to_col].dropna())]
     assert edges is not None and dstn is not None  # both branches above assign
+    if direction == "forward":
+        from graphistry.compute.gfql.row.pipeline import RowPipelineMixin
+        if RowPipelineMixin._gfql_has_edge_destination_label_col(e1, dstn.columns) is not None:
+            dstn = RowPipelineMixin._gfql_disambiguate_has_edge_destination_nodes(
+                dstn, node_id_col=node, edge_op=e1, next_node_op=n2,
+            )
     if n2f:
         for k, v in n2f.items():
             dstn = dstn[dstn[k] == v]

--- a/graphistry/compute/chain_specializations/hotpaths.py
+++ b/graphistry/compute/chain_specializations/hotpaths.py
@@ -13,7 +13,7 @@ from graphistry.compute.chain_fast_paths import (
     _resident_node_id_index, _resident_seed_indexes, _seed_node_rows, _seeded_scalar_filters,
     _tag_fast_path_aliases, SeededReturn,
 )
-from graphistry.compute.typing import ArrayLike, ArrayNamespace, DataFrameT, SeriesT
+from graphistry.compute.typing import ArrayLike, ArrayNamespace, DataFrameT, ScalarFilterDict, SeriesT
 from .admission import _indexed_kernel_admits, native_fast_path_admits
 
 if TYPE_CHECKING:
@@ -125,7 +125,7 @@ def _seeded_typed_hop_pandas_cudf(
 
 
 def _seeded_hop_tail_numeric(
-    cand: DataFrameT, edges: DataFrameT, n2f: Dict[str, object], src: str, dst: str, to_col: str, node: str,
+    cand: DataFrameT, edges: DataFrameT, n2f: ScalarFilterDict, src: str, dst: str, to_col: str, node: str,
 ) -> Optional[Tuple[DataFrameT, DataFrameT]]:
     """Validate numeric endpoints using arrays native to the frame backend."""
     import pandas as pd

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -13,6 +13,7 @@ from graphistry.compute.chain_fast_paths import (
     _seeded_scalar_filters, _tag_fast_path_alias_frames, _verify_scalar_filters_on_hit,
 )
 from graphistry.compute.typing import DataFrameT, SeriesT
+from graphistry.compute.util import generate_safe_column_name_from
 from graphistry.compute.gfql.identifiers import is_bare_identifier
 from graphistry.compute.gfql.expr_parser import (
     FunctionCall, GFQLExprParseError, Identifier, PropertyAccessExpr, parse_expr,
@@ -41,7 +42,7 @@ def _point_hop_rows(
     if indexed_seed is None:
         return None
     seed, _ = indexed_seed
-    matched_edges = _index_edge_rows(adj, seed[node], xp, engine, edges)
+    matched_edges = _index_edge_rows(adj, seed[node], xp, engine, edges, preserve_input_order=True)
     if matched_edges is None:
         return None
     if edge_filter:
@@ -142,6 +143,13 @@ def _project_joined_point_columns(
         return None
     from_col, to_col = ((g._source, g._destination) if edge.direction == "forward"
                         else (g._destination, g._source))
+    if len(seed) > 1 and len(edges) > 1:
+        seed_order = generate_safe_column_name_from("__gfql_seed_order__", list(seed.columns) + list(edges.columns))
+        edge_order = generate_safe_column_name_from("__gfql_edge_order__", list(edges.columns) + [seed_order])
+        ranks = seed[[g._node]].assign(**{seed_order: range(len(seed))}).set_index(g._node)[seed_order]
+        positions = ranks.reindex(edges[from_col]).reset_index(drop=True)
+        ordered = edges.reset_index(drop=True).assign(**{seed_order: positions, edge_order: range(len(edges))})
+        edges = ordered.sort_values([seed_order, edge_order]).drop(columns=[seed_order, edge_order])
     frames = {n0._name: (seed, from_col), n2._name: (tail, to_col)}
     aligned: Dict[str, DataFrameT] = {}
     pandas_positions: Dict[str, List[int]] = {}

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -1,8 +1,8 @@
 """Resident-index point queries that produce a row table."""
-import re
 from typing import Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
+from pandas.api.extensions import ExtensionArray
 
 from graphistry.Engine import Engine
 from graphistry.Plottable import Plottable
@@ -13,13 +13,12 @@ from graphistry.compute.chain_fast_paths import (
     _seeded_scalar_filters, _tag_fast_path_alias_frames, _verify_scalar_filters_on_hit,
 )
 from graphistry.compute.typing import DataFrameT, SeriesT
+from graphistry.compute.gfql.identifiers import is_bare_identifier
+from graphistry.compute.gfql.expr_parser import (
+    FunctionCall, GFQLExprParseError, Identifier, PropertyAccessExpr, parse_expr,
+)
 from .admission import point_rows_admits
 
-_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z_0-9]*\Z")
-_COALESCE_PROPERTIES = re.compile(
-    r"(?i:coalesce)\s*\(\s*([A-Za-z_][A-Za-z_0-9]*\.[A-Za-z_][A-Za-z_0-9]*)"
-    r"\s*,\s*([A-Za-z_][A-Za-z_0-9]*\.[A-Za-z_][A-Za-z_0-9]*)\s*\)"
-)
 
 
 def _point_hop_rows(
@@ -69,8 +68,8 @@ def _point_column(
 ) -> Optional[str]:
     if expr in frame.columns:
         return None if expr in aliases else expr
-    if (expr.startswith(source + ".") and _IDENTIFIER.fullmatch(source)
-            and _IDENTIFIER.fullmatch(expr[len(source) + 1:])
+    if (expr.startswith(source + ".") and is_bare_identifier(source)
+            and is_bare_identifier(expr[len(source) + 1:])
             and expr[len(source) + 1:] in frame.columns):
         column = expr[len(source) + 1:]
         if column in aliases and (column != source or str(frame[column].dtype).startswith("bool")):
@@ -99,10 +98,25 @@ def _project_point_columns(
         if column is not None:
             projected[alias] = frame[column]
             continue
-        coalesce = _COALESCE_PROPERTIES.fullmatch(expr)
-        if coalesce is None:
+        # Reuse the evaluator's cached grammar; this route supports two bare properties.
+        if not expr.lower().startswith("coalesce") or "`" in expr:
             return None
-        left_col, right_col = (_point_column(frame, term, source, aliases) for term in coalesce.groups())
+        try:
+            coalesce = parse_expr(expr)
+        except GFQLExprParseError:
+            return None
+        if (not isinstance(coalesce, FunctionCall) or coalesce.name.lower() != "coalesce"
+                or coalesce.distinct or len(coalesce.args) != 2):
+            return None
+        terms: List[str] = []
+        for argument in coalesce.args:
+            if (not isinstance(argument, PropertyAccessExpr)
+                    or not isinstance(argument.value, Identifier)
+                    or not is_bare_identifier(argument.value.name)
+                    or not is_bare_identifier(argument.property)):
+                return None
+            terms.append(f"{argument.value.name}.{argument.property}")
+        left_col, right_col = (_point_column(frame, term, source, aliases) for term in terms)
         if left_col is None or right_col is None:
             return None
         left, right = frame[left_col], frame[right_col]
@@ -131,7 +145,7 @@ def _project_joined_point_columns(
     frames = {n0._name: (seed, from_col), n2._name: (tail, to_col)}
     aligned: Dict[str, DataFrameT] = {}
     pandas_positions: Dict[str, List[int]] = {}
-    pandas_columns: Dict[str, object] = {}
+    pandas_columns: Dict[str, ExtensionArray] = {}
     projected: Dict[str, SeriesT] = {}
     for item in items:
         if not isinstance(item, (tuple, list)) or len(item) != 2:
@@ -140,7 +154,7 @@ def _project_joined_point_columns(
         if not isinstance(output, str) or not output or not isinstance(expression, str):
             return None
         parts = expression.split(".")
-        if len(parts) != 2 or not all(_IDENTIFIER.fullmatch(part) for part in parts):
+        if len(parts) != 2 or not all(is_bare_identifier(part) for part in parts):
             return None
         alias, column = parts
         if alias == edge._name and column in edges.columns:
@@ -199,7 +213,7 @@ def _try_point_rows(
     table, source = row.params["table"], row.params.get("source")
     if validate_schema:
         from graphistry.compute.chain import Chain
-        Chain(ops, validate=False).validate(collect_all=False)
+        Chain(ops)
         validate_chain_schema(g, ops, collect_all=False)
     adapter = _RowPipelineAdapter(g)
     adapter._gfql_rows_base_graph = g

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -57,7 +57,10 @@ def _point_hop_rows(
         tail = _verify_scalar_filters_on_hit(tail, tail_filter, engine)
         if tail is None:
             return None
-    matched_edges = matched_edges[matched_edges[to_col].isin(tail[node].dropna())]
+    if len(tail) == 0:
+        matched_edges = matched_edges.iloc[:0]
+    elif len(matched_edges) != 1:
+        matched_edges = matched_edges[matched_edges[to_col].isin(tail[node].dropna())]
     return seed, tail, matched_edges
 
 
@@ -150,10 +153,13 @@ def _project_joined_point_columns(
             # Align properties to edge rows to retain repeated bindings.
             if isinstance(frame, pd.DataFrame):
                 if alias not in pandas_positions:
-                    positions = pd.Index(frame[g._node]).get_indexer(edges[endpoint])
-                    if (positions < 0).any():
-                        return None
-                    pandas_positions[alias] = positions.tolist()
+                    if len(frame) == 1:
+                        pandas_positions[alias] = [0] * len(edges)
+                    else:
+                        positions = pd.Index(frame[g._node]).get_indexer(edges[endpoint])
+                        if (positions < 0).any():
+                            return None
+                        pandas_positions[alias] = positions.tolist()
                 pandas_columns[output] = frame[column].array.take(pandas_positions[alias])
                 continue
             if alias not in aligned:
@@ -252,8 +258,10 @@ def _try_point_rows(
         selected = projected
     elif boundary == 1:
         collides = source in selected.columns
-        if not collides and selected.columns[0] == g._node:
+        if not collides:
             selected = selected.reset_index(drop=True)
+            if selected.columns[0] != g._node:
+                selected.insert(0, g._node, selected.pop(g._node))
             selected.insert(1, source, True)
         else:
             selected = selected.drop(columns=[source]) if collides else selected

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -1,5 +1,8 @@
 """Resident-index point queries that produce a row table."""
-from typing import List, Literal, Optional, Tuple
+import re
+from typing import Dict, List, Literal, Optional, Sequence, Tuple
+
+import pandas as pd
 
 from graphistry.Engine import Engine
 from graphistry.Plottable import Plottable
@@ -9,8 +12,10 @@ from graphistry.compute.chain_fast_paths import (
     _resident_node_id_index, _resident_seed_indexes, _seed_node_rows_from_index,
     _seeded_scalar_filters, _tag_fast_path_alias_frames, _verify_scalar_filters_on_hit,
 )
-from graphistry.compute.typing import DataFrameT
+from graphistry.compute.typing import DataFrameT, SeriesT
 from .admission import point_rows_admits
+
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z_0-9]*\Z")
 
 
 def _point_hop_rows(
@@ -54,13 +59,41 @@ def _point_hop_rows(
         selected = seed[seed[node].isin(matched_edges[from_col].dropna())]
     else:
         selected = tail
-    original = matched_edges if table == "edges" else selected
-    tagged_nodes, tagged_edges = _tag_fast_path_alias_frames(
-        selected, matched_edges, n0._name, edge._name, n2._name, src, dst, node, edge.direction)
-    if g._edge is not None and tagged_edges.columns[0] != g._edge:
-        tagged_edges = tagged_edges[[g._edge, *[c for c in tagged_edges.columns if c != g._edge]]]
-    result = tagged_edges if table == "edges" else tagged_nodes
-    return _restore_point_source(result, original, source), tagged_edges
+    return selected, matched_edges
+
+
+def _project_point_columns(
+    frame: DataFrameT, projection: ASTCall, source: str, aliases: Sequence[str],
+) -> Optional[DataFrameT]:
+    items = projection.params.get("items")
+    if not isinstance(items, list):
+        return None
+    projected: Dict[str, SeriesT] = {}
+    for item in items:
+        if isinstance(item, str):
+            alias, expr = item, item
+        elif isinstance(item, (tuple, list)) and len(item) == 2:
+            alias, expr = item
+        else:
+            return None
+        if not isinstance(alias, str) or not alias or not isinstance(expr, str):
+            return None
+        if expr in frame.columns:
+            if expr in aliases:
+                return None
+            column = expr
+        elif (expr.startswith(source + ".") and _IDENTIFIER.fullmatch(source)
+              and _IDENTIFIER.fullmatch(expr[len(source) + 1:])
+              and expr[len(source) + 1:] in frame.columns):
+            column = expr[len(source) + 1:]
+            if column in aliases and (column != source or str(frame[column].dtype).startswith("bool")):
+                return None
+        else:
+            return None
+        projected[alias] = frame[column]
+    if isinstance(frame, pd.DataFrame):
+        return pd.DataFrame(projected, index=frame.index)
+    return frame.assign(**projected)[list(projected)]
 
 
 def _restore_point_source(result: DataFrameT, original: DataFrameT, source: str) -> DataFrameT:
@@ -95,6 +128,10 @@ def _try_point_rows(
     adapter._gfql_rows_base_graph = g
     if adapter._edges is not None and g._edge is not None and adapter._edges.columns[0] != g._edge:
         adapter._edges = adapter._edges.iloc[:0][[g._edge, *[c for c in adapter._edges.columns if c != g._edge]]]
+    projection = ops[-1] if len(ops) > boundary + 1 else None
+    assert projection is None or isinstance(projection, ASTCall)
+    aliases = [op._name for op in ops[:boundary] if op._name is not None]
+    edge_alias = None
     if boundary == 1:
         filters = _seeded_scalar_filters(n0.filter_dict, g._nodes)
         if not filters:
@@ -105,6 +142,26 @@ def _try_point_rows(
             return None
         selected, _ = indexed_seed
         original = selected
+    else:
+        edge, n2 = ops[1:3]
+        assert isinstance(edge, ASTEdge) and isinstance(n2, ASTNode)
+        gathered = _point_hop_rows(g, n0, edge, n2, table, source)
+        if gathered is None:
+            return None
+        selected, adapter._edges = gathered
+        edge_alias = edge._name
+        original = adapter._edges if table == "edges" else selected
+    projected = _project_point_columns(original, projection, source, aliases) if projection is not None else None
+    if projected is not None:
+        adapter._node = g._node if g._node in original.columns else None
+        adapter._edge = g._edge if g._edge in original.columns else None
+        if edge_alias is not None:
+            assert adapter._edges is not None and g._source is not None and g._destination is not None
+            _, adapter._edges = _tag_fast_path_alias_frames(
+                g._nodes.iloc[:0], adapter._edges.iloc[:0], None, edge_alias, None,
+                g._source, g._destination, g._node, "forward")
+        selected = projected
+    elif boundary == 1:
         collides = source in selected.columns
         if not collides and selected.columns[0] == g._node:
             selected = selected.reset_index(drop=True)
@@ -118,14 +175,18 @@ def _try_point_rows(
     else:
         edge, n2 = ops[1:3]
         assert isinstance(edge, ASTEdge) and isinstance(n2, ASTNode)
-        gathered = _point_hop_rows(g, n0, edge, n2, table, source)
-        if gathered is None:
-            return None
-        selected, adapter._edges = gathered
+        assert adapter._edges is not None and g._source is not None and g._destination is not None
+        tagged_nodes, adapter._edges = _tag_fast_path_alias_frames(
+            selected, adapter._edges, n0._name, edge_alias, n2._name,
+            g._source, g._destination, g._node, edge.direction)
+        selected = adapter._edges if table == "edges" else tagged_nodes
+        selected = _restore_point_source(selected, original, source)
+    if adapter._edges is not None and g._edge is not None and adapter._edges.columns[0] != g._edge:
+        adapter._edges = adapter._edges[[g._edge, *[c for c in adapter._edges.columns if c != g._edge]]]
+        if projected is None and table == "edges":
+            selected = selected[[g._edge, *[c for c in selected.columns if c != g._edge]]]
     out = row_table(adapter, selected)
-    if len(ops) > boundary + 1:
-        projection = ops[-1]
-        assert isinstance(projection, ASTCall)
+    if projection is not None and projected is None:
         out = _RowPipelineAdapter(out).select(projection.params["items"])
     _record_native_seed_lane(g._nodes, seam="point_rows", reason="served", hop_count=boundary // 2,
                              public_seed_scan=g._node not in (n0.filter_dict or {}))

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -1,6 +1,6 @@
 """Resident-index point queries that produce a row table."""
 import re
-from typing import Dict, List, Literal, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 
@@ -20,8 +20,7 @@ _IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z_0-9]*\Z")
 
 def _point_hop_rows(
     g: Plottable, n0: ASTNode, edge: ASTEdge, n2: ASTNode,
-    table: Literal["nodes", "edges"], source: str,
-) -> Optional[Tuple[DataFrameT, DataFrameT]]:
+) -> Optional[Tuple[DataFrameT, DataFrameT, DataFrameT]]:
     nodes, edges = g._nodes, g._edges
     node, src, dst = g._node, g._source, g._destination
     if nodes is None or edges is None or node is None or src is None or dst is None:
@@ -46,7 +45,7 @@ def _point_hop_rows(
         matched_edges = _verify_scalar_filters_on_hit(matched_edges, edge_filter, engine)
         if matched_edges is None:
             return None
-    from_col, to_col = (src, dst) if edge.direction == "forward" else (dst, src)
+    to_col = dst if edge.direction == "forward" else src
     tail = _index_node_rows(nid, matched_edges[to_col], xp, engine, nodes)
     if tail is None:
         return None
@@ -55,11 +54,7 @@ def _point_hop_rows(
         if tail is None:
             return None
     matched_edges = matched_edges[matched_edges[to_col].isin(tail[node].dropna())]
-    if table == "nodes" and source == n0._name:
-        selected = seed[seed[node].isin(matched_edges[from_col].dropna())]
-    else:
-        selected = tail
-    return selected, matched_edges
+    return seed, tail, matched_edges
 
 
 def _project_point_columns(
@@ -96,6 +91,55 @@ def _project_point_columns(
     return frame.assign(**projected)[list(projected)]
 
 
+def _project_joined_point_columns(
+    g: Plottable, seed: DataFrameT, tail: DataFrameT, edges: DataFrameT,
+    n0: ASTNode, edge: ASTEdge, n2: ASTNode, projection: ASTCall,
+) -> Optional[DataFrameT]:
+    if g._node is None or g._source is None or g._destination is None:
+        return None
+    aliases = [op._name for op in (n0, edge, n2) if op._name is not None]
+    if n0._name is None or n2._name is None or any(
+        alias in seed.columns or alias in edges.columns for alias in aliases
+    ):
+        return None
+    items = projection.params.get("items")
+    if not isinstance(items, list) or not items:
+        return None
+    from_col, to_col = ((g._source, g._destination) if edge.direction == "forward"
+                        else (g._destination, g._source))
+    frames = {n0._name: (seed, from_col), n2._name: (tail, to_col)}
+    aligned: Dict[str, DataFrameT] = {}
+    projected: Dict[str, SeriesT] = {}
+    for item in items:
+        if not isinstance(item, (tuple, list)) or len(item) != 2:
+            return None
+        output, expression = item
+        if not isinstance(output, str) or not output or not isinstance(expression, str):
+            return None
+        parts = expression.split(".")
+        if len(parts) != 2 or not all(_IDENTIFIER.fullmatch(part) for part in parts):
+            return None
+        alias, column = parts
+        if alias == edge._name and column in edges.columns:
+            values = edges[column].reset_index(drop=True)
+        elif alias in frames and column in frames[alias][0].columns:
+            frame, endpoint = frames[alias]
+            # Align properties to edge rows to retain repeated bindings.
+            if alias not in aligned:
+                if isinstance(frame, pd.DataFrame):
+                    positions = pd.Index(frame[g._node]).get_indexer(edges[endpoint])
+                    aligned[alias] = frame.iloc[positions].reset_index(drop=True)
+                else:
+                    aligned[alias] = frame.set_index(g._node, drop=False).reindex(edges[endpoint]).reset_index(drop=True)
+            values = aligned[alias][column]
+        else:
+            return None
+        projected[output] = values
+    if isinstance(seed, pd.DataFrame):
+        return pd.DataFrame(projected)
+    return edges.iloc[:, :0].reset_index(drop=True).assign(**projected)
+
+
 def _restore_point_source(result: DataFrameT, original: DataFrameT, source: str) -> DataFrameT:
     if source not in original.columns or str(original[source].dtype).startswith("bool"):
         return result
@@ -119,7 +163,7 @@ def _try_point_rows(
 
     n0, row = ops[0], ops[boundary]
     assert isinstance(n0, ASTNode) and isinstance(row, ASTCall)
-    table, source = row.params["table"], row.params["source"]
+    table, source = row.params["table"], row.params.get("source")
     if validate_schema:
         from graphistry.compute.chain import Chain
         Chain(ops).validate(collect_all=False)
@@ -145,12 +189,30 @@ def _try_point_rows(
     else:
         edge, n2 = ops[1:3]
         assert isinstance(edge, ASTEdge) and isinstance(n2, ASTNode)
-        gathered = _point_hop_rows(g, n0, edge, n2, table, source)
+        gathered = _point_hop_rows(g, n0, edge, n2)
         if gathered is None:
             return None
-        selected, adapter._edges = gathered
+        seed, tail, adapter._edges = gathered
+        if source is None:
+            assert projection is not None
+            joined = _project_joined_point_columns(g, seed, tail, adapter._edges, n0, edge, n2, projection)
+            if joined is None:
+                return None
+            assert g._source is not None and g._destination is not None
+            _, adapter._edges = _tag_fast_path_alias_frames(
+                g._nodes.iloc[:0], adapter._edges.iloc[:0], None, edge._name, None,
+                g._source, g._destination, g._node, edge.direction)
+            if g._edge is not None:
+                adapter._edges = adapter._edges[[g._edge, *[c for c in adapter._edges.columns if c != g._edge]]]
+            adapter._node = adapter._edge = adapter._source = adapter._destination = None
+            _record_native_seed_lane(g._nodes, seam="point_rows", reason="served", hop_count=1,
+                                     public_seed_scan=g._node not in (n0.filter_dict or {}))
+            return clear_row_exec_context(row_table(adapter, joined))
+        from_col = g._source if edge.direction == "forward" else g._destination
+        selected = seed[seed[g._node].isin(adapter._edges[from_col].dropna())] if source == n0._name else tail
         edge_alias = edge._name
         original = adapter._edges if table == "edges" else selected
+    assert isinstance(source, str)
     projected = _project_point_columns(original, projection, source, aliases) if projection is not None else None
     if projected is not None:
         adapter._node = g._node if g._node in original.columns else None

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -1,0 +1,132 @@
+"""Resident-index point queries that produce a row table."""
+from typing import List, Literal, Optional, Tuple
+
+from graphistry.Engine import Engine
+from graphistry.Plottable import Plottable
+from graphistry.compute.ast import ASTCall, ASTEdge, ASTNode, ASTObject
+from graphistry.compute.chain_fast_paths import (
+    _index_edge_rows, _index_node_rows, _record_native_seed_lane,
+    _resident_node_id_index, _resident_seed_indexes, _seed_node_rows_from_index,
+    _seeded_scalar_filters, _tag_fast_path_alias_frames, _verify_scalar_filters_on_hit,
+)
+from graphistry.compute.typing import DataFrameT
+from .admission import point_rows_admits
+
+
+def _point_hop_rows(
+    g: Plottable, n0: ASTNode, edge: ASTEdge, n2: ASTNode,
+    table: Literal["nodes", "edges"], source: str,
+) -> Optional[Tuple[DataFrameT, DataFrameT]]:
+    nodes, edges = g._nodes, g._edges
+    node, src, dst = g._node, g._source, g._destination
+    if nodes is None or edges is None or node is None or src is None or dst is None:
+        return None
+    seed_filter = _seeded_scalar_filters(n0.filter_dict, nodes)
+    tail_filter = _seeded_scalar_filters(n2.filter_dict, nodes)
+    edge_filter = _seeded_scalar_filters(edge.edge_match, edges)
+    if not seed_filter or tail_filter is None or edge_filter is None:
+        return None
+    ctx = _resident_seed_indexes(g, nodes, edges, node, src, dst, edge.direction)
+    if ctx is None:
+        return None
+    nid, adj, xp, engine = ctx
+    indexed_seed = _seed_node_rows_from_index(g, nodes, seed_filter, node, (nid, xp, engine), n0.filter_dict)
+    if indexed_seed is None:
+        return None
+    seed, _ = indexed_seed
+    matched_edges = _index_edge_rows(adj, seed[node], xp, engine, edges)
+    if matched_edges is None:
+        return None
+    if edge_filter:
+        matched_edges = _verify_scalar_filters_on_hit(matched_edges, edge_filter, engine)
+        if matched_edges is None:
+            return None
+    from_col, to_col = (src, dst) if edge.direction == "forward" else (dst, src)
+    tail = _index_node_rows(nid, matched_edges[to_col], xp, engine, nodes)
+    if tail is None:
+        return None
+    if tail_filter:
+        tail = _verify_scalar_filters_on_hit(tail, tail_filter, engine)
+        if tail is None:
+            return None
+    matched_edges = matched_edges[matched_edges[to_col].isin(tail[node].dropna())]
+    if table == "nodes" and source == n0._name:
+        selected = seed[seed[node].isin(matched_edges[from_col].dropna())]
+    else:
+        selected = tail
+    original = matched_edges if table == "edges" else selected
+    tagged_nodes, tagged_edges = _tag_fast_path_alias_frames(
+        selected, matched_edges, n0._name, edge._name, n2._name, src, dst, node, edge.direction)
+    if g._edge is not None and tagged_edges.columns[0] != g._edge:
+        tagged_edges = tagged_edges[[g._edge, *[c for c in tagged_edges.columns if c != g._edge]]]
+    result = tagged_edges if table == "edges" else tagged_nodes
+    return _restore_point_source(result, original, source), tagged_edges
+
+
+def _restore_point_source(result: DataFrameT, original: DataFrameT, source: str) -> DataFrameT:
+    if source not in original.columns or str(original[source].dtype).startswith("bool"):
+        return result
+    from graphistry.compute.gfql.identifiers import shadow_restore_column
+    out = result.reset_index(drop=True)
+    out[shadow_restore_column(source)] = original[source].reset_index(drop=True)
+    return out
+
+
+def _try_point_rows(
+    g: Plottable, ops: List[ASTObject], engine: Engine,
+    start_nodes: Optional[DataFrameT] = None, validate_schema: bool = True,
+) -> Optional[Plottable]:
+    boundary = point_rows_admits(ops, engine, start_nodes)
+    if boundary is None or g._nodes is None or g._node is None:
+        return None
+    from graphistry.compute.gfql.row.pipeline import _RowPipelineAdapter
+    from graphistry.compute.gfql.row.frame_ops import row_table
+    from graphistry.compute.gfql.exec_context import clear_row_exec_context
+    from graphistry.compute.validate.validate_schema import validate_chain_schema
+
+    n0, row = ops[0], ops[boundary]
+    assert isinstance(n0, ASTNode) and isinstance(row, ASTCall)
+    table, source = row.params["table"], row.params["source"]
+    if validate_schema:
+        from graphistry.compute.chain import Chain
+        Chain(ops).validate(collect_all=False)
+        validate_chain_schema(g, ops, collect_all=False)
+    adapter = _RowPipelineAdapter(g)
+    adapter._gfql_rows_base_graph = g
+    if adapter._edges is not None and g._edge is not None and adapter._edges.columns[0] != g._edge:
+        adapter._edges = adapter._edges.iloc[:0][[g._edge, *[c for c in adapter._edges.columns if c != g._edge]]]
+    if boundary == 1:
+        filters = _seeded_scalar_filters(n0.filter_dict, g._nodes)
+        if not filters:
+            return None
+        ctx = _resident_node_id_index(g, g._nodes, g._node)
+        indexed_seed = _seed_node_rows_from_index(g, g._nodes, filters, g._node, ctx, n0.filter_dict)
+        if indexed_seed is None:
+            return None
+        selected, _ = indexed_seed
+        original = selected
+        collides = source in selected.columns
+        if not collides and selected.columns[0] == g._node:
+            selected = selected.reset_index(drop=True)
+            selected.insert(1, source, True)
+        else:
+            selected = selected.drop(columns=[source]) if collides else selected
+            selected = selected.assign(**{source: True})
+            rest = [c for c in selected.columns if c not in (g._node, source)]
+            selected = selected[[g._node, *rest, source] if collides else [g._node, source, *rest]]
+        selected = _restore_point_source(selected, original, source)
+    else:
+        edge, n2 = ops[1:3]
+        assert isinstance(edge, ASTEdge) and isinstance(n2, ASTNode)
+        gathered = _point_hop_rows(g, n0, edge, n2, table, source)
+        if gathered is None:
+            return None
+        selected, adapter._edges = gathered
+    out = row_table(adapter, selected)
+    if len(ops) > boundary + 1:
+        projection = ops[-1]
+        assert isinstance(projection, ASTCall)
+        out = _RowPipelineAdapter(out).select(projection.params["items"])
+    _record_native_seed_lane(g._nodes, seam="point_rows", reason="served", hop_count=boundary // 2,
+                             public_seed_scan=g._node not in (n0.filter_dict or {}))
+    return clear_row_exec_context(out)

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -16,6 +16,10 @@ from graphistry.compute.typing import DataFrameT, SeriesT
 from .admission import point_rows_admits
 
 _IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z_0-9]*\Z")
+_COALESCE_PROPERTIES = re.compile(
+    r"(?i:coalesce)\s*\(\s*([A-Za-z_][A-Za-z_0-9]*\.[A-Za-z_][A-Za-z_0-9]*)"
+    r"\s*,\s*([A-Za-z_][A-Za-z_0-9]*\.[A-Za-z_][A-Za-z_0-9]*)\s*\)"
+)
 
 
 def _point_hop_rows(
@@ -57,6 +61,21 @@ def _point_hop_rows(
     return seed, tail, matched_edges
 
 
+def _point_column(
+    frame: DataFrameT, expr: str, source: str, aliases: Sequence[str],
+) -> Optional[str]:
+    if expr in frame.columns:
+        return None if expr in aliases else expr
+    if (expr.startswith(source + ".") and _IDENTIFIER.fullmatch(source)
+            and _IDENTIFIER.fullmatch(expr[len(source) + 1:])
+            and expr[len(source) + 1:] in frame.columns):
+        column = expr[len(source) + 1:]
+        if column in aliases and (column != source or str(frame[column].dtype).startswith("bool")):
+            return None
+        return column
+    return None
+
+
 def _project_point_columns(
     frame: DataFrameT, projection: ASTCall, source: str, aliases: Sequence[str],
 ) -> Optional[DataFrameT]:
@@ -73,19 +92,18 @@ def _project_point_columns(
             return None
         if not isinstance(alias, str) or not alias or not isinstance(expr, str):
             return None
-        if expr in frame.columns:
-            if expr in aliases:
-                return None
-            column = expr
-        elif (expr.startswith(source + ".") and _IDENTIFIER.fullmatch(source)
-              and _IDENTIFIER.fullmatch(expr[len(source) + 1:])
-              and expr[len(source) + 1:] in frame.columns):
-            column = expr[len(source) + 1:]
-            if column in aliases and (column != source or str(frame[column].dtype).startswith("bool")):
-                return None
-        else:
+        column = _point_column(frame, expr, source, aliases)
+        if column is not None:
+            projected[alias] = frame[column]
+            continue
+        coalesce = _COALESCE_PROPERTIES.fullmatch(expr)
+        if coalesce is None:
             return None
-        projected[alias] = frame[column]
+        left_col, right_col = (_point_column(frame, term, source, aliases) for term in coalesce.groups())
+        if left_col is None or right_col is None:
+            return None
+        left, right = frame[left_col], frame[right_col]
+        projected[alias] = left.where(~left.isna(), right)
     if isinstance(frame, pd.DataFrame):
         return pd.DataFrame(projected, index=frame.index)
     return frame.assign(**projected)[list(projected)]
@@ -109,6 +127,8 @@ def _project_joined_point_columns(
                         else (g._destination, g._source))
     frames = {n0._name: (seed, from_col), n2._name: (tail, to_col)}
     aligned: Dict[str, DataFrameT] = {}
+    pandas_positions: Dict[str, List[int]] = {}
+    pandas_columns: Dict[str, object] = {}
     projected: Dict[str, SeriesT] = {}
     for item in items:
         if not isinstance(item, (tuple, list)) or len(item) != 2:
@@ -121,22 +141,29 @@ def _project_joined_point_columns(
             return None
         alias, column = parts
         if alias == edge._name and column in edges.columns:
+            if isinstance(edges, pd.DataFrame):
+                pandas_columns[output] = edges[column].array
+                continue
             values = edges[column].reset_index(drop=True)
         elif alias in frames and column in frames[alias][0].columns:
             frame, endpoint = frames[alias]
             # Align properties to edge rows to retain repeated bindings.
-            if alias not in aligned:
-                if isinstance(frame, pd.DataFrame):
+            if isinstance(frame, pd.DataFrame):
+                if alias not in pandas_positions:
                     positions = pd.Index(frame[g._node]).get_indexer(edges[endpoint])
-                    aligned[alias] = frame.iloc[positions].reset_index(drop=True)
-                else:
-                    aligned[alias] = frame.set_index(g._node, drop=False).reindex(edges[endpoint]).reset_index(drop=True)
+                    if (positions < 0).any():
+                        return None
+                    pandas_positions[alias] = positions.tolist()
+                pandas_columns[output] = frame[column].array.take(pandas_positions[alias])
+                continue
+            if alias not in aligned:
+                aligned[alias] = frame.set_index(g._node, drop=False).reindex(edges[endpoint]).reset_index(drop=True)
             values = aligned[alias][column]
         else:
             return None
         projected[output] = values
     if isinstance(seed, pd.DataFrame):
-        return pd.DataFrame(projected)
+        return pd.DataFrame(pandas_columns)
     return edges.iloc[:, :0].reset_index(drop=True).assign(**projected)
 
 

--- a/graphistry/compute/chain_specializations/point_rows.py
+++ b/graphistry/compute/chain_specializations/point_rows.py
@@ -199,7 +199,7 @@ def _try_point_rows(
     table, source = row.params["table"], row.params.get("source")
     if validate_schema:
         from graphistry.compute.chain import Chain
-        Chain(ops).validate(collect_all=False)
+        Chain(ops, validate=False).validate(collect_all=False)
         validate_chain_schema(g, ops, collect_all=False)
     adapter = _RowPipelineAdapter(g)
     adapter._gfql_rows_base_graph = g

--- a/graphistry/compute/dataframe/join.py
+++ b/graphistry/compute/dataframe/join.py
@@ -3,7 +3,7 @@
 import operator
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 
-from graphistry.Engine import Engine, POLARS_ENGINES
+from graphistry.Engine import Engine, POLARS_ENGINES, is_polars_df
 from graphistry.compute.gfql.cypher.reentry.naming import REENTRY_HIDDEN_COLUMN_PREFIX
 from graphistry.compute.gfql.identifiers import HIDDEN_ALIAS_COLUMN_PREFIX
 from graphistry.compute.typing import DataFrameT, DomainT
@@ -320,8 +320,9 @@ def estimate_inner_join_rows(
 
         from graphistry.compute.gfql.lazy import collect
 
-        left_counts = left.lazy().group_by(left_on).len().rename({"len": left_n})  # type: ignore[operator]
-        right_counts = right.lazy().group_by(right_on).len().rename({"len": right_n})  # type: ignore[operator]
+        assert is_polars_df(left) and is_polars_df(right)
+        left_counts = left.lazy().group_by(left_on).len().rename({"len": left_n})
+        right_counts = right.lazy().group_by(right_on).len().rename({"len": right_n})
         value = collect(
             left_counts.join(right_counts, left_on=left_on, right_on=right_on, how="inner")
             .select((pl.col(left_n) * pl.col(right_n)).sum())
@@ -366,8 +367,9 @@ def path_ordered_expand_join(
 
         from graphistry.compute.gfql.lazy import collect
 
+        assert is_polars_df(state) and is_polars_df(step)
         joined = (
-            state.lazy().with_row_index(path_order_col)  # type: ignore[operator]
+            state.lazy().with_row_index(path_order_col)
             .join(step.lazy(), left_on=current_col, right_on=from_col, how="inner")
             .sort([path_order_col, *tiebreak_cols])
             .drop(current_col)
@@ -410,13 +412,17 @@ def semijoin_by_column(
 ) -> DataFrameT:
     """Rows of ``frame`` whose ``left_on`` value appears in ``keys[right_on]``."""
     if engine in POLARS_ENGINES:
-        return cast(
-            DataFrameT,
-            frame.join(  # type: ignore[call-arg]
-                keys.select(right_on).unique(),  # type: ignore[operator]
-                left_on=left_on,
-                right_on=right_on,
-                how="semi",  # type: ignore[arg-type]
-            ),
-        )
+        import polars as pl
+
+        if isinstance(frame, pl.DataFrame):
+            assert isinstance(keys, pl.DataFrame)
+            return cast(DataFrameT, frame.join(
+                keys.select(right_on).unique(),
+                left_on=left_on, right_on=right_on, how="semi",
+            ))
+        assert isinstance(frame, pl.LazyFrame) and isinstance(keys, pl.LazyFrame)
+        return cast(DataFrameT, frame.join(
+            keys.select(right_on).unique(),
+            left_on=left_on, right_on=right_on, how="semi",
+        ))
     return cast(DataFrameT, frame[frame[left_on].isin(keys[right_on])])

--- a/graphistry/compute/dataframe/join.py
+++ b/graphistry/compute/dataframe/join.py
@@ -1,7 +1,7 @@
 """Join-related engine-polymorphic DataFrame operations."""
 
 import operator
-from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 from graphistry.Engine import Engine, POLARS_ENGINES, is_polars_df
 from graphistry.compute.gfql.cypher.reentry.naming import REENTRY_HIDDEN_COLUMN_PREFIX
@@ -414,15 +414,18 @@ def semijoin_by_column(
     if engine in POLARS_ENGINES:
         import polars as pl
 
+        result: Union[pl.DataFrame, pl.LazyFrame]
         if isinstance(frame, pl.DataFrame):
             assert isinstance(keys, pl.DataFrame)
-            return cast(DataFrameT, frame.join(
+            result = frame.join(
                 keys.select(right_on).unique(),
                 left_on=left_on, right_on=right_on, how="semi",
-            ))
-        assert isinstance(frame, pl.LazyFrame) and isinstance(keys, pl.LazyFrame)
-        return cast(DataFrameT, frame.join(
-            keys.select(right_on).unique(),
-            left_on=left_on, right_on=right_on, how="semi",
-        ))
+            )
+        else:
+            assert isinstance(frame, pl.LazyFrame) and isinstance(keys, pl.LazyFrame)
+            result = frame.join(
+                keys.select(right_on).unique(),
+                left_on=left_on, right_on=right_on, how="semi",
+            )
+        return cast(DataFrameT, result)
     return cast(DataFrameT, frame[frame[left_on].isin(keys[right_on])])

--- a/graphistry/compute/dataframe/join.py
+++ b/graphistry/compute/dataframe/join.py
@@ -318,13 +318,14 @@ def estimate_inner_join_rows(
     if engine in POLARS_ENGINES:
         import polars as pl
 
-        left_counts = left.group_by(left_on).len().rename({"len": left_n})  # type: ignore[operator]
-        right_counts = right.group_by(right_on).len().rename({"len": right_n})  # type: ignore[operator]
-        value = (
+        from graphistry.compute.gfql.lazy import collect
+
+        left_counts = left.lazy().group_by(left_on).len().rename({"len": left_n})  # type: ignore[operator]
+        right_counts = right.lazy().group_by(right_on).len().rename({"len": right_n})  # type: ignore[operator]
+        value = collect(
             left_counts.join(right_counts, left_on=left_on, right_on=right_on, how="inner")
             .select((pl.col(left_n) * pl.col(right_n)).sum())
-            .item()
-        )
+        ).item()
         return 0 if value is None else int(value)
 
     left_counts = left.groupby(left_on, sort=False).size().reset_index()
@@ -363,9 +364,11 @@ def path_ordered_expand_join(
     if engine in POLARS_ENGINES:
         import polars as pl
 
+        from graphistry.compute.gfql.lazy import collect
+
         joined = (
-            state.with_row_index(path_order_col)  # type: ignore[operator]
-            .join(step, left_on=current_col, right_on=from_col, how="inner")
+            state.lazy().with_row_index(path_order_col)  # type: ignore[operator]
+            .join(step.lazy(), left_on=current_col, right_on=from_col, how="inner")
             .sort([path_order_col, *tiebreak_cols])
             .drop(current_col)
             .rename({to_col: current_col})
@@ -374,7 +377,7 @@ def path_ordered_expand_join(
             joined = joined.with_columns(pl.col(current_col).alias(alias))
         return cast(
             DataFrameT,
-            joined.drop([col for col in drop_after if col in joined.columns]),
+            collect(joined.drop([col for col in drop_after if col in joined.collect_schema().names()])),
         )
 
     import numpy as np

--- a/graphistry/compute/gfql/agg_types.py
+++ b/graphistry/compute/gfql/agg_types.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
     import polars as pl
 
     from graphistry.compute.gfql.cypher.ast import CypherScalar
-    from graphistry.compute.typing import SeriesT
+    from graphistry.compute.typing import PolarsDType, SeriesT
 
 
 #: Aggregates Cypher restricts to ``INTEGER | FLOAT | DURATION`` (``mean`` spells ``avg``).
@@ -111,7 +111,7 @@ def agg_result_is_integer(func: str, input_is_boolean: bool) -> bool:
     return func == "sum" and input_is_boolean
 
 
-def polars_agg_result_cast(func: str, input_dtype: "Optional[pl.DataType]") -> "Optional[pl.DataType]":
+def polars_agg_result_cast(func: str, input_dtype: "Optional[pl.DataType]") -> "Optional[PolarsDType]":
     """The dtype polars' own aggregate kernel does NOT produce, or ``None`` when it conforms.
 
     Polars answers EVERY ``count()`` with ``UInt32`` and ``sum()`` over ``Boolean`` with ``UInt32``,

--- a/graphistry/compute/gfql/cypher/result_postprocess.py
+++ b/graphistry/compute/gfql/cypher/result_postprocess.py
@@ -277,7 +277,8 @@ def _projection_alias_rows(
 
 
 def apply_result_projection(
-    result: Plottable, projection: ResultProjectionPlan, *, structured: bool = True
+    result: Plottable, projection: ResultProjectionPlan, *, structured: bool = True,
+    source_node_id: Optional[str] = None,
 ) -> Plottable:
     """Project Cypher RETURN columns onto ``result._nodes``.
 
@@ -294,7 +295,9 @@ def apply_result_projection(
     rows_df = result._nodes
     if is_polars_df(rows_df):
         from graphistry.compute.gfql.lazy.engine.polars.projection import apply_result_projection_polars
-        return apply_result_projection_polars(result, projection, structured=structured)
+        return apply_result_projection_polars(
+            result, projection, structured=structured, source_node_id=source_node_id,
+        )
     return _apply_result_projection_pandas(result, projection, structured=structured)
 
 

--- a/graphistry/compute/gfql/index/bindings.py
+++ b/graphistry/compute/gfql/index/bindings.py
@@ -105,6 +105,8 @@ def _integer_index(index: Union[AdjacencyIndex, NodeIdIndex, NodePropIndex]) -> 
     keys are declined rather than risking a lossy compare.
     """
     key_ok = index.keys_sorted.dtype.kind in ("i", "u")
+    if isinstance(index, NodeIdIndex) and index.source_ref is not None:
+        key_ok = key_ok and index.n_nodes == len(index.source_ref)
     if not isinstance(index, AdjacencyIndex):
         return key_ok
     return key_ok and index.other_values.dtype.kind in ("i", "u")

--- a/graphistry/compute/gfql/index/bindings.py
+++ b/graphistry/compute/gfql/index/bindings.py
@@ -295,6 +295,10 @@ def _seed_rows_via_property_index(
         if value is None or isinstance(value, bool) or not isinstance(value, Integral):
             continue
         index = registry.get_node_prop_valid(column, nodes, engine)
+        if index is None and engine in (Engine.POLARS, Engine.POLARS_GPU):
+            # Both Polars targets index the same host frame with NumPy arrays.
+            other = Engine.POLARS_GPU if engine == Engine.POLARS else Engine.POLARS
+            index = registry.get_node_prop_valid(column, nodes, other)
         if index is None:
             continue
         values = xp.asarray([value])

--- a/graphistry/compute/gfql/index/build.py
+++ b/graphistry/compute/gfql/index/build.py
@@ -39,6 +39,26 @@ def _csr_from_keys(keys: ArrayLike, xp: ArrayNamespace) -> Tuple[ArrayLike, Arra
     return unique_keys, group_offsets, row_positions
 
 
+
+def _non_null_id_rows(
+    frame: DataFrameT, columns: Sequence[str], engine: Engine, xp: ArrayNamespace,
+) -> Tuple[DataFrameT, Optional[ArrayLike]]:
+    """Remove unlinked null ids before conversion; retain original row positions."""
+    if engine in (Engine.POLARS, Engine.POLARS_GPU):
+        import polars as pl
+
+        valid = frame.select(pl.all_horizontal(pl.col(column).is_not_null() for column in columns)).to_series()
+        if bool(valid.all()):
+            return frame, None
+        positions = xp.nonzero(valid.to_numpy())[0]
+        return frame.filter(valid), positions
+    valid = frame[list(columns)].notna().all(axis=1)
+    if bool(valid.all()):
+        return frame, None
+    mask = valid.values if engine == Engine.CUDF else valid.to_numpy()
+    return frame[valid], xp.nonzero(mask)[0]
+
+
 def build_adjacency_index(
     edges: DataFrameT,
     kind: AdjacencyIndexKind,
@@ -49,9 +69,15 @@ def build_adjacency_index(
     fingerprint_cols: Tuple[str, ...],
 ) -> AdjacencyIndex:
     xp, backend = array_namespace(engine)
-    keys = col_to_array(edges, key_col, engine)
-    other_values = col_to_array(edges, other_col, engine)
+    valid_edges, original_rows = _non_null_id_rows(edges, (key_col, other_col), engine, xp)
+    keys = col_to_array(valid_edges, key_col, engine)
+    other_values = col_to_array(valid_edges, other_col, engine)
     unique_keys, group_offsets, row_positions = _csr_from_keys(keys, xp)
+    if original_rows is not None:
+        row_positions = original_rows[row_positions]
+        neighbors = xp.zeros(len(edges), dtype=other_values.dtype)
+        neighbors[original_rows] = other_values
+        other_values = neighbors
     return AdjacencyIndex(
         kind=kind,
         key_col=key_col,
@@ -65,7 +91,7 @@ def build_adjacency_index(
         engine=engine,
         fingerprint=frame_fingerprint(edges, fingerprint_cols, engine),
         source_ref=cast(DataFrameT, edges),
-        n_edges=int(keys.shape[0]),
+        n_edges=len(edges),
         n_keys=int(unique_keys.shape[0]),
     )
 
@@ -75,7 +101,7 @@ def build_node_id_index(
     node_col: str,
     engine: Engine,
 ) -> Optional[NodeIdIndex]:
-    """Sorted node-id -> first-row index, or None when node ids are NOT unique.
+    """Sorted non-null node-id -> first-row index; None for duplicate non-null ids.
 
     ``_csr_from_keys`` returns ``row_positions`` of length E (all rows, grouped by
     key), but a node-id lookup indexes it with a *unique-key* searchsorted position
@@ -86,12 +112,15 @@ def build_node_id_index(
     caller falls back to the correct ``select_by_ids`` isin path. (Regression guard: a non-unique
     node-id index dropped reached nodes / emitted unrelated rows.)"""
     xp, backend = array_namespace(engine)
-    keys = col_to_array(nodes, node_col, engine)
+    valid_nodes, original_rows = _non_null_id_rows(nodes, (node_col,), engine, xp)
+    keys = col_to_array(valid_nodes, node_col, engine)
     unique_keys, group_offsets, row_positions = _csr_from_keys(keys, xp)
     n_keys = int(unique_keys.shape[0])
     if n_keys != int(keys.shape[0]):
         return None  # duplicate node ids -> not a valid unique index; scan fallback
     first_row_per_key = row_positions[group_offsets[:-1]]  # length U, aligned to keys
+    if original_rows is not None:
+        first_row_per_key = original_rows[first_row_per_key]
     return NodeIdIndex(
         key_col=node_col,
         keys_sorted=unique_keys,
@@ -395,6 +424,9 @@ def build_degree_fact(
         if col not in edges.columns:
             return None
     if hi < lo or (hi - lo + 1) > _MAX_DEGREE_SPAN:
+        return None
+    _, null_free_rows = _non_null_id_rows(edges, (src_col, dst_col), engine, xp)
+    if null_free_rows is not None:
         return None
     src = col_to_array(edges, src_col, engine)
     dst = col_to_array(edges, dst_col, engine)

--- a/graphistry/compute/gfql/index/degrees.py
+++ b/graphistry/compute/gfql/index/degrees.py
@@ -60,6 +60,13 @@ def degrees_from_index(
     ii = _valid_adjacency(registry, EDGE_IN_ADJ, edges_df, cols, engine)
     if oi is None or ii is None:
         return None
+    if int(oi.row_positions.shape[0]) != oi.n_edges or int(ii.row_positions.shape[0]) != ii.n_edges:
+        return None  # Endpoint groupby counts null links that traversal must omit.
+    if engine in (Engine.POLARS, Engine.POLARS_GPU):
+        if nodes_df.get_column(node_col).null_count():
+            return None
+    elif bool(nodes_df[node_col].isna().any()):
+        return None
     xp, _ = array_namespace(engine)
     node_ids = col_to_array(nodes_df, node_col, engine)
     out_deg = _degree_for_nodes(oi, node_ids, xp)   # out = src-keyed adjacency

--- a/graphistry/compute/gfql/index/engine_arrays.py
+++ b/graphistry/compute/gfql/index/engine_arrays.py
@@ -45,11 +45,21 @@ def col_to_array(df: DataFrameT, col: str, engine: Engine) -> ArrayLike:
     if engine == Engine.CUDF:
         # cudf Series -> cupy array (stays on device)
         return cast(ArrayLike, df[col].values)
-    return cast(ArrayLike, df[col].to_numpy())
+    series = df[col]
+    dtype = series.dtype
+    if dtype.kind in ("i", "u"):
+        values = series.to_numpy(dtype=f"{dtype.kind}{dtype.itemsize}")
+    else:
+        values = series.to_numpy()
+    return cast(ArrayLike, values)
 
 
 def ids_to_array(ids: DataFrameT, col: str, engine: Engine) -> ArrayLike:
     """Frontier ids (a frame/Series) -> backend array, matching index backend."""
+    if engine in (Engine.POLARS, Engine.POLARS_GPU):
+        ids = ids.drop_nulls(subset=[col])
+    else:
+        ids = ids.dropna(subset=[col])
     return col_to_array(ids, col, engine)
 
 

--- a/graphistry/compute/gfql/index/engine_arrays.py
+++ b/graphistry/compute/gfql/index/engine_arrays.py
@@ -64,7 +64,12 @@ def take_rows(df: DataFrameT, positions: ArrayLike, engine: Engine) -> DataFrame
         import numpy as np
 
         idx = np.asarray(positions)
-        return cast(DataFrameT, df[idx])
+        position = int(idx[0]) if idx.ndim == 1 and idx.size == 1 and idx.dtype.kind in "iu" else None
+        if position is not None and 0 <= position < len(df):
+            result = df.slice(position, 1)
+        else:
+            result = df[idx]
+        return cast(DataFrameT, result)
     # pandas / cudf: iloc accepts numpy (pandas) or cupy (cudf) int arrays
     return cast(DataFrameT, df.iloc[positions])
 

--- a/graphistry/compute/gfql/index/engine_arrays.py
+++ b/graphistry/compute/gfql/index/engine_arrays.py
@@ -8,7 +8,7 @@ CSR + searchsorted gather runs on:
 - cudf    -> cupy device arrays, ``df.iloc`` to gather rows
 - polars / polars-gpu -> numpy host arrays, polars row-gather
 
-Vectorization-first: no per-element Python work, no ``.to_list()`` ping-pong.
+Bulk operations stay vectorized; bounded CPU gathers can reuse row slices.
 """
 from __future__ import annotations
 
@@ -67,6 +67,20 @@ def take_rows(df: DataFrameT, positions: ArrayLike, engine: Engine) -> DataFrame
         position = int(idx[0]) if idx.ndim == 1 and idx.size == 1 and idx.dtype.kind in "iu" else None
         if position is not None and 0 <= position < len(df):
             result = df.slice(position, 1)
+        elif engine == Engine.POLARS and idx.ndim == 1 and 2 <= idx.size <= 8 and idx.dtype.kind in "iu":
+            # Scheduling a tiny gather can cost more than assembling its slices.
+            values = idx.tolist()
+            if all(0 <= value < len(df) for value in values):
+                if all(value == values[0] + offset for offset, value in enumerate(values)):
+                    result = df.slice(values[0], len(values))
+                elif df.width <= 32:
+                    result = df.slice(values[0], 1)
+                    for value in values[1:]:
+                        result.vstack(df.slice(value, 1), in_place=True)
+                else:
+                    result = df[idx]
+            else:
+                result = df[idx]
         else:
             result = df[idx]
         return cast(DataFrameT, result)

--- a/graphistry/compute/gfql/index/registry.py
+++ b/graphistry/compute/gfql/index/registry.py
@@ -57,8 +57,8 @@ class AdjacencyIndex:
     edge_id_col: Optional[str]  # edge-id binding if present (else row pos == id)
     keys_sorted: ArrayLike    # distinct key ids, ascending (len U)  [array]
     group_offsets: ArrayLike  # CSR offsets into row_positions (len U+1) [array]
-    row_positions: ArrayLike  # edge row indices grouped by key (len E) [array]
-    other_values: ArrayLike   # neighbor id per edge row, ORIGINAL order (len E) [array]
+    row_positions: ArrayLike  # non-null-link edge positions grouped by key (len <= E)
+    other_values: ArrayLike   # original-row neighbors (len E); only row_positions are valid
     backend: IndexBackend     # 'numpy' | 'cupy'
     engine: Engine
     fingerprint: FrameFingerprint = field(compare=False, default=(-1, (), ""))

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -1000,6 +1000,10 @@ def _chain_traversal_polars(self: Plottable, ops, start_nodes: Optional[Any] = N
     g = ensure_nodes_polars(self)
     assert g._node is not None and g._source is not None and g._destination is not None
     start_nodes = _align_seed_dtype(start_nodes, g._node, g._nodes)
+    if len(ops) == 1 and isinstance(ops[0], ASTNode):
+        # A node selection retains source rows, including duplicate and null IDs.
+        # Traversal's endpoint combine applies set semantics only when edges exist.
+        return _exec(ops[0], g, start_nodes, None)
     g, _endpoint_restore = _align_edge_endpoints(g, g._node, g._source, g._destination)
     if g._edge is None:
         EID = "__gfql_edge_index__"

--- a/graphistry/compute/gfql/lazy/engine/polars/chain.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain.py
@@ -19,6 +19,7 @@ from graphistry.compute.endpoint_utils import drop_null_endpoint_edges
 from graphistry.Plottable import Plottable
 from graphistry.compute.ast import ASTObject, ASTNode, ASTEdge
 from .chain_specializations.admission import polars_plain_single_hop_admits, polars_single_node_admits
+from .chain_specializations.point_rows import _try_point_rows_polars
 from .chain_specializations.hotpaths import _plain_seeded_index_hop_polars, _plain_single_hop_polars, _single_node_polars, _try_seeded_chain_polars
 
 if TYPE_CHECKING:
@@ -768,6 +769,10 @@ def chain_polars(self: Plottable, ops, start_nodes: Optional[Any] = None) -> Plo
                         suggestion="Use distinct alias names for each step in the chain",
                     )
                 _seen[_name] = _idx
+
+    point_rows = _try_point_rows_polars(self, ops, start_nodes)
+    if point_rows is not None:
+        return point_rows
 
     has_call = any(isinstance(op, ASTCall) for op in ops)
     has_traversal = any(isinstance(op, (ASTNode, ASTEdge)) for op in ops)

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py
@@ -3,6 +3,8 @@ the seeded lane. The dispatcher and the tests consult the same predicates."""
 
 from typing import Literal, Optional, Sequence
 
+from graphistry.compute.typing import DataFrameT
+
 from graphistry.compute.ast import ASTObject, ASTNode, ASTEdge
 
 
@@ -21,7 +23,7 @@ def _plain_edge(op: ASTObject) -> bool:
             and op.edge_query is None and not op.include_zero_hop_seed and not op.prune_to_endpoints)
 
 
-def polars_plain_single_hop_admits(ops: Sequence[ASTObject], start_nodes: Optional[object]) -> Optional[PolarsPlainSingleHopShape]:
+def polars_plain_single_hop_admits(ops: Sequence[ASTObject], start_nodes: Optional[DataFrameT]) -> Optional[PolarsPlainSingleHopShape]:
     """The polars chain's plain single-hop branch for ``ops``: ``"seeded-index"`` when the
     resident-index hop is consulted first (seed filter, no destination filter, directed),
     ``"skip-combine"`` when the one-hop endpoint filter serves it without the
@@ -41,7 +43,7 @@ def polars_plain_single_hop_admits(ops: Sequence[ASTObject], start_nodes: Option
     return "skip-combine" if (unconstrained or directed) else None
 
 
-def polars_single_node_admits(ops: Sequence[ASTObject], start_nodes: Optional[object]) -> bool:
+def polars_single_node_admits(ops: Sequence[ASTObject], start_nodes: Optional[DataFrameT]) -> bool:
     """Admit one node operation without a query, with or without start nodes."""
     if len(ops) != 1:
         return False

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from graphistry.compute.gfql.lazy.engine.polars.dtypes import PolarsFrame
 
 
-def _single_node_polars(g: Plottable, ops: Sequence[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
+def _single_node_polars(g: Plottable, ops: Sequence[ASTObject], start_nodes: Optional[DataFrameT] = None) -> Optional[Plottable]:
     """Select node rows, intersect start nodes, and attach the node alias marker."""
     import polars as pl
     from graphistry.Engine import Engine, EngineAbstract, df_to_engine

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
@@ -32,17 +32,17 @@ def _single_node_polars(g: Plottable, ops: Sequence[ASTObject], start_nodes: Opt
     import polars as pl
     from graphistry.Engine import Engine, EngineAbstract, df_to_engine
     from graphistry.compute.chain_specializations.hotpaths import _single_node_rows_via_index_or_filter
-    from graphistry.compute.gfql.lazy.engine.polars.chain import _align_seed_dtype, _bound_edge_endpoints, _semi
+    from graphistry.compute.gfql.lazy.engine.polars.chain import _align_seed_dtype, _bound_edge_endpoints, _exec
     op0 = ops[0]
     assert isinstance(op0, ASTNode)
     g0 = ensure_nodes_polars(g)
     nc = g0._node
     assert nc is not None
     edge_src, edge_dst = _bound_edge_endpoints(g)
-    nodes = _single_node_rows_via_index_or_filter(g0, op0, EngineAbstract.POLARS)
     if start_nodes is not None:
         seed = _align_seed_dtype(df_to_engine(start_nodes, Engine.POLARS), nc, g0._nodes)
-        nodes = _semi(nodes, seed, nc, nc)
+        return _exec(op0, g0, seed, None)
+    nodes = _single_node_rows_via_index_or_filter(g0, op0, EngineAbstract.POLARS)
     if op0._name is not None:
         nodes = nodes.with_columns(pl.lit(True).alias(op0._name))
     return g0.nodes(nodes, nc).edges(g0._edges.clear(), edge_src, edge_dst)
@@ -167,6 +167,14 @@ def _seeded_typed_return_dst_polars(
         dst_ids = edges.get_column(to_col).drop_nulls().unique()
         dstn = nodes_df.filter(pl.col(node).is_in(dst_ids.implode()))
     assert edges is not None and dstn is not None  # both branches above assign
+    if direction == "forward":
+        from graphistry.compute.gfql.row.pipeline import RowPipelineMixin
+        label_col = RowPipelineMixin._gfql_has_edge_destination_label_col(e1, dstn.columns)
+        if label_col is not None and not RowPipelineMixin._gfql_node_filter_has_label(n2.filter_dict):
+            dstn = dstn.filter(
+                ~pl.col(node).is_duplicated().any()
+                | pl.col(label_col).fill_null(False).cast(pl.Boolean)
+            )
     dstn = filter_by_dict_polars(dstn, n2.filter_dict)
     # A sole destination was selected from the sole surviving edge.
     if not (edges.height == 1 and dstn.height == 1):

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
@@ -171,7 +171,8 @@ def _seeded_typed_return_dst_polars(
     # drop dangling edges + dedup destination nodes (mirror the pandas tail)
     keep_ids = dstn.get_column(node).drop_nulls()
     edges = edges.filter(pl.col(to_col).is_in(keep_ids.implode()))
-    dstn = dstn.filter(pl.col(node).is_in(edges.get_column(to_col).implode())).unique(subset=[node], maintain_order=True)
+    # Every retained destination was gathered from these edges before its node filter.
+    dstn = dstn.unique(subset=[node], maintain_order=True)
     return dstn, edges, seed_nodes, kernel_admits
 
 

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py
@@ -168,11 +168,12 @@ def _seeded_typed_return_dst_polars(
         dstn = nodes_df.filter(pl.col(node).is_in(dst_ids.implode()))
     assert edges is not None and dstn is not None  # both branches above assign
     dstn = filter_by_dict_polars(dstn, n2.filter_dict)
-    # drop dangling edges + dedup destination nodes (mirror the pandas tail)
-    keep_ids = dstn.get_column(node).drop_nulls()
-    edges = edges.filter(pl.col(to_col).is_in(keep_ids.implode()))
-    # Every retained destination was gathered from these edges before its node filter.
-    dstn = dstn.unique(subset=[node], maintain_order=True)
+    # A sole destination was selected from the sole surviving edge.
+    if not (edges.height == 1 and dstn.height == 1):
+        keep_ids = dstn.get_column(node).drop_nulls()
+        edges = edges.filter(pl.col(to_col).is_in(keep_ids.implode()))
+    if dstn.height > 1:
+        dstn = dstn.unique(subset=[node], maintain_order=True)
     return dstn, edges, seed_nodes, kernel_admits
 
 
@@ -210,7 +211,10 @@ def _try_seeded_chain_polars(g: Plottable, ops: Sequence[ASTObject]) -> Optional
     _, kept_edges, _, _ = reduced
     if not isinstance(kept_edges, pl.DataFrame):
         return None
-    endpoint_ids = pl.concat([kept_edges.get_column(src), kept_edges.get_column(dst)]).drop_nulls().unique()
+    endpoint_ids = pl.concat([kept_edges.get_column(src), kept_edges.get_column(dst)])
+    # The index lookup deduplicates IDs; drop nulls before any scan fallback.
+    if endpoint_ids.null_count():
+        endpoint_ids = endpoint_ids.drop_nulls().unique()
     nid_ctx = _resident_node_id_index(g, nodes, node)
     result_nodes = None
     if nid_ctx is not None:
@@ -224,13 +228,21 @@ def _try_seeded_chain_polars(g: Plottable, ops: Sequence[ASTObject]) -> Optional
         return None
     from_col, to_col = (src, dst) if e1.direction == "forward" else (dst, src)
     flags = [
-        pl.col(node).is_in(kept_edges.get_column(endpoint).implode()).fill_null(False).alias(name)
+        pl.col(node).is_in(pl.lit(kept_edges.get_column(endpoint)).implode()).fill_null(False).alias(name)
         for name, endpoint in ((n0._name, from_col), (n2._name, to_col)) if name is not None
     ]
     if flags:
-        result_nodes = result_nodes.with_columns(flags)
+        if kept_edges.height == 1 and result_nodes.get_column(node).null_count() == 0:
+            result_nodes = result_nodes.clone()
+            for name, endpoint in ((n0._name, from_col), (n2._name, to_col)):
+                if name is not None:
+                    matches = result_nodes.get_column(node) == kept_edges.get_column(endpoint).item(0)
+                    result_nodes.insert_column(result_nodes.width, matches.alias(name))
+        else:
+            result_nodes = result_nodes.with_columns(flags)
     if e1._name is not None:
-        kept_edges = kept_edges.with_columns(pl.lit(True).alias(e1._name))
+        kept_edges = kept_edges.clone()
+        kept_edges.insert_column(kept_edges.width, pl.Series(e1._name, [True]).new_from_index(0, kept_edges.height))
     _record_indexed_traversal(
         seam="native_seeded_hop", engine=ctx[3], served=True, reason="served", hop_count=1,
         public_seed_scan=node not in n0.filter_dict, hop_details=[{"hop": 1}])

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -1,11 +1,12 @@
 """Resident-index source rows for native Polars point queries."""
-import re
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 
 if TYPE_CHECKING:
     import polars as pl
 
 from graphistry.Plottable import Plottable
+from graphistry.compute.typing import DataFrameT
+from graphistry.compute.gfql.identifiers import is_bare_identifier
 from graphistry.compute.ast import ASTCall, ASTEdge, ASTNode, ASTObject
 from graphistry.compute.chain_fast_paths import (
     _index_edge_rows, _index_node_rows, _record_native_seed_lane,
@@ -72,10 +73,10 @@ def _joined_projection(
         output, expr = item
         if not isinstance(output, str) or not isinstance(expr, str):
             return None
-        match = re.fullmatch(r"([A-Za-z_][A-Za-z_0-9]*)\.([A-Za-z_][A-Za-z_0-9]*)", expr)
-        if match is None:
+        parts = expr.split(".")
+        if len(parts) != 2 or not all(is_bare_identifier(part) for part in parts):
             return None
-        alias, column = match.groups()
+        alias, column = parts
         if alias not in frames or column not in frames[alias].columns:
             return None
         if singleton:
@@ -125,7 +126,7 @@ def _with_singleton_aliases(
     return out
 
 
-def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
+def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Optional[DataFrameT] = None) -> Optional[Plottable]:
     import polars as pl
     from graphistry.compute.gfql.index.bindings import _policy_is_active
     from graphistry.compute.gfql.lazy import active_target, ExecutionTarget

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -162,7 +162,8 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
     else:
         edge, tail_op = ops[1:3]
         assert isinstance(edge, ASTEdge) and isinstance(tail_op, ASTNode)
-        if nodes.schema[node] != edges.schema[src] or nodes.schema[node] != edges.schema[dst]:
+        node_dtype = nodes.get_column(node).dtype
+        if node_dtype != edges.get_column(src).dtype or node_dtype != edges.get_column(dst).dtype:
             return None
         ctx = _resident_seed_indexes(g, nodes, edges, node, src, dst, edge.direction)
         if ctx is None:

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -53,7 +53,8 @@ def _joined_projection(
     import polars as pl
     from graphistry.compute.gfql.lazy import collect
     from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import _select_emits_temporal_constructor_text
-    if seed.get_column(node).n_unique() != seed.height or tail.get_column(node).n_unique() != tail.height:
+    if ((seed.height > 1 and seed.get_column(node).n_unique() != seed.height)
+            or (tail.height > 1 and tail.get_column(node).n_unique() != tail.height)):
         return None
     items = projection.params.get("items")
     if not isinstance(items, list) or not items:

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -1,5 +1,9 @@
 """Resident-index source rows for native Polars point queries."""
-from typing import List, Optional, Sequence
+import re
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
+
+if TYPE_CHECKING:
+    import polars as pl
 
 from graphistry.Plottable import Plottable
 from graphistry.compute.ast import ASTCall, ASTEdge, ASTNode, ASTObject
@@ -28,13 +32,63 @@ def polars_point_rows_admits(ops: Sequence[ASTObject]) -> Optional[int]:
             or set(row.params) - {"table", "source"} or row.params.get("table") != "nodes"):
         return None
     source = row.params.get("source")
-    if not isinstance(source, str) or not any(isinstance(op, ASTNode) and op._name == source for op in ops[:boundary]):
+    joined = boundary == 3 and source is None and len(ops) == 5
+    if joined:
+        if not all(isinstance(op, ASTNode) and isinstance(op._name, str) for op in ops[:boundary:2]):
+            return None
+    elif not isinstance(source, str) or not any(isinstance(op, ASTNode) and op._name == source for op in ops[:boundary]):
         return None
     if len(ops) > boundary + 1:
         projection = ops[-1]
         if not isinstance(projection, ASTCall) or projection.function != "select" or set(projection.params) != {"items"}:
             return None
     return boundary
+
+
+def _joined_projection(
+    seed: "pl.DataFrame", edges: "pl.DataFrame", tail: "pl.DataFrame",
+    node: str, from_col: str, to_col: str, seed_alias: str, tail_alias: str,
+    edge_alias: Optional[str], projection: ASTCall,
+) -> "Optional[pl.DataFrame]":
+    import polars as pl
+    from graphistry.compute.gfql.lazy import collect
+    from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import _select_emits_temporal_constructor_text
+    if seed.get_column(node).n_unique() != seed.height or tail.get_column(node).n_unique() != tail.height:
+        return None
+    items = projection.params.get("items")
+    if not isinstance(items, list) or not items:
+        return None
+    frames = {seed_alias: seed, tail_alias: tail}
+    if edge_alias is not None:
+        frames[edge_alias] = edges
+    properties: Dict[str, List[pl.Expr]] = {alias: [] for alias in frames}
+    outputs = []
+    for index, item in enumerate(items):
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            return None
+        output, expr = item
+        if not isinstance(output, str) or not isinstance(expr, str):
+            return None
+        match = re.fullmatch(r"([A-Za-z_][A-Za-z_0-9]*)\.([A-Za-z_][A-Za-z_0-9]*)", expr)
+        if match is None:
+            return None
+        alias, column = match.groups()
+        if alias not in frames or column not in frames[alias].columns:
+            return None
+        temporary = f"_value_{index}"
+        properties[alias].append(pl.col(column).alias(temporary))
+        outputs.append(pl.col(temporary).alias(output))
+    if len({item[0] for item in items}) != len(items):
+        return None
+    left = seed.lazy().select(pl.col(node).alias("_seed"), *properties[seed_alias]).with_row_index("_seed_order")
+    step = edges.lazy().select(
+        pl.col(from_col).alias("_seed"), pl.col(to_col).alias("_tail"),
+        *([] if edge_alias is None else properties[edge_alias]),
+    ).with_row_index("_edge_order")
+    right = tail.lazy().select(pl.col(node).alias("_tail"), *properties[tail_alias])
+    result = collect(left.join(step, on="_seed", how="inner").join(right, on="_tail", how="inner")
+                     .sort(["_seed_order", "_edge_order"]).select(outputs))
+    return None if _select_emits_temporal_constructor_text(result) else result
 
 
 def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
@@ -59,7 +113,7 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
         return None
     n0, row = ops[0], ops[boundary]
     assert isinstance(n0, ASTNode) and isinstance(row, ASTCall) and n0.filter_dict
-    source = row.params["source"]
+    source = row.params.get("source")
     nid_ctx = _resident_node_id_index(g, nodes, node)
     if nid_ctx is None:
         return None
@@ -69,6 +123,7 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
         return None
     seed, _ = seed_result
     if boundary == 1:
+        assert isinstance(source, str)
         selected = seed.with_columns(pl.lit(True).alias(source))
         kept_edges = edges.clear()
     else:
@@ -89,6 +144,20 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
             return None
         tail = filter_by_dict_polars(tail, tail_op.filter_dict)
         kept_edges = kept_edges.filter(pl.col(to_col).is_in(tail.get_column(node).implode()))
+        if source is None:
+            projection = ops[-1]
+            assert isinstance(projection, ASTCall) and isinstance(n0._name, str) and isinstance(tail_op._name, str)
+            selected_joined = _joined_projection(seed, kept_edges, tail, node, from_col, to_col,
+                                                 n0._name, tail_op._name, edge._name, projection)
+            if selected_joined is None:
+                return None
+            if edge._name is not None:
+                kept_edges = kept_edges.with_columns(pl.lit(True).alias(edge._name))
+            adapter = _RowPipelineAdapter(g.edges(kept_edges))
+            adapter._node = adapter._edge = adapter._source = adapter._destination = None
+            _record_native_seed_lane(nodes, seam="point_rows", reason="served", hop_count=1,
+                                     public_seed_scan=node not in n0.filter_dict)
+            return clear_row_exec_context(row_table(adapter, selected_joined))
         selected = tail if source == tail_op._name else seed.filter(pl.col(node).is_in(kept_edges.get_column(from_col).implode()))
         selected = selected.with_columns([
             pl.col(node).is_in(kept_edges.get_column(endpoint).implode()).fill_null(False).alias(alias)

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -1,0 +1,109 @@
+"""Resident-index source rows for native Polars point queries."""
+from typing import List, Optional, Sequence
+
+from graphistry.Plottable import Plottable
+from graphistry.compute.ast import ASTCall, ASTEdge, ASTNode, ASTObject
+from graphistry.compute.chain_fast_paths import (
+    _index_edge_rows, _index_node_rows, _record_native_seed_lane,
+    _resident_node_id_index, _resident_seed_indexes, _seed_node_rows_from_index,
+)
+from .admission import polars_seeded_lane_admits
+
+
+def polars_point_rows_admits(ops: Sequence[ASTObject]) -> Optional[int]:
+    boundary = 1 if len(ops) in (2, 3) else 3 if len(ops) in (4, 5) else None
+    if boundary is None:
+        return None
+    first = ops[0]
+    if not isinstance(first, ASTNode) or first.query is not None or not first.filter_dict:
+        return None
+    if boundary == 3 and not polars_seeded_lane_admits(ops[:3]):
+        return None
+    for op in ops[:boundary]:
+        filters = op.filter_dict if isinstance(op, ASTNode) else op.edge_match if isinstance(op, ASTEdge) else None
+        if filters and any(not isinstance(value, (str, int, float, bool)) for value in filters.values()):
+            return None
+    row = ops[boundary]
+    if (not isinstance(row, ASTCall) or row.function != "rows"
+            or set(row.params) - {"table", "source"} or row.params.get("table") != "nodes"):
+        return None
+    source = row.params.get("source")
+    if not isinstance(source, str) or not any(isinstance(op, ASTNode) and op._name == source for op in ops[:boundary]):
+        return None
+    if len(ops) > boundary + 1:
+        projection = ops[-1]
+        if not isinstance(projection, ASTCall) or projection.function != "select" or set(projection.params) != {"items"}:
+            return None
+    return boundary
+
+
+def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
+    import polars as pl
+    from graphistry.compute.gfql.index.bindings import _policy_is_active
+    from graphistry.compute.gfql.lazy import active_target, ExecutionTarget
+    from graphistry.compute.gfql.exec_context import clear_row_exec_context
+    from graphistry.compute.gfql.row.frame_ops import row_table
+    from graphistry.compute.gfql.row.pipeline import _RowPipelineAdapter
+    from graphistry.compute.gfql.lazy.engine.polars.predicates import filter_by_dict_polars
+    from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import select_polars
+
+    boundary = polars_point_rows_admits(ops)
+    if boundary is None or start_nodes is not None or _policy_is_active() or active_target() == ExecutionTarget.GPU:
+        return None
+    nodes, edges = g._nodes, g._edges
+    node, src, dst = g._node, g._source, g._destination
+    if not isinstance(nodes, pl.DataFrame) or not isinstance(edges, pl.DataFrame) or node is None or src is None or dst is None:
+        return None
+    aliases = [op._name for op in ops[:boundary] if op._name is not None]
+    if len(aliases) != len(set(aliases)) or any(alias in nodes.columns or alias in edges.columns for alias in aliases):
+        return None
+    n0, row = ops[0], ops[boundary]
+    assert isinstance(n0, ASTNode) and isinstance(row, ASTCall) and n0.filter_dict
+    source = row.params["source"]
+    nid_ctx = _resident_node_id_index(g, nodes, node)
+    if nid_ctx is None:
+        return None
+    nid, xp, engine = nid_ctx
+    seed_result = _seed_node_rows_from_index(g, nodes, n0.filter_dict, node, nid_ctx, n0.filter_dict)
+    if seed_result is None:
+        return None
+    seed, _ = seed_result
+    if boundary == 1:
+        selected = seed.with_columns(pl.lit(True).alias(source))
+        kept_edges = edges.clear()
+    else:
+        edge, tail_op = ops[1:3]
+        assert isinstance(edge, ASTEdge) and isinstance(tail_op, ASTNode)
+        if nodes.schema[node] != edges.schema[src] or nodes.schema[node] != edges.schema[dst]:
+            return None
+        ctx = _resident_seed_indexes(g, nodes, edges, node, src, dst, edge.direction)
+        if ctx is None:
+            return None
+        gathered_edges = _index_edge_rows(ctx[1], seed.get_column(node), xp, engine, edges, preserve_input_order=True)
+        if not isinstance(gathered_edges, pl.DataFrame):
+            return None
+        kept_edges = filter_by_dict_polars(gathered_edges, edge.edge_match)
+        from_col, to_col = (src, dst) if edge.direction == "forward" else (dst, src)
+        tail = _index_node_rows(nid, kept_edges.get_column(to_col), xp, engine, nodes, preserve_input_order=True)
+        if tail is None:
+            return None
+        tail = filter_by_dict_polars(tail, tail_op.filter_dict)
+        kept_edges = kept_edges.filter(pl.col(to_col).is_in(tail.get_column(node).implode()))
+        selected = tail if source == tail_op._name else seed.filter(pl.col(node).is_in(kept_edges.get_column(from_col).implode()))
+        selected = selected.with_columns([
+            pl.col(node).is_in(kept_edges.get_column(endpoint).implode()).fill_null(False).alias(alias)
+            for alias, endpoint in ((n0._name, from_col), (tail_op._name, to_col)) if alias is not None
+        ])
+        if edge._name is not None:
+            kept_edges = kept_edges.with_columns(pl.lit(True).alias(edge._name))
+    out = row_table(_RowPipelineAdapter(g.edges(kept_edges)), selected)
+    if len(ops) > boundary + 1:
+        projection = ops[-1]
+        assert isinstance(projection, ASTCall)
+        projected = select_polars(out, projection.params["items"])
+        if projected is None:
+            return None
+        out = projected
+    _record_native_seed_lane(nodes, seam="point_rows", reason="served", hop_count=boundary // 2,
+                             public_seed_scan=node not in n0.filter_dict)
+    return clear_row_exec_context(out)

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -102,6 +102,28 @@ def _joined_projection(
     return None if _select_emits_temporal_constructor_text(result) else result
 
 
+def _with_true_alias(frame: "pl.DataFrame", alias: str) -> "pl.DataFrame":
+    """Append a Boolean alias without changing the input frame."""
+    import polars as pl
+    out = frame.clone()
+    out.insert_column(out.width, pl.Series(alias, [True]).new_from_index(0, frame.height))
+    return out
+
+
+def _with_singleton_aliases(
+    frame: "pl.DataFrame", seed: "pl.DataFrame", tail: "pl.DataFrame", node: str,
+    first: Optional[str], last: Optional[str],
+) -> "pl.DataFrame":
+    """Attach alias flags to one selected node from single-row endpoints."""
+    import polars as pl
+    out = frame.clone()
+    for alias, endpoint in ((first, seed), (last, tail)):
+        if alias is not None:
+            matches = frame.get_column(node).equals(endpoint.get_column(node), null_equal=False)
+            out.insert_column(out.width, pl.Series(alias, [matches]))
+    return out
+
+
 def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Optional[object] = None) -> Optional[Plottable]:
     import polars as pl
     from graphistry.compute.gfql.index.bindings import _policy_is_active
@@ -135,7 +157,7 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
     seed, _ = seed_result
     if boundary == 1:
         assert isinstance(source, str)
-        selected = seed.with_columns(pl.lit(True).alias(source))
+        selected = _with_true_alias(seed, source)
         kept_edges = edges.clear()
     else:
         edge, tail_op = ops[1:3]
@@ -154,7 +176,9 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
         if tail is None:
             return None
         tail = filter_by_dict_polars(tail, tail_op.filter_dict)
-        kept_edges = kept_edges.filter(pl.col(to_col).is_in(tail.get_column(node).implode()))
+        # A single gathered tail is the endpoint of the single surviving edge.
+        if not (kept_edges.height == 1 and tail.height == 1):
+            kept_edges = kept_edges.filter(pl.col(to_col).is_in(tail.get_column(node).implode()))
         if source is None:
             projection = ops[-1]
             assert isinstance(projection, ASTCall) and isinstance(n0._name, str) and isinstance(tail_op._name, str)
@@ -163,19 +187,27 @@ def _try_point_rows_polars(g: Plottable, ops: List[ASTObject], start_nodes: Opti
             if selected_joined is None:
                 return None
             if edge._name is not None:
-                kept_edges = kept_edges.with_columns(pl.lit(True).alias(edge._name))
+                kept_edges = _with_true_alias(kept_edges, edge._name)
             adapter = _RowPipelineAdapter(g.edges(kept_edges))
             adapter._node = adapter._edge = adapter._source = adapter._destination = None
             _record_native_seed_lane(nodes, seam="point_rows", reason="served", hop_count=1,
                                      public_seed_scan=node not in n0.filter_dict)
             return clear_row_exec_context(row_table(adapter, selected_joined))
-        selected = tail if source == tail_op._name else seed.filter(pl.col(node).is_in(kept_edges.get_column(from_col).implode()))
-        selected = selected.with_columns([
-            pl.col(node).is_in(kept_edges.get_column(endpoint).implode()).fill_null(False).alias(alias)
-            for alias, endpoint in ((n0._name, from_col), (tail_op._name, to_col)) if alias is not None
-        ])
+        if source == tail_op._name:
+            selected = tail
+        elif seed.height == 1 and kept_edges.height:
+            selected = seed
+        else:
+            selected = seed.filter(pl.col(node).is_in(kept_edges.get_column(from_col).implode()))
+        if seed.height == tail.height == selected.height == 1 and kept_edges.height:
+            selected = _with_singleton_aliases(selected, seed, tail, node, n0._name, tail_op._name)
+        else:
+            selected = selected.with_columns([
+                pl.col(node).is_in(kept_edges.get_column(endpoint).implode()).fill_null(False).alias(alias)
+                for alias, endpoint in ((n0._name, from_col), (tail_op._name, to_col)) if alias is not None
+            ])
         if edge._name is not None:
-            kept_edges = kept_edges.with_columns(pl.lit(True).alias(edge._name))
+            kept_edges = _with_true_alias(kept_edges, edge._name)
     out = row_table(_RowPipelineAdapter(g.edges(kept_edges)), selected)
     if len(ops) > boundary + 1:
         projection = ops[-1]

--- a/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py
@@ -63,6 +63,8 @@ def _joined_projection(
         frames[edge_alias] = edges
     properties: Dict[str, List[pl.Expr]] = {alias: [] for alias in frames}
     outputs = []
+    singleton = seed.height == 1 and tail.height == 1
+    singleton_columns = []
     for index, item in enumerate(items):
         if not isinstance(item, (list, tuple)) or len(item) != 2:
             return None
@@ -75,11 +77,20 @@ def _joined_projection(
         alias, column = match.groups()
         if alias not in frames or column not in frames[alias].columns:
             return None
+        if singleton:
+            series = frames[alias].get_column(column)
+            if alias != edge_alias:
+                series = series.new_from_index(0, edges.height)
+            singleton_columns.append(series.alias(output))
+            continue
         temporary = f"_value_{index}"
         properties[alias].append(pl.col(column).alias(temporary))
         outputs.append(pl.col(temporary).alias(output))
     if len({item[0] for item in items}) != len(items):
         return None
+    if singleton:
+        result = pl.DataFrame(singleton_columns)
+        return None if _select_emits_temporal_constructor_text(result) else result
     left = seed.lazy().select(pl.col(node).alias("_seed"), *properties[seed_alias]).with_row_index("_seed_order")
     step = edges.lazy().select(
         pl.col(from_col).alias("_seed"), pl.col(to_col).alias("_tail"),

--- a/graphistry/compute/gfql/lazy/engine/polars/degrees.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/degrees.py
@@ -64,7 +64,11 @@ def get_degrees_polars(
         if not _reg.is_empty():
             _d = degrees_from_index(_reg, nodes, node_col, edges, (src, dst), _index_engine(engine))
             if _d is not None:
+                import numpy as np
+
                 _in, _out = _d
+                # Polars and Polars GPU resident indexes use host NumPy arrays.
+                assert isinstance(_in, np.ndarray) and isinstance(_out, np.ndarray)
                 drop0 = [c for c in colnames(nodes) if c in (degree_in, degree_out, col)]
                 base0 = nodes.drop(drop0) if drop0 else nodes
                 out0 = base0.with_columns(

--- a/graphistry/compute/gfql/lazy/engine/polars/hop_eager.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/hop_eager.py
@@ -278,8 +278,7 @@ def hop_polars(
         allowed_source_lf = None
         if source_node_match is not None:
             source_filter_domain = all_nodes
-            only_seeds_can_be_sources = nodes is not None
-            if only_seeds_can_be_sources:
+            if nodes is not None:
                 source_filter_domain = all_nodes.join(
                     _idframe(nodes, node_col).rename({NID: node_col}), on=node_col, how="semi")
             allowed_source_lf = _idframe_lf(
@@ -330,9 +329,7 @@ def hop_polars(
     allowed_source = None
     if source_node_match is not None:
         source_filter_domain = all_nodes
-        only_seeds_can_be_sources = (
-            nodes is not None and not to_fixed_point and resolved_max_hops == 1)
-        if only_seeds_can_be_sources:
+        if nodes is not None and not to_fixed_point and resolved_max_hops == 1:
             source_filter_domain = all_nodes.join(
                 _idframe(nodes, node_col).rename({NID: node_col}), on=node_col, how="semi")
         allowed_source = _idframe(

--- a/graphistry/compute/gfql/lazy/engine/polars/nan_clean.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/nan_clean.py
@@ -55,14 +55,14 @@ def _pl_nan_to_null(df: "PolarsFrame") -> "PolarsFrame":
     it). Only columns that genuinely carry NaN are rewritten -- values identical to the
     old unconditional ``fill_nan``."""
     import polars as pl
+    if isinstance(df, pl.DataFrame) and id(df) in _nan_free_frame_id_cache:
+        return df
     # collect_schema(): LazyFrame.schema is deprecated and warns.
     schema = df.collect_schema() if isinstance(df, pl.LazyFrame) else df.schema
     float_cols = [c for c, dt in schema.items() if dt in (pl.Float32, pl.Float64)]
     if not float_cols:
         return df
     if isinstance(df, pl.DataFrame):
-        if id(df) in _nan_free_frame_id_cache:
-            return df
         nan_cols = [c for c in float_cols if df.get_column(c).is_nan().any()]
         if not nan_cols:
             _mark_pl_nan_clean(df)

--- a/graphistry/compute/gfql/lazy/engine/polars/predicates.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/predicates.py
@@ -3,14 +3,15 @@
 Common comparison/membership/string/null predicates lower to native polars expressions.
 NO-CHEATING contract: no pandas bridge — a predicate with no native lowering raises
 NotImplementedError (bridging one column would misrepresent pandas semantics as polars and
-break columnar/GPU assumptions; use engine='pandas'). All filtering is one vectorized
-``df.filter(expr)`` — no per-row work, no Python materialization.
+break columnar/GPU assumptions; use engine='pandas'). Filtering uses one vectorized
+``df.filter(expr)``. A single eager CPU row
+can use scalar equality when its storage and filter types agree.
 """
 from __future__ import annotations
 
 import operator
 import re
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, TypeVar, Union
 
 from graphistry.compute.predicates.ASTPredicate import ASTPredicate
 from graphistry.compute.predicates.str import Contains, Endswith, Fullmatch, Match, Startswith
@@ -406,8 +407,39 @@ def _is_cross_type_predicate(df: "Union[pl.DataFrame, pl.LazyFrame]", col: str, 
     return _mismatch(val)
 
 
+def _filter_singleton_equalities(
+    df: "Union[pl.DataFrame, pl.LazyFrame]", filter_dict: Optional[Mapping[str, object]],
+) -> "Optional[pl.DataFrame]":
+    """Check supported equalities on one CPU row; otherwise use expression filtering."""
+    import polars as pl
+    from graphistry.compute.gfql.lazy import active_target, ExecutionTarget
+
+    if not isinstance(df, pl.DataFrame) or df.height != 1 or not filter_dict:
+        return None
+    if active_target() == ExecutionTarget.GPU:
+        return None
+    matches = True
+    schema = df.schema
+    for column, expected in filter_dict.items():
+        dtype = schema.get(column)
+        supported = (
+            dtype == pl.Boolean and type(expected) is bool
+            or dtype == pl.String and type(expected) is str
+            or dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64)
+            and type(expected) is int and -(2**63) <= expected < 2**63
+        )
+        if not supported:
+            return None
+        actual = df.get_column(column).item()
+        matches = matches and actual is not None and actual == expected
+    return df if matches else df.clear()
+
+
 def filter_by_dict_polars(df: "PolarsFrameT", filter_dict: "Optional[Dict[str, Any]]") -> "PolarsFrameT":
     """Return rows of polars ``df`` matching all entries in ``filter_dict`` via one filter."""
+    singleton = _filter_singleton_equalities(df, filter_dict)
+    if singleton is not None:
+        return singleton  # type: ignore[return-value]  # The helper admits only eager frames.
     combined = filter_expr_by_dict_polars(df, filter_dict)
     if combined is None:
         return df

--- a/graphistry/compute/gfql/lazy/engine/polars/predicates.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/predicates.py
@@ -4,8 +4,8 @@ Common comparison/membership/string/null predicates lower to native polars expre
 NO-CHEATING contract: no pandas bridge — a predicate with no native lowering raises
 NotImplementedError (bridging one column would misrepresent pandas semantics as polars and
 break columnar/GPU assumptions; use engine='pandas'). Filtering uses one vectorized
-``df.filter(expr)``. A single eager CPU row
-can use scalar equality when its storage and filter types agree.
+``df.filter(expr)``. Small eager CPU frames
+can use scalar equalities when their storage and filter types agree.
 """
 from __future__ import annotations
 
@@ -407,6 +407,16 @@ def _is_cross_type_predicate(df: "Union[pl.DataFrame, pl.LazyFrame]", col: str, 
     return _mismatch(val)
 
 
+def _supports_scalar_equality(dtype: object, expected: object) -> bool:
+    import polars as pl
+    return (
+        dtype == pl.Boolean and type(expected) is bool
+        or dtype == pl.String and type(expected) is str
+        or dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64)
+        and type(expected) is int and -(2**63) <= expected < 2**63
+    )
+
+
 def _filter_singleton_equalities(
     df: "Union[pl.DataFrame, pl.LazyFrame]", filter_dict: Optional[Mapping[str, object]],
 ) -> "Optional[pl.DataFrame]":
@@ -422,24 +432,47 @@ def _filter_singleton_equalities(
     schema = df.schema
     for column, expected in filter_dict.items():
         dtype = schema.get(column)
-        supported = (
-            dtype == pl.Boolean and type(expected) is bool
-            or dtype == pl.String and type(expected) is str
-            or dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64)
-            and type(expected) is int and -(2**63) <= expected < 2**63
-        )
-        if not supported:
+        if not _supports_scalar_equality(dtype, expected):
             return None
         actual = df.get_column(column).item()
         matches = matches and actual is not None and actual == expected
     return df if matches else df.clear()
 
 
+def _filter_small_equalities(
+    df: "Union[pl.DataFrame, pl.LazyFrame]", filter_dict: Optional[Mapping[str, object]],
+) -> "Optional[pl.DataFrame]":
+    """Filter up to 32 eager CPU rows without starting an expression plan."""
+    import polars as pl
+    from graphistry.compute.gfql.lazy import active_target, ExecutionTarget
+
+    if not isinstance(df, pl.DataFrame) or df.height <= 1:
+        return _filter_singleton_equalities(df, filter_dict)
+    if df.height > 32 or not filter_dict or active_target() == ExecutionTarget.GPU:
+        return None
+    schema = df.schema
+    mask = [True] * df.height
+    for column, expected in filter_dict.items():
+        if not _supports_scalar_equality(schema.get(column), expected):
+            return None
+        values = df.get_column(column).to_list()
+        mask = [matched and actual is not None and actual == expected
+                for matched, actual in zip(mask, values)]
+    positions = [index for index, matched in enumerate(mask) if matched]
+    if not positions:
+        return df.clear()
+    if len(positions) == df.height:
+        return df
+    if positions[-1] - positions[0] + 1 == len(positions):
+        return df.slice(positions[0], len(positions))
+    return df[positions]
+
+
 def filter_by_dict_polars(df: "PolarsFrameT", filter_dict: "Optional[Dict[str, Any]]") -> "PolarsFrameT":
     """Return rows of polars ``df`` matching all entries in ``filter_dict`` via one filter."""
-    singleton = _filter_singleton_equalities(df, filter_dict)
-    if singleton is not None:
-        return singleton  # type: ignore[return-value]  # The helper admits only eager frames.
+    small = _filter_small_equalities(df, filter_dict)
+    if small is not None:
+        return small  # type: ignore[return-value]  # The helper admits only eager frames.
     combined = filter_expr_by_dict_polars(df, filter_dict)
     if combined is None:
         return df

--- a/graphistry/compute/gfql/lazy/engine/polars/projection.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/projection.py
@@ -53,14 +53,25 @@ def _has_temporal_constructor_text(rows_df: pl.DataFrame, col: str) -> bool:
     projection declines (NIE) rather than leak raw constructor text. Cheap native scan. Only
     standalone property projection needs this guard: whole-entity returns flatten the same raw
     column but are re-rendered downstream via render_entity_text."""
+    return _columns_have_temporal_constructor_text(rows_df, [col])
+
+
+def _columns_have_temporal_constructor_text(
+    rows_df: pl.DataFrame, columns: typing.Sequence[str],
+) -> bool:
+    """Check whether any selected string column contains temporal-constructor text."""
     import polars as pl
     from graphistry.compute.gfql.temporal.constructors import TEMPORAL_CALL_EXPR_RE
     # ^-anchored so values merely CONTAINING "date" (update({...}), candidate(...),
     # my date({x})) don't false-positive — these columns hold a WHOLE constructor string.
     pattern = r"^\s*" + TEMPORAL_CALL_EXPR_RE.pattern
+    if not columns:
+        return False
     try:
         return bool(
-            rows_df.select(pl.col(col).str.contains(pattern).any()).item()
+            rows_df.select(pl.any_horizontal([
+                pl.col(col).str.contains(pattern).any() for col in columns
+            ])).item()
         )
     except Exception:
         return False

--- a/graphistry/compute/gfql/lazy/engine/polars/projection.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/projection.py
@@ -218,6 +218,7 @@ def _try_native_projection(
     rows_df: pl.DataFrame,
     projection: ResultProjectionPlan,
     structured: bool,
+    source_node_id: typing.Optional[str] = None,
 ) -> typing.Optional[Plottable]:
     """Native projection for property/expr columns already in the polars row table + structured-
     flat or entity-text whole-entity returns; None → caller raises NIE."""
@@ -225,7 +226,7 @@ def _try_native_projection(
 
     exprs: typing.List[pl.Expr] = []
     entity_meta: typing.MutableMapping[str, _PolarsWholeRowProjectionMeta] = {}
-    id_column = result._node
+    id_column = result._node if result._node is not None else source_node_id
     primary = _alias_view_polars(rows_df, projection.alias)
     primary_columns = primary.columns if primary is not None else {}
     for column in projection.columns:
@@ -279,6 +280,7 @@ def apply_result_projection_polars(
     projection: ResultProjectionPlan,
     *,
     structured: bool = True,
+    source_node_id: typing.Optional[str] = None,
 ) -> Plottable:
     """Native polars result projection, or honest NotImplementedError (no pandas fallback).
 
@@ -289,7 +291,7 @@ def apply_result_projection_polars(
     native → raise rather than secretly run the pandas renderer.
     """
     rows_df = result._nodes
-    native = _try_native_projection(result, rows_df, projection, structured)
+    native = _try_native_projection(result, rows_df, projection, structured, source_node_id)
     if native is not None:
         return native
     raise NotImplementedError(

--- a/graphistry/compute/gfql/lazy/engine/polars/projection.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/projection.py
@@ -62,12 +62,17 @@ def _columns_have_temporal_constructor_text(
     """Check whether any selected string column contains temporal-constructor text."""
     import polars as pl
     from graphistry.compute.gfql.temporal.constructors import TEMPORAL_CALL_EXPR_RE
+    from graphistry.compute.gfql.lazy import active_target, ExecutionTarget
     # ^-anchored so values merely CONTAINING "date" (update({...}), candidate(...),
     # my date({x})) don't false-positive — these columns hold a WHOLE constructor string.
     pattern = r"^\s*" + TEMPORAL_CALL_EXPR_RE.pattern
     if not columns:
         return False
     try:
+        if rows_df.height == 1 and active_target() != ExecutionTarget.GPU:
+            values = [rows_df.get_column(col).item() for col in columns]
+            if all(value is None or isinstance(value, str) and "(" not in value for value in values):
+                return False
         return bool(
             rows_df.select(pl.any_horizontal([
                 pl.col(col).str.contains(pattern).any() for col in columns

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1231,6 +1231,48 @@ def _project_preserving_height(table: Any, exprs: List[Any]) -> Any:
     return table.select(exprs)
 
 
+def _project_eager_columns(
+    table: "pl.DataFrame", items: Sequence[SelectItem], exprs: Sequence["pl.Expr"],
+) -> Optional["pl.DataFrame"]:
+    """Gather columns and uniform coalesce inputs without an expression execution plan."""
+    import polars as pl
+    from graphistry.compute.gfql.expr_parser import FunctionCall, parse_expr
+
+    if not isinstance(table, pl.DataFrame) or not exprs:
+        return None
+    projected: List[pl.Series] = []
+    for item, expression in zip(items, exprs):
+        bare = expression.meta.undo_aliases()
+        output = expression.meta.output_name()
+        if bare.meta.is_column():
+            projected.append(table.get_column(bare.meta.output_name()).alias(output))
+            continue
+        source = item if isinstance(item, str) else item[1]
+        if not isinstance(source, str) or not source.lstrip().lower().startswith("coalesce"):
+            return None
+        parsed = parse_expr(source)
+        if not isinstance(parsed, FunctionCall) or parsed.name.lower() != "coalesce" or parsed.distinct:
+            return None
+        operands: List[pl.Series] = []
+        for argument in parsed.args:
+            lowered = lower_expr(argument, table.columns)
+            if lowered is None or not lowered.meta.is_column():
+                return None
+            operands.append(table.get_column(lowered.meta.output_name()))
+        if not operands or any(series.dtype != operands[0].dtype for series in operands[1:]):
+            return None
+        chosen = operands[-1]
+        for series in operands:
+            if series.null_count() == table.height:
+                continue
+            if series.null_count() != 0:
+                return None
+            chosen = series
+            break
+        projected.append(chosen.alias(output))
+    return pl.DataFrame(projected)
+
+
 def _project_polars(g: Plottable, items: Sequence[SelectItem], extend: bool) -> Optional[Plottable]:
     """Shared body of ``select_polars`` / ``with_columns_polars``; None if any item isn't
     lowerable (honest NIE, no pandas bridge)."""
@@ -1238,7 +1280,11 @@ def _project_polars(g: Plottable, items: Sequence[SelectItem], extend: bool) -> 
     exprs = _lower_with_schema(table, lambda: lower_select_items(items, list(table.columns)), node_id=g._node)
     if exprs is None:
         return None
-    out = table.with_columns(exprs) if extend else _project_preserving_height(table, exprs)
+    out = None if extend else _lower_with_schema(
+        table, lambda: _project_eager_columns(table, items, exprs), node_id=g._node,
+    )
+    if out is None:
+        out = table.with_columns(exprs) if extend else _project_preserving_height(table, exprs)
     if _select_emits_temporal_constructor_text(out):
         # decline (NIE): projected String column holds temporal-constructor text (date({...})
         # etc.) that pandas normalizes to ISO, not yet native — don't leak the raw text.

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1042,7 +1042,10 @@ def _finish_binding_rows_polars(
         )
 
     try:
-        joined_state = state.lazy()
+        alias_columns = {alias: names(frame) for alias, frame in alias_frames.items()}
+        property_names = [f"{alias}.{col}" for alias, columns in alias_columns.items() for col in columns]
+        binding_order = generate_safe_column_name_from("__gfql_binding_order__", names(state) + property_names)
+        joined_state = state.lazy().with_row_index(binding_order)
         attach_set = (
             None if attach_prop_aliases is None else set(attach_prop_aliases)
         )
@@ -1062,7 +1065,7 @@ def _finish_binding_rows_polars(
                 ]
                 + [
                     pl.col(col).alias(f"{alias}.{col}")
-                    for col in names(lookup_src)
+                    for col in alias_columns[alias]
                     if col != node_id
                 ]
             )
@@ -1071,7 +1074,7 @@ def _finish_binding_rows_polars(
             joined_state = joined_state.join(
                 lookup, left_on=alias, right_on=node_id, how="left",
             )
-        out_df = _lazy_collect(joined_state.drop(WALK_CURRENT_COL))
+        out_df = _lazy_collect(joined_state.sort(binding_order).drop([WALK_CURRENT_COL, binding_order]))
     except pl.exceptions.SchemaError:
         if not decline_on_schema_error:
             raise
@@ -2012,7 +2015,28 @@ def binding_rows_polars(
             next_op = ops[edge_idx + 1]
             if not isinstance(next_op, ASTNode):
                 return None
-            next_nodes = filter_by_dict_polars(nodes_lf, next_op.filter_dict)
+            candidate_nodes = nodes_lf
+            dis_label_col = RowPipelineMixin._gfql_has_edge_destination_label_col(edge_op, nodes.columns)
+            if (
+                dis_label_col is not None
+                and not sem.is_multihop
+                and edge_op.direction == "forward"
+                and not RowPipelineMixin._gfql_node_filter_has_label(next_op.filter_dict)
+            ):
+                # Only collisions among reached nodes trigger HAS_<Label> narrowing.
+                # Probe before destination predicates, matching the eager binding walk.
+                reached = state.select(WALK_CURRENT_COL).join(
+                    oriented.select([WALK_FROM_COL, WALK_TO_COL]),
+                    left_on=WALK_CURRENT_COL, right_on=WALK_FROM_COL, how="inner",
+                ).select(WALK_TO_COL)
+                candidate_nodes = nodes_lf.join(
+                    reached, left_on=node_id, right_on=WALK_TO_COL, how="semi",
+                )
+                candidate_nodes = candidate_nodes.filter(
+                    ~pl.col(node_id).is_duplicated().any()
+                    | pl.col(dis_label_col).fill_null(False).cast(pl.Boolean)
+                )
+            next_nodes = filter_by_dict_polars(candidate_nodes, next_op.filter_dict)
             # pandas' endpoint prefilter twin: before the id set, so membership + alias frame agree
             next_nodes = _apply_alias_prefilters_polars(next_nodes, next_op._name, alias_prefilters)
             next_node_ids = next_nodes.select(node_id).unique()
@@ -2095,10 +2119,12 @@ def binding_rows_polars(
                     )
                     trail_cols_pl = trail_cols_pl + _seg_trail_cols
             else:
+                path_order = generate_safe_column_name_from("__gfql_path_order__", _names(state) + _names(oriented))
                 state = (
-                    state.join(oriented, left_on=WALK_CURRENT_COL, right_on=WALK_FROM_COL, how="inner")
-.drop(WALK_CURRENT_COL)
-.rename({WALK_TO_COL: WALK_CURRENT_COL})
+                    state.with_row_index(path_order)
+                    .join(oriented, left_on=WALK_CURRENT_COL, right_on=WALK_FROM_COL, how="inner")
+                    .drop(WALK_CURRENT_COL)
+                    .rename({WALK_TO_COL: WALK_CURRENT_COL})
                 )
                 for _used in trail_cols_pl:
                     state = state.filter(
@@ -2114,33 +2140,8 @@ def binding_rows_polars(
                 right_on=node_id,
                 how="semi",
             )
-            # HAS_<Label> destination disambiguation (pandas'
-            # _gfql_disambiguate_has_edge_destination_nodes): on DUPLICATE-id graphs
-            # pandas narrows the unlabeled next op to the edge's HAS_<Label> rows
-            # taken from the ORIGINAL node table, which still carries the colliding
-            # label rows. Reproducing that narrowing natively would be silently
-            # row-order-dependent, so: unique-id graphs need no narrowing (pandas'
-            # duplicated() probe is False) → native is parity-exact; duplicate-id
-            # graphs DECLINE (honest NIE). ``nodes`` above IS the pre-chain node
-            # table; when there is no pre-chain graph to probe we cannot prove
-            # uniqueness of what pandas would have seen, so decline.
-            dis_label_col = RowPipelineMixin._gfql_has_edge_destination_label_col(edge_op, nodes.columns)
-            if (
-                dis_label_col is not None
-                and not sem.is_multihop
-                and edge_op.direction == "forward"
-                and not RowPipelineMixin._gfql_node_filter_has_label(next_op.filter_dict)
-            ):
-                if g._gfql_rows_base_graph is None:
-                    return None
-                _base_dup = bool(
-                    nodes.lazy()
-.select(pl.col(node_id).is_duplicated().any())
-.collect()
-.item()
-                )
-                if _base_dup:
-                    return None
+            if not sem.is_multihop:
+                state = state.sort([path_order, _new_trail]).drop(path_order)
             next_alias = next_op._name
             if isinstance(next_alias, str):
                 state = state.with_columns(pl.col(WALK_CURRENT_COL).alias(next_alias))

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1034,7 +1034,7 @@ def _finish_binding_rows_polars(
     from graphistry.compute.ast import ASTEdge, ASTNode
     from graphistry.compute.gfql.lazy import collect as _lazy_collect
 
-    def names(frame: "PolarsFrameT") -> List[str]:
+    def names(frame: "Union[pl.DataFrame, pl.LazyFrame]") -> List[str]:
         return (
             frame.collect_schema().names()
             if isinstance(frame, pl.LazyFrame)
@@ -1042,6 +1042,7 @@ def _finish_binding_rows_polars(
         )
 
     try:
+        joined_state = state.lazy()
         attach_set = (
             None if attach_prop_aliases is None else set(attach_prop_aliases)
         )
@@ -1054,7 +1055,7 @@ def _finish_binding_rows_polars(
             if attach_set is not None and alias not in attach_set:
                 continue
             lookup_src = alias_frames[alias]
-            lookup = lookup_src.select(
+            lookup = lookup_src.lazy().select(
                 [
                     pl.col(node_id),
                     pl.col(node_id).alias(f"{alias}.{node_id}"),
@@ -1065,17 +1066,12 @@ def _finish_binding_rows_polars(
                     if col != node_id
                 ]
             )
-            if (set(names(lookup)) - {node_id}) & set(names(state)):
+            if (set(names(lookup)) - {node_id}) & set(names(joined_state)):
                 return None
-            state = state.join(
+            joined_state = joined_state.join(
                 lookup, left_on=alias, right_on=node_id, how="left",
             )
-        state = state.drop(WALK_CURRENT_COL)
-        out_df = (
-            _lazy_collect(state)
-            if isinstance(state, pl.LazyFrame)
-            else state
-        )
+        out_df = _lazy_collect(joined_state.drop(WALK_CURRENT_COL))
     except pl.exceptions.SchemaError:
         if not decline_on_schema_error:
             raise

--- a/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
+++ b/graphistry/compute/gfql/lazy/engine/polars/row_pipeline.py
@@ -1250,11 +1250,9 @@ def _project_polars(g: Plottable, items: Sequence[SelectItem], extend: bool) -> 
 
 def _select_emits_temporal_constructor_text(out: Any) -> bool:
     import polars as pl
-    from graphistry.compute.gfql.lazy.engine.polars.projection import _has_temporal_constructor_text
-    for name, dtype in out.schema.items():
-        if dtype == pl.String and _has_temporal_constructor_text(out, name):
-            return True
-    return False
+    from graphistry.compute.gfql.lazy.engine.polars.projection import _columns_have_temporal_constructor_text
+    columns = [name for name, dtype in out.schema.items() if dtype == pl.String]
+    return _columns_have_temporal_constructor_text(out, columns)
 
 
 def select_polars(g: Plottable, items: Sequence[SelectItem]) -> Optional[Plottable]:

--- a/graphistry/compute/gfql/row/frame_ops.py
+++ b/graphistry/compute/gfql/row/frame_ops.py
@@ -102,6 +102,17 @@ def _restore_alias_shadowed_user_column(
             ).select(orig_cols)
         return table_df
     restore_col = shadow_restore_column(source)
+    # Traversal merges may reset row indexes; unique binding keys retain entity identity.
+    if (
+        key is not None and key != source
+        and key in table_df.columns and key in base_frame.columns
+        and bool(base_frame[key].is_unique)
+    ):
+        restored = base_frame.set_index(key)[source].reindex(table_df[key])
+        restored.index = table_df.index
+        out = table_df.copy()
+        out[restore_col] = restored
+        return out
     base_index = getattr(base_frame, "index", None)
     if base_index is not None and bool(base_index.is_unique):
         # guarded .loc proves index-subset alignment (cuDF Index.isin disagrees with pandas)
@@ -113,13 +124,6 @@ def _restore_alias_shadowed_user_column(
             out = table_df.copy()
             out[restore_col] = restored
             return out
-    if (
-        key is not None and key != source
-        and key in table_df.columns and key in base_frame.columns
-        and bool(base_frame[key].is_unique)
-    ):
-        renamed = base_frame[[key, source]].rename(columns={source: restore_col})
-        return table_df.merge(renamed, on=key, how="left")
     return table_df
 
 

--- a/graphistry/compute/gfql/row/pipeline.py
+++ b/graphistry/compute/gfql/row/pipeline.py
@@ -86,7 +86,7 @@ from graphistry.compute.gfql.identifiers import (
     shadow_restore_column,
     trail_column_name,
 )
-from graphistry.compute.util import generate_safe_column_name
+from graphistry.compute.util import generate_safe_column_name, generate_safe_column_name_from
 from graphistry.compute.gfql.cache_registry import register_process_singleton
 from graphistry.compute.gfql.series_str_compat import is_non_textual_scalar_dtype, series_sequence_len, series_str_match
 from graphistry.compute.gfql.row.ordering import (
@@ -4204,7 +4204,14 @@ class RowPipelineMixin:
                 )
                 trail_cols = trail_cols + segment_trail_cols
             else:
+                path_order = None
+                if engine == Engine.CUDF:
+                    path_order = generate_safe_column_name_from("__gfql_path_order__", list(state_df.columns) + list(oriented.columns))
+                    state_df = state_df.assign(**{path_order: range(len(state_df))})
                 state_df = state_df.merge(oriented, left_on=WALK_CURRENT_COL, right_on=WALK_FROM_COL, how="inner")
+                if path_order is not None:
+                    tie_cols = [ident_col] if ident_col in state_df.columns else []
+                    state_df = state_df.sort_values([path_order, *tie_cols]).drop(columns=[path_order])
                 state_df = state_df.drop(columns=[WALK_CURRENT_COL, WALK_FROM_COL]).rename(columns={WALK_TO_COL: WALK_CURRENT_COL})
                 if not shortest_path_mode and ident_col in state_df.columns:
                     state_df = RowPipelineMixin._gfql_drop_reused_relationship_rows(
@@ -4433,6 +4440,13 @@ class RowPipelineMixin:
                 lookup_source, alias, base_nodes, node_id
             )
             lookup = self._gfql_node_alias_lookup_frame(lookup_source, node_id, alias)
+            order_cols = []
+            if resolve_engine(EngineAbstract.AUTO, bindings) == Engine.CUDF:
+                order_col = generate_safe_column_name_from("__gfql_binding_order__", list(bindings.columns) + list(lookup.columns))
+                lookup_order = generate_safe_column_name_from("__gfql_lookup_order__", list(bindings.columns) + list(lookup.columns))
+                bindings = bindings.assign(**{order_col: range(len(bindings))})
+                lookup = lookup.assign(**{lookup_order: range(len(lookup))})
+                order_cols = [order_col, lookup_order]
             bindings = bindings.merge(
                 lookup,
                 left_on=alias,
@@ -4440,6 +4454,8 @@ class RowPipelineMixin:
                 how="left",
                 suffixes=("", f"__{alias}_join__"),
             )
+            if order_cols:
+                bindings = bindings.sort_values(order_cols).drop(columns=order_cols)
             dup_col = f"{node_id}__{alias}_join__"
             if dup_col in bindings.columns:
                 bindings = bindings.drop(columns=[dup_col])

--- a/graphistry/compute/gfql_fast_paths.py
+++ b/graphistry/compute/gfql_fast_paths.py
@@ -3835,7 +3835,7 @@ def _execute_seeded_typed_hop_fast_path(
         # value-identical contract).
         if is_polars:
             import polars as pl
-            out_frame = p_rows.select([pl.col(prop).alias(out) for out, _, prop in select_items])
+            out_frame = pl.DataFrame([p_rows.get_column(prop).alias(out) for out, _, prop in select_items])
         else:
             casts = _pivot_parity_casts(
                 p_rows, [(out, prop) for out, _, prop in select_items], node,

--- a/graphistry/compute/gfql_fast_paths.py
+++ b/graphistry/compute/gfql_fast_paths.py
@@ -17,7 +17,7 @@ from graphistry.Plottable import Plottable
 if TYPE_CHECKING:
     import polars as pl
     from graphistry.compute.gfql.index.api import ColStatsOutcome
-    from graphistry.compute.gfql.index.registry import ColStatsFact, DegreeFact, PartitionValue
+    from graphistry.compute.gfql.index.registry import ColStatsFact, DegreeFact, NodeIdIndex, PartitionValue
     from graphistry.compute.typing import ArrayLike, ArrayNamespace
 from graphistry.Engine import Engine, EngineAbstract, POLARS_ENGINES, df_concat, df_cons, df_to_engine, df_unique, resolve_engine
 from graphistry.util import setup_logger
@@ -99,7 +99,7 @@ from graphistry.compute.gfql.physical_planner import PhysicalPlanner
 from graphistry.compute.gfql.passes import DEFAULT_LOGICAL_PASSES, DEFAULT_TIER2_PASSES, PassManager
 from graphistry.compute.gfql.row.pipeline import _RowPipelineAdapter, is_row_pipeline_call
 from graphistry.compute.gfql.search_any import search_any_mask
-from graphistry.compute.typing import DataFrameT, FilterDict, SeriesT, NodeDtypes
+from graphistry.compute.typing import DataFrameT, FilterDict, ScalarFilterDict, SeriesT, NodeDtypes
 from graphistry.compute.gfql.lazy import collect as _lazy_collect, collect_all as _lazy_collect_all
 from graphistry.compute.util.generate_safe_column_name import generate_safe_column_name
 from graphistry.compute.validate.validate_schema import validate_chain_schema
@@ -3428,8 +3428,9 @@ def _seeded_typed_hop_two_alias_frame(
 
 
 def _node_lookup_scan_reason(
-    base_graph: Plottable, node: str, n0f: Dict[str, object], nid_ctx: object,
-) -> str:
+    base_graph: Plottable, node: str, n0f: ScalarFilterDict,
+    nid_ctx: Optional[Tuple["NodeIdIndex", "ArrayNamespace", Engine]],
+) -> Literal["index_policy_off", "index_missing", "index_stale", "cost_gate"]:
     """Why a seeded node lookup scanned: policy off, no index, a stale one, or the
     property index's cost gate."""
     from graphistry.compute.gfql.index import get_index_policy, get_registry

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -2853,5 +2853,8 @@ def _chain_dispatch(
             inputs.engine,
             inputs.include_paths,
         )
+    # Only the list-input branch sets this after constructing and validating a
+    # fresh Chain. This avoids another constructor; execution still validates
+    # current operations and schema, and no validation state persists on the AST.
     chain_input = chain_obj if _ast_validated else chain_obj.chain
     return chain_impl(g, chain_input, engine, policy=policy, context=context, start_nodes=start_nodes)

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -2853,8 +2853,6 @@ def _chain_dispatch(
             inputs.engine,
             inputs.include_paths,
         )
-    # Only the list-input branch sets this after constructing and validating a
-    # fresh Chain. This avoids another constructor; execution still validates
-    # current operations and schema, and no validation state persists on the AST.
+    # Validation state applies only to the fresh list-input Chain; execution revalidates mutable operations.
     chain_input = chain_obj if _ast_validated else chain_obj.chain
     return chain_impl(g, chain_input, engine, policy=policy, context=context, start_nodes=start_nodes)

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -2765,6 +2765,7 @@ def _gfql_with_strictness(
                     engine,
                     expanded_policy,
                     context,
+                    _ast_validated=True,
                 )
             else:
                 raise TypeError(
@@ -2787,6 +2788,7 @@ def _chain_dispatch(
     policy: Optional[PolicyDict],
     context: ExecutionContext,
     start_nodes: Optional[DataFrameT] = None,
+    _ast_validated: bool = False,
 ) -> Plottable:
     reject_alias_named_like_binding(g, chain_obj, include_edge_endpoint_aliases=True)
     engine_name = engine.value if hasattr(engine, "value") else str(engine)
@@ -2850,4 +2852,5 @@ def _chain_dispatch(
             inputs.engine,
             inputs.include_paths,
         )
-    return chain_impl(g, chain_obj.chain, engine, policy=policy, context=context, start_nodes=start_nodes)
+    chain_input = chain_obj if _ast_validated else chain_obj.chain
+    return chain_impl(g, chain_input, engine, policy=policy, context=context, start_nodes=start_nodes)

--- a/graphistry/compute/gfql_unified.py
+++ b/graphistry/compute/gfql_unified.py
@@ -1633,6 +1633,7 @@ def _execute_compiled_query_chain_non_union(
             result,
             compiled_query.result_projection,
             structured=not row_guard_needs_single_column_entity_text,
+            source_node_id=base_graph._node,
         )
     if compiled_query.optional_projection_row_guard is not None:
         expected_rows = 1

--- a/graphistry/compute/typing.py
+++ b/graphistry/compute/typing.py
@@ -55,6 +55,10 @@ NodeDtypes = Mapping[str, DType]
 FilterValue = Any
 FilterDict = Dict[str, FilterValue]
 
+# Scalar equality filters accepted by the seeded specialization admission gate.
+ScalarFilterValue = Union[int, float, str, bool]
+ScalarFilterDict = Dict[str, ScalarFilterValue]
+
 # Type variable for return type preservation in predicates
 T = TypeVar('T')
 

--- a/graphistry/tests/compute/chain_specializations/test_native_admission.py
+++ b/graphistry/tests/compute/chain_specializations/test_native_admission.py
@@ -49,6 +49,7 @@ def _sig(res):
 
 
 EXPECTED = {
+    "point joined hop projection": None,
     "point node rows": None, "point node projection": None,
     "point typed hop rows": None, "point typed hop seed rows": None,
     "point reverse hop projection": None,

--- a/graphistry/tests/compute/chain_specializations/test_native_admission.py
+++ b/graphistry/tests/compute/chain_specializations/test_native_admission.py
@@ -11,7 +11,7 @@ import pytest
 import graphistry
 import graphistry.compute.chain as chain_mod
 from graphistry.Engine import Engine
-from graphistry.compute.ast import e_forward, n
+from graphistry.compute.ast import ASTCall, e_forward, n
 from graphistry.compute.chain_specializations.admission import native_fast_path_admits
 from graphistry.tests.compute.gfql.routes.corpus import CORPUS, EDGES, NODES, by_name
 
@@ -49,6 +49,9 @@ def _sig(res):
 
 
 EXPECTED = {
+    "point node rows": None, "point node projection": None,
+    "point typed hop rows": None, "point typed hop seed rows": None,
+    "point reverse hop projection": None,
     "single node, scalar filter": "single-node", "single node, named": "single-node",
     "single node, predicate filter": "single-node", "single node, no filter": "single-node",
     "plain single hop, unseeded": "seeded-hop", "plain single hop, seeded": "seeded-hop",
@@ -77,6 +80,9 @@ def test_admits_iff_served(engine, name):
     g = _graph(engine)
     ops = by_name()[name].ops()
     admitted = native_fast_path_admits(ops, Engine(engine), None) is not None
+    if any(isinstance(op, ASTCall) for op in ops):
+        assert chain_mod._try_chain_fast_path(g, ops, Engine(engine)) is None
+        return
     res, served = _served(g, ops, engine)
     assert served == admitted, f"{name}: predicate={admitted} served={served}"
     if served:

--- a/graphistry/tests/compute/chain_specializations/test_native_admission.py
+++ b/graphistry/tests/compute/chain_specializations/test_native_admission.py
@@ -49,6 +49,7 @@ def _sig(res):
 
 
 EXPECTED = {
+    "point node coalesce": None,
     "point joined hop projection": None,
     "point node rows": None, "point node projection": None,
     "point typed hop rows": None, "point typed hop seed rows": None,

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -430,3 +430,22 @@ def test_point_coalesce_shared_grammar_declines_outside_boundary(expression):
     from graphistry.compute.chain_specializations.point_rows import _project_point_columns
     frame = pd.DataFrame({"lhs": [1], "rhs": [2]})
     assert _project_point_columns(frame, select([("answer", expression)]), "a", ["a", "b"]) is None
+
+
+@pytest.mark.parametrize("table,source", [("nodes", "b"), ("edges", "e")])
+@pytest.mark.parametrize("seed", [0, 1, 98])
+@pytest.mark.parametrize("disable_routes", [False, True])
+def test_empty_and_populated_traversals_keep_binding_first(engine, table, source, seed, disable_routes):
+    g = graph(engine)
+    ops = [n({"key": seed}, name="a"), e_forward(name="e"), n(name="b"),
+           rows(table=table, source=source)]
+    with routes_off(ROUTES if disable_routes else ()):
+        result = g.gfql(ops, engine=engine)
+    edge_columns = ["eid", "e", "s", "d", "type", "weight"]
+    expected_columns = (["key", "a", "b", "id", "kind", "value", "content"]
+                        if table == "nodes" else edge_columns)
+    expected_rows = {0: 2 if table == "nodes" else 3, 1: 1, 98: 0}
+    assert list(result._nodes.columns) == expected_columns
+    assert list(result._edges.columns) == edge_columns
+    assert len(result._nodes) == expected_rows[seed]
+    assert len(result._edges) == 0

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -401,3 +401,32 @@ def test_single_row_false_filter_still_validates_later_predicates():
     frame = pd.DataFrame({"first": [0], "second": [1]})
     with pytest.raises(GFQLSchemaError):
         _verify_scalar_filters_on_hit(frame, {"first": 1, "second": "wrong type"}, Engine.PANDAS)
+
+
+@pytest.mark.parametrize("expression", [
+    "coalesce(a.lhs, a.rhs)", "COALESCE(a.lhs,a.rhs)",
+    "CoAlEsCe ( a.lhs , a.rhs )", "coalesce(a . lhs, a.rhs)",
+])
+def test_point_coalesce_shared_grammar_keeps_null_semantics(engine, expression):
+    from graphistry.compute.chain_specializations.point_rows import _project_point_columns
+    frame = pd.DataFrame({"lhs": pd.Series([None, 3], dtype="Int64"),
+                          "rhs": pd.Series([7, 8], dtype="Int64")})
+    if engine == "cudf":
+        frame = pytest.importorskip("cudf").from_pandas(frame)
+    result = _project_point_columns(frame, select([("answer", expression)]), "a", ["a"])
+    assert result is not None
+    assert topd(result)["answer"].tolist() == [7, 3]
+    assert topd(frame)["lhs"].isna().tolist() == [True, False]
+
+
+@pytest.mark.parametrize("expression", [
+    "coalesce(DISTINCT a.lhs, a.rhs)", "coalesce(a.lhs)",
+    "coalesce(a.lhs, a.rhs, a.lhs)", "coalesce(a.lhs, 0)",
+    "coalesce(a.lhs, a.rhs) + 1", "coalesce(a.lhs.deep, a.rhs)",
+    "coalesce(a.lhs, coalesce(a.rhs, a.lhs))", "coalesce(a.`lhs`, a.rhs)",
+    "coalesce(a.lhs, b.rhs)", "coalesce(a.lhs, a.rhs", "coalesceX(a.lhs,a.rhs)",
+])
+def test_point_coalesce_shared_grammar_declines_outside_boundary(expression):
+    from graphistry.compute.chain_specializations.point_rows import _project_point_columns
+    frame = pd.DataFrame({"lhs": [1], "rhs": [2]})
+    assert _project_point_columns(frame, select([("answer", expression)]), "a", ["a", "b"]) is None

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -110,7 +110,7 @@ def test_point_route_serves_without_chain_and_preserves_results(engine, shape, p
 
 @pytest.mark.parametrize("shape", ["single", "tail", "seed", "edges"])
 @pytest.mark.parametrize("alias", ["value", "kind", "content"])
-def test_alias_property_collisions(engine, shape, alias, request):
+def test_alias_property_collisions(engine, shape, alias):
     g = graph(engine)
     ops = point_ops(shape, False, alias)
     with routes_off(ROUTES):
@@ -119,7 +119,6 @@ def test_alias_property_collisions(engine, shape, alias, request):
     assert actual is not None
     if engine == "cudf" and shape == "seed" and alias == "value":
         assert topd(actual._nodes)["__gfql_shadow_restore__value__"].tolist() == [0]
-        request.applymarker(pytest.mark.xfail(strict=True, reason="general cuDF alias restoration uses reordered row indexes; local repro in plan"))
     assert_result(actual, expected)
 
 

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -233,3 +233,57 @@ def test_projection_requires_parsing_for_non_identifier_properties(source, expre
     from graphistry.compute.chain_specializations.point_rows import _project_point_columns
     frame = pd.DataFrame({"value": [1], "two words": [2]})
     assert _project_point_columns(frame, select([("out", expression)]), source, [source]) is None
+
+
+@pytest.mark.parametrize("variant", ["base", "loop", "dangling", "empty", "nullable", "duplicate-index", "nonleading"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("named_edge", [False, True])
+def test_joined_point_projection(engine, variant, reverse, named_edge, monkeypatch):
+    g = graph(engine, variant)
+    hop = e_reverse if reverse else e_forward
+    items = [("seed", "a.value"), ("tail", "b.value"), ("id", "b.key")]
+    if named_edge:
+        items.append(("weight", "e.weight"))
+    ops = [n({"key": 0}, name="a"), hop({"type": "X"}, name="e" if named_edge else None),
+           n(name="b"), rows(), select(items)]
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine)
+    def fail(*args, **kwargs):
+        raise AssertionError("joined point fell back to chain execution")
+    monkeypatch.setattr(chain_mod, "_chain_impl", fail)
+    actual = g.gfql(ops, engine=engine)
+    assert_result(actual, expected)
+
+
+@pytest.mark.parametrize("items", [[("v", "a.value + b.value")], [("v", "a")], [],
+                                   [("v", "a.missing")], [("v", "a.`value`")]])
+def test_joined_point_projection_declines(engine, items):
+    g = graph(engine)
+    ops = [n({"key": 0}, name="a"), e_forward({"type": "X"}), n(name="b"), rows(), select(items)]
+    assert _try_point_rows(g, ops, Engine(engine), validate_schema=False) is None
+
+
+@pytest.mark.parametrize("seed,tail", [({"key": 999}, {}), ({"key": 0}, {"value": 1}),
+                                      ({"key": 0}, {"value": 999}), ({"bucket": 0}, {"value": 1})])
+def test_joined_point_filters_and_repeated_outputs(engine, seed, tail, monkeypatch):
+    g = graph(engine)
+    g = g.nodes(g._nodes.assign(bucket=g._nodes["key"] // 3)).gfql_index_all(engine=engine)
+    g = g.gfql_index_node_props(["bucket"], engine=engine)
+    from graphistry.compute.gfql.index import with_index_policy
+    g = with_index_policy(g, "force")
+    ops = [n(seed, name="a"), e_forward({"type": "X"}), n(tail, name="b"), rows(),
+           select([("v", "a.value"), ("v", "b.value"), ("key", "a.key")])]
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine)
+    def fail(*args, **kwargs):
+        raise AssertionError("joined point fell back")
+    monkeypatch.setattr(chain_mod, "_chain_impl", fail)
+    assert_result(g.gfql(ops, engine=engine), expected)
+
+
+@pytest.mark.parametrize("alias", ["value", "key", "content"])
+def test_joined_point_alias_collision_declines(engine, alias):
+    g = graph(engine)
+    ops = [n({"key": 0}, name=alias), e_forward({"type": "X"}), n(name="b"), rows(),
+           select([("v", f"{alias}.value"), ("tail", "b.value")])]
+    assert _try_point_rows(g, ops, Engine(engine), validate_schema=False) is None

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -340,3 +340,30 @@ def test_point_coalesce_projection(engine, left, right, dtype, empty, monkeypatc
 def test_point_coalesce_unsupported_expression_falls_back(expr):
     from graphistry.compute.chain_specializations.point_rows import _project_point_columns
     assert _project_point_columns(graph("pandas")._nodes, select([("v", expr)]), "a", ["a", "b"]) is None
+
+
+@pytest.mark.parametrize("where", ["seed", "tail", "edge"])
+def test_nullable_equality_does_not_match_null(engine, where):
+    g = graph(engine)
+    nodes, edges = topd(g._nodes), topd(g._edges)
+    nodes["value"] = nodes["value"].astype("Int64")
+    edges["weight"] = edges["weight"].astype("Int64")
+    if where == "seed":
+        nodes.loc[0, "value"] = pd.NA
+        ops = [n({"key": 0, "value": 1}, name="a"), rows(source="a")]
+    else:
+        if where == "tail":
+            nodes.loc[[1, 2], "value"] = pd.NA
+        else:
+            edges.loc[[0, 1, 5], "weight"] = pd.NA
+        ops = [n({"key": 0}, name="a"),
+               e_forward({"type": "X", **({"weight": 1} if where == "edge" else {})}),
+               n({"value": 1} if where == "tail" else {}, name="b"), rows(source="b")]
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    g = g.nodes(nodes).edges(edges).gfql_index_all(engine=engine)
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine, index_policy="off")
+    assert len(expected._nodes) == 0
+    assert_result(g.gfql(ops, engine=engine), expected)

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -1,0 +1,213 @@
+import importlib
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.Engine import Engine
+from graphistry.compute.ast import ASTCall, e_forward, e_reverse, e_undirected, n, rows, select
+from graphistry.compute.chain_specializations.admission import point_rows_admits
+from graphistry.compute.chain_specializations.point_rows import _try_point_rows
+from graphistry.compute.predicates.numeric import GT
+from graphistry.tests.compute.gfql.routes.switch import ROUTES, routes_off
+
+chain_mod = importlib.import_module("graphistry.compute.chain")
+
+
+@pytest.fixture(params=["pandas", "cudf"])
+def engine(request):
+    from graphistry.tests.compute.gfql.routes.test_route_harness import _skip_unavailable
+    _skip_unavailable(request.param)
+    return request.param
+
+
+def graph(engine, variant="base"):
+    nodes = pd.DataFrame({"key": range(100), "id": range(1000, 1100), "kind": ["Person"] * 100,
+                          "value": range(100), "content": ["hello"] * 100})
+    edges = pd.DataFrame({"s": [0, 0, 1, 2, 4, 0], "d": [1, 2, 0, 0, 99, 1],
+                          "type": ["X", "X", "X", "Y", "X", "X"], "eid": range(6), "weight": range(6)})
+    if variant == "loop":
+        edges.loc[len(edges)] = [0, 0, "X", 6, 6]
+    elif variant == "dangling":
+        edges.loc[len(edges)] = [0, 10000, "X", 6, 6]
+    elif variant == "nonleading":
+        nodes = nodes[["id", "value", "key", "kind", "content"]]
+    elif variant == "empty":
+        edges = edges.iloc[:0]
+    elif variant == "nullable":
+        nodes = nodes.astype({"value": "Int64"})
+        nodes.loc[1, "value"] = pd.NA
+    elif variant == "duplicate-index":
+        nodes.index = [0] * len(nodes)
+        edges.index = [0] * len(edges)
+    if engine == "cudf":
+        cudf = pytest.importorskip("cudf")
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    return graphistry.nodes(nodes, "key").edges(edges, "s", "d", "eid").gfql_index_all(engine=engine)
+
+
+def topd(frame):
+    return frame.to_pandas() if hasattr(frame, "to_pandas") else frame
+
+
+def assert_result(actual, expected):
+    for attr in ("_nodes", "_edges"):
+        aa, ee = topd(getattr(actual, attr)), topd(getattr(expected, attr))
+        if aa is None or ee is None:
+            assert aa is ee
+            continue
+        assert list(aa.columns) == list(ee.columns)
+        cols = list(aa.columns)
+        if cols:
+            aa = aa.sort_values(cols, na_position="last")
+            ee = ee.sort_values(cols, na_position="last")
+        pd.testing.assert_frame_equal(aa.reset_index(drop=True), ee.reset_index(drop=True))
+    for attr in ("_node", "_edge", "_source", "_destination"):
+        assert getattr(actual, attr) == getattr(expected, attr)
+    assert actual._gfql_rows_base_graph is None
+    assert actual._gfql_start_nodes is None
+
+
+def point_ops(shape, projection=False, alias="a"):
+    if shape == "single":
+        ops = [n({"key": 0}, name=alias), rows(source=alias)]
+    else:
+        edge = e_reverse if shape == "reverse" else e_forward
+        source = alias if shape == "seed" else "e" if shape == "edges" else "b"
+        ops = [n({"key": 0}, name=alias), edge({"type": "X"}, name="e"),
+               n({"kind": "Person"}, name="b"), rows(table="edges" if shape == "edges" else "nodes", source=source)]
+    if projection:
+        source = ops[-1].params["source"]
+        prop = "weight" if shape == "edges" else "value"
+        ops += [select([("out", f"{source}.{prop}")])]
+    return ops
+
+
+@pytest.mark.parametrize("shape", ["single", "tail", "seed", "edges", "reverse"])
+@pytest.mark.parametrize("projection", [False, True])
+@pytest.mark.parametrize("variant", ["base", "loop", "dangling", "nonleading", "empty", "nullable", "duplicate-index"])
+def test_point_route_serves_without_chain_and_preserves_results(engine, shape, projection, variant, monkeypatch):
+    g = graph(engine, variant)
+    ops = point_ops(shape, projection)
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine)
+    before_nodes, before_edges = topd(g._nodes).copy(), topd(g._edges).copy()
+    def reject_chain(*args, **kwargs):
+        pytest.fail("point query entered chain orchestration")
+    monkeypatch.setattr(chain_mod, "_chain_impl", reject_chain)
+    result = g.gfql(ops, engine=engine)
+    assert_result(result, expected)
+    pd.testing.assert_frame_equal(topd(g._nodes), before_nodes)
+    pd.testing.assert_frame_equal(topd(g._edges), before_edges)
+
+
+@pytest.mark.parametrize("shape", ["single", "tail", "seed", "edges"])
+@pytest.mark.parametrize("alias", ["value", "kind", "content"])
+def test_alias_property_collisions(engine, shape, alias, request):
+    g = graph(engine)
+    ops = point_ops(shape, False, alias)
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine)
+    actual = _try_point_rows(g, ops, Engine(engine))
+    assert actual is not None
+    if engine == "cudf" and shape == "seed" and alias == "value":
+        assert topd(actual._nodes)["__gfql_shadow_restore__value__"].tolist() == [0]
+        request.applymarker(pytest.mark.xfail(strict=True, reason="general cuDF alias restoration uses reordered row indexes; local repro in plan"))
+    assert_result(actual, expected)
+
+
+@pytest.mark.parametrize("ops", [
+    [n(), rows(source="a")],
+    [n({"key": GT(0)}, name="a"), rows(source="a")],
+    [n({"key": 0}, name="a", query="value > 1"), rows(source="a")],
+    [n({"key": 0}, name="a"), e_undirected(), n(name="b"), rows(source="b")],
+    [n({"key": 0}, name="a"), e_forward(hops=2), n(name="b"), rows(source="b")],
+    [n({"key": 0}, name="a"), e_forward(prune_to_endpoints=True), n(name="b"), rows(source="b")],
+    [n({"key": 0}, name="a"), e_forward(source_node_match={"value": 0}), n(name="b"), rows(source="b")],
+    [n({"key": 0}, name="a"), rows()],
+    [n({"key": 0}, name="a"), rows(source="missing")],
+    [n({"key": 0}, name="a"), rows(table="edges", source="a")],
+    [n({"key": 0}, name="a"), rows(source="a", alias_endpoints={"a": "src"})],
+    [n({"key": 0}, name="a"), ASTCall("rows", {"table": "nodes", "source": "a", "unexpected": True})],
+])
+def test_admission_declines_unsupported_shapes(ops):
+    assert point_rows_admits(ops, Engine.PANDAS, None) is None
+
+
+@pytest.mark.parametrize("shape", ["single", "tail"])
+@pytest.mark.parametrize("mode", ["off", "missing", "stale"])
+def test_unusable_indexes_decline_without_scanning(engine, shape, mode, monkeypatch):
+    g = graph(engine)
+    if mode == "off":
+        from graphistry.compute.gfql.index import with_index_policy
+        g = with_index_policy(g, "off")
+    elif mode == "missing":
+        g = graphistry.nodes(g._nodes, "key").edges(g._edges, "s", "d", "eid")
+    else:
+        g = g.nodes(g._nodes.copy())
+    bindings = importlib.import_module("graphistry.compute.gfql.index.bindings")
+    def reject_scan(*args, **kwargs):
+        pytest.fail("a declined point route scanned the node table")
+    monkeypatch.setattr(bindings, "_filter_frame", reject_scan)
+    assert _try_point_rows(g, point_ops(shape), Engine(engine)) is None
+
+
+@pytest.mark.parametrize("shape", ["single", "tail"])
+def test_start_nodes_and_other_engines_decline(shape):
+    ops = point_ops(shape)
+    assert point_rows_admits(ops, Engine.PANDAS, pd.DataFrame({"key": [0]})) is None
+    for engine in (Engine.POLARS, Engine.POLARS_GPU):
+        assert point_rows_admits(ops, engine, None) is None
+
+
+@pytest.mark.parametrize("shape", ["single", "tail"])
+def test_property_index_serves_with_residual_and_empty_filters(engine, shape, monkeypatch):
+    g = graph(engine).gfql_index_node_props(["id"], engine=engine)
+    for filters in ({"id": 1000, "kind": "Person"}, {"id": 9999}, {"id": 1000, "kind": "Absent"}):
+        ops = point_ops(shape)
+        ops[0] = n(filters, name="a")
+        with routes_off(ROUTES):
+            expected = g.gfql(ops, engine=engine)
+        actual = _try_point_rows(g, ops, Engine(engine))
+        assert actual is not None
+        assert_result(actual, expected)
+
+
+@pytest.mark.parametrize("shape", ["single", "tail"])
+def test_policy_hooks_keep_the_canonical_dispatch(engine, shape, monkeypatch):
+    g = graph(engine)
+    seen = []
+    def point_must_decline(*args, **kwargs):
+        pytest.fail("policy-bearing query entered the point route")
+    monkeypatch.setattr(chain_mod, "_try_point_rows", point_must_decline)
+    g.gfql(point_ops(shape), engine=engine, policy={"prechain": lambda ctx: seen.append("prechain")})
+    assert seen
+
+
+@pytest.mark.parametrize("filters", [{"absent": 1}, {"key": "wrong-type"}])
+def test_schema_errors_match_the_general_path(engine, filters):
+    g = graph(engine)
+    ops = [n(filters, name="a"), rows(source="a")]
+    with routes_off(ROUTES), pytest.raises(Exception) as expected:
+        g.gfql(ops, engine=engine, strict=True)
+    with pytest.raises(type(expected.value)) as actual:
+        g.gfql(ops, engine=engine, strict=True)
+    assert actual.value.code == expected.value.code
+
+
+@pytest.mark.parametrize("shape", ["single", "tail"])
+def test_index_trace_reports_the_point_route(engine, shape):
+    g = graph(engine)
+    report = g.gfql_explain(point_ops(shape), engine=engine)
+    assert report["used_index"]
+    assert any(step.get("seam") == "point_rows" for step in report["steps"])
+
+
+@pytest.mark.parametrize("source", ["value", "kind"])
+@pytest.mark.parametrize("key", [0, 2, 4])
+def test_colliding_source_property_stays_with_its_node(engine, source, key):
+    g = graph(engine)
+    ops = [n({"key": key}, name=source), rows(source=source), select([("out", f"{source}.{source}")])]
+    result = g.gfql(ops, engine=engine)
+    expected = key if source == "value" else "Person"
+    assert topd(result._nodes)["out"].tolist() == [expected]

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -367,3 +367,37 @@ def test_nullable_equality_does_not_match_null(engine, where):
         expected = g.gfql(ops, engine=engine, index_policy="off")
     assert len(expected._nodes) == 0
     assert_result(g.gfql(ops, engine=engine), expected)
+
+
+@pytest.mark.parametrize("value,dtype,filter_value", [
+    (1, "int64", 1), (1, "int64", 2), (1, "int64", "1"),
+    (2**63 + 1, "uint64", 2**63), (2**63 + 1, "uint64", 2**63 + 1),
+    (1.0, "float64", 1), (float("nan"), "float64", 1),
+    (pd.NA, "Int64", 1), (True, "boolean", True), (pd.NA, "boolean", False),
+    ("one", "string", "one"), (pd.NA, "string", "one"),
+    ("one", "object", 1), (None, "object", "one"),
+    (pd.Timestamp("2020-01-01"), "datetime64[ns]", "2020-01-01"),
+    ("one", "category", "one"),
+])
+def test_single_row_scalar_filter_matches_vector_oracle(value, dtype, filter_value):
+    from graphistry.compute.chain_fast_paths import _verify_scalar_filters_on_hit
+    frame = pd.DataFrame({"value": pd.Series([value], dtype=dtype)})
+    filters = {"value": filter_value}
+    doubled = pd.concat([frame, frame], ignore_index=True)
+    try:
+        expected = _verify_scalar_filters_on_hit(doubled, filters, Engine.PANDAS)
+    except Exception as error:
+        with pytest.raises(type(error)):
+            _verify_scalar_filters_on_hit(frame, filters, Engine.PANDAS)
+    else:
+        actual = _verify_scalar_filters_on_hit(frame, filters, Engine.PANDAS)
+        assert actual is not None and expected is not None
+        pd.testing.assert_frame_equal(actual.reset_index(drop=True), expected.head(1).reset_index(drop=True))
+
+
+def test_single_row_false_filter_still_validates_later_predicates():
+    from graphistry.compute.chain_fast_paths import _verify_scalar_filters_on_hit
+    from graphistry.compute.exceptions import GFQLSchemaError
+    frame = pd.DataFrame({"first": [0], "second": [1]})
+    with pytest.raises(GFQLSchemaError):
+        _verify_scalar_filters_on_hit(frame, {"first": 1, "second": "wrong type"}, Engine.PANDAS)

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -37,6 +37,13 @@ def graph(engine, variant="base"):
     elif variant == "nullable":
         nodes = nodes.astype({"value": "Int64"})
         nodes.loc[1, "value"] = pd.NA
+    elif variant == "categorical":
+        nodes["value"] = nodes["value"].astype("category")
+    elif variant == "timestamp":
+        nodes["value"] = pd.date_range("2020-01-01", periods=len(nodes), tz="UTC")
+    elif variant == "float-null":
+        nodes["value"] = nodes["value"].astype(float)
+        nodes.loc[1, "value"] = float("nan")
     elif variant == "duplicate-index":
         nodes.index = [0] * len(nodes)
         edges.index = [0] * len(edges)
@@ -235,7 +242,8 @@ def test_projection_requires_parsing_for_non_identifier_properties(source, expre
     assert _project_point_columns(frame, select([("out", expression)]), source, [source]) is None
 
 
-@pytest.mark.parametrize("variant", ["base", "loop", "dangling", "empty", "nullable", "duplicate-index", "nonleading"])
+@pytest.mark.parametrize("variant", ["base", "loop", "dangling", "empty", "nullable", "duplicate-index",
+                                     "nonleading", "categorical", "timestamp", "float-null"])
 @pytest.mark.parametrize("reverse", [False, True])
 @pytest.mark.parametrize("named_edge", [False, True])
 def test_joined_point_projection(engine, variant, reverse, named_edge, monkeypatch):
@@ -287,3 +295,48 @@ def test_joined_point_alias_collision_declines(engine, alias):
     ops = [n({"key": 0}, name=alias), e_forward({"type": "X"}), n(name="b"), rows(),
            select([("v", f"{alias}.value"), ("tail", "b.value")])]
     assert _try_point_rows(g, ops, Engine(engine), validate_schema=False) is None
+
+
+def test_joined_point_result_owns_projected_arrays():
+    g = graph("pandas")
+    ops = [n({"key": 0}, name="a"), e_forward({"type": "X"}, name="e"), n(name="b"), rows(),
+           select([("seed", "a.value"), ("tail", "b.value"), ("weight", "e.weight")])]
+    original_nodes, original_edges = g._nodes.copy(), g._edges.copy()
+    result = g.gfql(ops, engine="pandas")
+    result._nodes.loc[:, ["seed", "tail", "weight"]] = -1
+    pd.testing.assert_frame_equal(g._nodes, original_nodes)
+    pd.testing.assert_frame_equal(g._edges, original_edges)
+
+
+@pytest.mark.parametrize("left,right,dtype", [
+    ("value", "fallback", "object"), (None, "fallback", "object"),
+    ("", "fallback", "object"), (None, None, "object"),
+    (pd.NA, "fallback", "string"), (float("nan"), 2.0, "float64"),
+    (pd.NA, 2, "Int64"), (pd.NA, False, "boolean"),
+])
+@pytest.mark.parametrize("empty", [False, True])
+def test_point_coalesce_projection(engine, left, right, dtype, empty, monkeypatch):
+    g = graph(engine)
+    nodes = topd(g._nodes)
+    nodes["lhs"] = pd.Series([left] * len(nodes), dtype=dtype)
+    nodes["rhs"] = pd.Series([right] * len(nodes), dtype=dtype)
+    if engine == "cudf":
+        nodes = pytest.importorskip("cudf").from_pandas(nodes)
+    g = g.nodes(nodes).gfql_index_all(engine=engine)
+    ops = [n({"key": 999 if empty else 0}, name="a"), rows(source="a"),
+           select([("key", "a.key"), ("v", "coalesce(a.lhs, a.rhs)")])]
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine)
+    import graphistry.compute.chain_specializations.point_rows as point_mod
+    def fail(*args, **kwargs):
+        raise AssertionError("point projection used the general expression evaluator")
+    monkeypatch.setattr(point_mod, "_restore_point_source", fail)
+    assert_result(g.gfql(ops, engine=engine), expected)
+
+
+@pytest.mark.parametrize("expr", ["coalesce(a.value)", "coalesce(a.value, a.key, 0)",
+                                  "coalesce(a.value, 0)", "coalesce(a.value, b.value)",
+                                  "coalesce(a.value, a.key) + 1", "coalesce(a.value, a.`key`)"])
+def test_point_coalesce_unsupported_expression_falls_back(expr):
+    from graphistry.compute.chain_specializations.point_rows import _project_point_columns
+    assert _project_point_columns(graph("pandas")._nodes, select([("v", expr)]), "a", ["a", "b"]) is None

--- a/graphistry/tests/compute/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/chain_specializations/test_point_rows.py
@@ -211,3 +211,25 @@ def test_colliding_source_property_stays_with_its_node(engine, source, key):
     result = g.gfql(ops, engine=engine)
     expected = key if source == "value" else "Person"
     assert topd(result._nodes)["out"].tolist() == [expected]
+
+
+@pytest.mark.parametrize("items", [
+    [("out", "a.value + 1")], [("out", 7)], [("out", "a")],
+    [("eid", "a.value")], [("key", "a.value")], [],
+    [("out", "a.value"), ("out", "a.id")],
+])
+def test_projection_shortcut_and_fallback_preserve_binding_metadata(engine, items):
+    g = graph(engine)
+    ops = [n({"key": 2}, name="a"), rows(source="a"), select(items)]
+    with routes_off(ROUTES):
+        expected = g.gfql(ops, engine=engine)
+    actual = _try_point_rows(g, ops, Engine(engine))
+    assert actual is not None
+    assert_result(actual, expected)
+
+
+@pytest.mark.parametrize("source,expression", [("a.b", "a.b.value"), ("a", "a.two words")])
+def test_projection_requires_parsing_for_non_identifier_properties(source, expression):
+    from graphistry.compute.chain_specializations.point_rows import _project_point_columns
+    frame = pd.DataFrame({"value": [1], "two words": [2]})
+    assert _project_point_columns(frame, select([("out", expression)]), source, [source]) is None

--- a/graphistry/tests/compute/chain_specializations/test_scalar_filter_contract.py
+++ b/graphistry/tests/compute/chain_specializations/test_scalar_filter_contract.py
@@ -1,0 +1,24 @@
+"""The scalar filter contract accepts Python scalars and declines containers/nulls."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from graphistry.compute.chain_fast_paths import _seeded_scalar_filters
+
+
+class IntSubclass(int):
+    pass
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, "x", True, False, IntSubclass(2)])
+def test_scalar_filter_keeps_admitted_value_and_type(value):
+    filters = {"value": value}
+    result = _seeded_scalar_filters(filters, pd.DataFrame({"value": [1]}))
+    assert result is not None
+    assert result["value"] is value
+    assert filters == {"value": value}
+
+
+@pytest.mark.parametrize("value", [None, pd.NA, [1], (1,), {1}, {"a": 1}, np.int64(1), np.bool_(True)])
+def test_scalar_filter_declines_outside_python_scalar_contract(value):
+    assert _seeded_scalar_filters({"value": value}, pd.DataFrame({"value": [1]})) is None

--- a/graphistry/tests/compute/gfql/coverage_baselines/ci-polars-py3.12.json
+++ b/graphistry/tests/compute/gfql/coverage_baselines/ci-polars-py3.12.json
@@ -8,6 +8,7 @@
     "graphistry/compute/gfql/lazy/engine/polars/chain_specializations/__init__.py": 100.0,
     "graphistry/compute/gfql/lazy/engine/polars/chain_specializations/admission.py": 95.0,
     "graphistry/compute/gfql/lazy/engine/polars/chain_specializations/hotpaths.py": 95.0,
+    "graphistry/compute/gfql/lazy/engine/polars/chain_specializations/point_rows.py": 93.0,
     "graphistry/compute/gfql/lazy/engine/polars/degrees.py": 82.0,
     "graphistry/compute/gfql/lazy/engine/polars/dtypes.py": 92.0,
     "graphistry/compute/gfql/lazy/engine/polars/hop.py": 87.0,

--- a/graphistry/tests/compute/gfql/index/test_engine_arrays.py
+++ b/graphistry/tests/compute/gfql/index/test_engine_arrays.py
@@ -84,7 +84,7 @@ def test_singleton_result_can_replace_column_without_mutating_source(engine):
 @pytest.mark.parametrize("width", [15, 32, 33, 64])
 @pytest.mark.parametrize("chunked", [False, True])
 @pytest.mark.parametrize("positions", [
-    np.array([0, 1]), np.array([1, 2]), np.array([2, 0]), np.array([1, 1]),
+    np.array([], dtype=np.int64), np.array([0]), np.array([0, 1]), np.array([1, 2]), np.array([2, 0]), np.array([1, 1]),
     np.array([2, 0, 1, 2, 0, 1, 2, 0]), np.array([0] * 9),
     np.array([0, 3]), np.array([0, -1]), np.array([0, -4]),
     np.array([0, 2**64 - 1], dtype=np.uint64),

--- a/graphistry/tests/compute/gfql/index/test_engine_arrays.py
+++ b/graphistry/tests/compute/gfql/index/test_engine_arrays.py
@@ -1,0 +1,80 @@
+"""Native index gathers preserve Polars values, schemas, and indexing errors."""
+from decimal import Decimal
+import numpy as np
+import pytest
+
+pl = pytest.importorskip("polars")
+from polars.testing import assert_frame_equal
+from graphistry.Engine import Engine
+from graphistry.compute.gfql.index.engine_arrays import take_rows
+
+
+def frame():
+    return pl.DataFrame([
+        pl.Series("integer", [1, None, -(2**63)], dtype=pl.Int64),
+        pl.Series("unsigned", [2**63 + 1, None, 2**64 - 1], dtype=pl.UInt64),
+        pl.Series("float", [float("nan"), float("inf"), -0.0]),
+        pl.Series("bool", [True, None, False], dtype=pl.Boolean),
+        pl.Series("string", ["雪", None, ""], dtype=pl.String),
+        pl.Series("binary", [b"x", None, b""], dtype=pl.Binary),
+        pl.Series("datetime", [1, None, 10**18 + 123], dtype=pl.Int64).cast(pl.Datetime("ns")),
+        pl.Series("duration", [1, None, 123], dtype=pl.Int64).cast(pl.Duration("ns")),
+        pl.Series("date", [0, None, 20000], dtype=pl.Int64).cast(pl.Date),
+        pl.Series("time", [1, None, 123], dtype=pl.Int64).cast(pl.Time),
+        pl.Series("decimal", [Decimal("1.23"), None, Decimal("-4.56")], dtype=pl.Decimal(10, 2)),
+        pl.Series("list", [[1, None], None, []], dtype=pl.List(pl.Int64)),
+        pl.Series("struct", [{"a": 1}, None, {"a": None}], dtype=pl.Struct({"a": pl.Int64})),
+        pl.Series("category", ["red", None, "blue"], dtype=pl.Categorical),
+        pl.Series("enum", ["red", None, "blue"], dtype=pl.Enum(["red", "blue"])),
+    ])
+
+
+POSITIONS = [
+    np.array([0], dtype=np.uint32), np.array([1], dtype=np.uint64), np.array([2], dtype=np.int8),
+    np.array([1], dtype=np.int16), np.array([1], dtype=np.int32), np.array([1], dtype=np.int64),
+    np.array([-1]), np.array([-3]), np.array([-4]), np.array([3]),
+    np.array([2, 0, 2]), np.array([], dtype=np.int64), np.array([], dtype=float),
+    np.array([1.0]), np.array([True]), np.array([[0]]), np.array(1),
+    np.array([2**64 - 1], dtype=np.uint64),
+]
+
+
+@pytest.mark.parametrize("engine", [Engine.POLARS, Engine.POLARS_GPU])
+@pytest.mark.parametrize("chunked", [False, True])
+@pytest.mark.parametrize("positions", POSITIONS)
+def test_take_rows_matches_native_array_indexing(engine, chunked, positions):
+    data = frame()
+    if chunked:
+        data = pl.concat([data.head(1), data.tail(2)], rechunk=False)
+    original = data.clone()
+    try:
+        expected = data[positions]
+    except Exception as error:
+        with pytest.raises(type(error)) as actual:
+            take_rows(data, positions, engine)
+        assert str(actual.value) == str(error)
+    else:
+        actual = take_rows(data, positions, engine)
+        assert_frame_equal(actual, expected, check_exact=True)
+    assert_frame_equal(data, original, check_exact=True)
+
+
+@pytest.mark.parametrize("engine", [Engine.POLARS, Engine.POLARS_GPU])
+def test_take_rows_empty_frame_keeps_bounds_error(engine):
+    data = frame().clear()
+    positions = np.array([0])
+    with pytest.raises(Exception) as expected:
+        data[positions]
+    with pytest.raises(type(expected.value)) as actual:
+        take_rows(data, positions, engine)
+    assert str(actual.value) == str(expected.value)
+
+
+@pytest.mark.parametrize("engine", [Engine.POLARS, Engine.POLARS_GPU])
+def test_singleton_result_can_replace_column_without_mutating_source(engine):
+    data = frame()
+    original = data.clone()
+    result = take_rows(data, np.array([0]), engine)
+    result.replace_column(0, pl.Series("integer", [999], dtype=pl.Int64))
+    assert result["integer"].item() == 999
+    assert_frame_equal(data, original, check_exact=True)

--- a/graphistry/tests/compute/gfql/index/test_engine_arrays.py
+++ b/graphistry/tests/compute/gfql/index/test_engine_arrays.py
@@ -78,3 +78,35 @@ def test_singleton_result_can_replace_column_without_mutating_source(engine):
     result.replace_column(0, pl.Series("integer", [999], dtype=pl.Int64))
     assert result["integer"].item() == 999
     assert_frame_equal(data, original, check_exact=True)
+
+
+@pytest.mark.parametrize("engine", [Engine.POLARS, Engine.POLARS_GPU])
+@pytest.mark.parametrize("width", [15, 32, 33, 64])
+@pytest.mark.parametrize("chunked", [False, True])
+@pytest.mark.parametrize("positions", [
+    np.array([0, 1]), np.array([1, 2]), np.array([2, 0]), np.array([1, 1]),
+    np.array([2, 0, 1, 2, 0, 1, 2, 0]), np.array([0] * 9),
+    np.array([0, 3]), np.array([0, -1]), np.array([0, -4]),
+    np.array([0, 2**64 - 1], dtype=np.uint64),
+    np.array([0, 1], dtype=np.uint8), np.array([0, 1], dtype=np.uint64),
+    np.array([0.0, 1.0]), np.array([True, False]), np.array([[0, 1]]),
+])
+def test_small_gather_matches_native_values_errors_and_isolation(engine, width, chunked, positions):
+    data = frame()
+    for column in range(data.width, width):
+        data.insert_column(data.width, data["integer"].alias(f"extra_{column}"))
+    if chunked:
+        data = pl.concat([data.head(1), data.tail(2)], rechunk=False)
+    original = data.clone()
+    try:
+        expected = data[positions]
+    except Exception as error:
+        with pytest.raises(type(error)) as actual_error:
+            take_rows(data, positions, engine)
+        assert str(actual_error.value) == str(error)
+    else:
+        result = take_rows(data, positions, engine)
+        assert_frame_equal(result, expected, check_exact=True)
+        result.replace_column(0, pl.Series("integer", [999] * result.height, dtype=pl.Int64))
+        assert_frame_equal(data, original, check_exact=True)
+    assert_frame_equal(data, original, check_exact=True)

--- a/graphistry/tests/compute/gfql/index/test_index.py
+++ b/graphistry/tests/compute/gfql/index/test_index.py
@@ -2129,3 +2129,93 @@ def test_documented_recovery_from_in_place_mutation(engine):
     assert _i1913_ids(dropped, _I1913_2HOP, engine) == oracle
     brand_new = graphistry.nodes(nf, "id").edges(ef, "s", "d")
     assert _i1913_ids(brand_new, _I1913_2HOP, engine) == oracle
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("dtype,big", [("Int64", 2**53), ("UInt64", 2**63)])
+@pytest.mark.parametrize("shape", ["empty", "all-null", "mixed", "no-null"])
+def test_nullable_integer_index_positions_and_precision(engine, dtype, big, shape):
+    from graphistry.Engine import Engine
+    from graphistry.compute.gfql.index.engine_arrays import array_namespace
+    from graphistry.compute.gfql.index.lookup import lookup_edge_rows, lookup_node_rows
+    from graphistry.compute.gfql.index.registry import EDGE_OUT_ADJ, EDGE_IN_ADJ, NODE_ID
+
+    ids = [None, big + 1, big, 0]
+    src = [None, big + 1, big, None, big, 0]
+    dst = [big, big, big + 1, None, None, 0]
+    if shape == "empty":
+        ids, src, dst = [], [], []
+    elif shape == "all-null":
+        ids, src, dst = [None, None], [None, None], [None, None]
+    elif shape == "no-null":
+        ids, src, dst = [big + 1, big, 0], [big + 1, big, 0], [big, big + 1, 0]
+    nodes = pd.DataFrame({"id": pd.array(np.asarray(ids, dtype=object), dtype=dtype)})
+    edges = pd.DataFrame({"src": pd.array(np.asarray(src, dtype=object), dtype=dtype), "dst": pd.array(np.asarray(dst, dtype=object), dtype=dtype)})
+    g = graphistry.nodes(nodes, "id").edges(edges, "src", "dst").gfql_index_all(engine=engine)
+    registry = get_registry(g)
+    xp, _ = array_namespace(Engine(engine))
+    query_dtype = "uint64" if dtype == "UInt64" else "int64"
+    queries = [0, big, big + 1, big + 2]
+    node_index = registry.get_valid(NODE_ID, g._nodes, ("id",), Engine(engine))
+    assert node_index is not None
+    from graphistry.compute.gfql.index.bindings import _integer_index
+    assert _integer_index(node_index) == all(value is not None for value in ids)
+    for query in queries:
+        probe = xp.asarray([query], dtype=query_dtype)
+        assert lookup_node_rows(node_index, probe, xp).tolist() == [i for i, value in enumerate(ids) if value == query]
+        for kind, keys in [(EDGE_OUT_ADJ, src), (EDGE_IN_ADJ, dst)]:
+            index = registry.get_valid(kind, g._edges, ("src", "dst"), Engine(engine))
+            assert index is not None
+            assert index.n_edges == len(edges)
+            actual_rows, matched = lookup_edge_rows(index, probe, xp)
+            expected_rows = [i for i, key in enumerate(keys) if key == query and src[i] is not None and dst[i] is not None]
+            assert sorted(actual_rows.tolist()) == expected_rows
+            assert matched.tolist() == ([query] if expected_rows else [])
+            other = dst if kind == EDGE_OUT_ADJ else src
+            assert index.other_values[actual_rows].tolist() == [other[i] for i in actual_rows.tolist()]
+    pd.testing.assert_frame_equal(nodes, pd.DataFrame({"id": pd.array(np.asarray(ids, dtype=object), dtype=dtype)}))
+    pd.testing.assert_frame_equal(edges, pd.DataFrame({"src": pd.array(np.asarray(src, dtype=object), dtype=dtype), "dst": pd.array(np.asarray(dst, dtype=object), dtype=dtype)}))
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("dtype,big", [("Int64", 2**53), ("UInt64", 2**63)])
+@pytest.mark.parametrize("seed_offset", [0, 1, 2])
+def test_nullable_integer_hop_exact_identity(engine, dtype, big, seed_offset):
+    nodes = pd.DataFrame({"id": pd.array(np.asarray([None, big + 1, big], dtype=object), dtype=dtype)})
+    edges = pd.DataFrame({
+        "src": pd.array(np.asarray([None, big, big + 1, big], dtype=object), dtype=dtype),
+        "dst": pd.array(np.asarray([big, big + 1, big, None], dtype=object), dtype=dtype),
+    })
+    g = graphistry.nodes(nodes, "id").edges(edges, "src", "dst").gfql_index_all(engine=engine)
+    seeds = pd.DataFrame({"id": pd.array(np.asarray([big + seed_offset, None], dtype=object), dtype=dtype)})
+    expected = ([big, big + 1], [(big, big + 1)]) if seed_offset == 0 else (
+        ([big, big + 1], [(big + 1, big)]) if seed_offset == 1 else ([], [])
+    )
+    for policy in ("off", "force"):
+        candidate = copy(g)
+        candidate._gfql_index_policy = policy
+        actual = candidate.hop(nodes=seeds, hops=1, direction="forward", engine=engine)
+        assert _sig(actual) == expected
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("null_nodes", [False, True])
+@pytest.mark.parametrize("null_edges", [False, True])
+def test_nullable_index_degree_boundary(engine, null_nodes, null_edges):
+    from graphistry.Engine import Engine
+    from graphistry.compute.gfql.index.build import build_degree_fact
+    from graphistry.compute.gfql.index.degrees import degrees_from_index
+
+    nodes = pd.DataFrame({"id": pd.array([0, 1] + ([None] if null_nodes else []), dtype="Int64")})
+    edges = pd.DataFrame({
+        "src": pd.array([0, 1] + ([0, None] if null_edges else []), dtype="Int64"),
+        "dst": pd.array([1, 0] + ([None, 1] if null_edges else []), dtype="Int64"),
+    })
+    base = _to_engine_frames(graphistry.nodes(nodes, "id").edges(edges, "src", "dst"), engine)
+    indexed = base.gfql_index_all(engine=engine)
+    assert _degcols(_degrees(indexed, engine)) == _degcols(_degrees(base, engine))
+    native_engine = Engine(engine)
+    degree_arrays = degrees_from_index(get_registry(indexed), indexed._nodes, "id", indexed._edges, ("src", "dst"), native_engine)
+    assert (degree_arrays is None) == (null_nodes or null_edges)
+    fact = build_degree_fact(indexed._edges, "src", "dst", 0, 1, native_engine)
+    assert (fact is None) == null_edges

--- a/graphistry/tests/compute/gfql/index/test_indexed_bindings.py
+++ b/graphistry/tests/compute/gfql/index/test_indexed_bindings.py
@@ -639,8 +639,11 @@ def test_node_property_index_absent_matches_indexed(
         _assert_result_exact(actual, expected, engine)
 
 
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("index-hop", "indexed-kernel")),
+])
 def test_node_property_index_duplicate_values_match_scan(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, require_engagement: bool,
 ) -> None:
     """A non-unique property still gathers EVERY matching row (CSR, not first-hit)."""
     from graphistry.compute.ast import rows as rows_call
@@ -651,8 +654,9 @@ def test_node_property_index_duplicate_values_match_scan(
         expected = _run(g, query, "pandas", m, generic=True)
     actual, steps, widths = _seed_filter_widths(g, query, "pandas", monkeypatch)
     _assert_result_exact(actual, expected, "pandas")
-    assert widths and widths[0] == 4  # every row with grp == 0, none of the others
-    assert [s for s in steps if s.get("seam") == "connected_bindings"]
+    if require_engagement:
+        assert widths and widths[0] == 4  # every row with grp == 0, none of the others
+        assert [s for s in steps if s.get("seam") == "connected_bindings"]
 
 
 @pytest.mark.parametrize("case", ["stale", "policy_off"])
@@ -701,9 +705,11 @@ def test_node_property_index_declines_unindexable_columns() -> None:
         g.gfql_index_node_props(["nosuch"])
 
 
-@pytest.mark.route_engaged("index-hop")
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("index-hop", "indexed-kernel")),
+])
 def test_node_property_index_prefers_the_most_selective_column(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, require_engagement: bool,
 ) -> None:
     from graphistry.compute.ast import rows as rows_call
 
@@ -718,7 +724,8 @@ def test_node_property_index_prefers_the_most_selective_column(
         expected = _run(g, query, "pandas", m, generic=True)
     actual, _, widths = _seed_filter_widths(g, query, "pandas", monkeypatch)
     _assert_result_exact(actual, expected, "pandas")
-    assert widths and widths[0] == 1  # 'public' (1 match) beats 'grp' (4 matches)
+    if require_engagement:
+        assert widths and widths[0] == 1  # 'public' (1 match) beats 'grp' (4 matches)
 
 
 @pytest.mark.parametrize(

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_hotpaths.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_hotpaths.py
@@ -1,0 +1,53 @@
+"""Named Polars hops preserve tables across singleton and fallback boundaries."""
+import importlib
+
+import pytest
+
+import graphistry
+from graphistry.compute import ast
+
+pl = pytest.importorskip("polars")
+from polars.testing import assert_frame_equal
+
+chain_polars = importlib.import_module("graphistry.compute.gfql.lazy.engine.polars.chain")
+
+
+@pytest.mark.parametrize("dtype", [pl.Int64, pl.UInt64, pl.Float64])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("shape", ["one", "loop", "parallel", "dangling", "null", "filtered", "multi", "empty"])
+@pytest.mark.parametrize("aliases", [("m", "e", "p"), (None, None, None), ("m", None, None), (None, "e", "p")])
+def test_named_hop_exact_tables(dtype, reverse, shape, aliases, monkeypatch):
+    offset = 2**63 + 1024 if dtype == pl.UInt64 else 0
+    nodes = pl.DataFrame({
+        "key": pl.Series([offset + i for i in [4, 1, 6, 2, 5, 3]], dtype=dtype),
+        "id": [104, 101, 106, 102, 105, 103],
+        "kind": ["Message", "Person", "Message", "Person", "Message", "Person"],
+        "value": ["a", None, "c", "d", "e", "f"],
+    })
+    ends = {
+        "one": ([4], [1]), "loop": ([4], [4]), "parallel": ([4, 4], [1, 1]),
+        "dangling": ([4], [99]), "null": ([4], [None]), "filtered": ([4], [6]),
+        "multi": ([4, 4, 4, 6], [1, 2, None, 1]), "empty": ([], []),
+    }[shape]
+    src, dst = [[None if v is None else offset + v for v in values] for values in ends]
+    if reverse:
+        src, dst = dst, src
+    edges = pl.DataFrame({
+        "s": pl.Series(src, dtype=dtype), "d": pl.Series(dst, dtype=dtype),
+        "type": pl.Series(["T"] * len(src), dtype=pl.String),
+        "v": pl.Series(range(len(src)), dtype=pl.Int64),
+    })
+    g = graphistry.nodes(nodes, "key").edges(edges, "s", "d").gfql_index_all(engine="polars")
+    n0, e, n2 = aliases
+    ops = [
+        ast.n({"key": offset + 4}, name=n0),
+        (ast.e_reverse if reverse else ast.e_forward)({"type": "T"}, name=e),
+        ast.n({} if shape == "loop" else {"kind": "Person"}, name=n2),
+    ]
+    actual = g.gfql(ops, engine="polars", index_policy="use")
+    monkeypatch.setattr(chain_polars, "_try_seeded_chain_polars", lambda *args: None)
+    expected = g.gfql(ops, engine="polars", index_policy="use")
+    assert_frame_equal(actual._nodes, expected._nodes)
+    assert_frame_equal(actual._edges, expected._edges)
+    assert_frame_equal(g._nodes, nodes)
+    assert_frame_equal(g._edges, edges)

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
@@ -70,3 +70,45 @@ def test_single_node_property_multihit_order(project):
         expected = g.gfql(ops, engine="polars", index_policy="force")
     actual = g.gfql(ops, engine="polars", index_policy="force")
     assert_frame_equal(actual._nodes, expected._nodes)
+
+
+@pytest.mark.parametrize("variant", ["base", "loop", "dangling", "nonleading", "empty", "nullable", "timestamp", "float-null", "categorical"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("multi_seed", [False, True])
+def test_joined_projection_exact_path_bag(variant, reverse, multi_seed):
+    from polars.testing import assert_frame_equal
+    g = make_graph(variant)
+    if multi_seed:
+        g = graphistry.nodes(g._nodes.with_columns((pl.col("id") % 2).alias("bucket")), "key").edges(g._edges, "s", "d", "eid")
+        g = g.gfql_index_all(engine="polars").gfql_index_node_props(["bucket"], engine="polars")
+    edge = e_reverse if reverse else e_forward
+    ops = [n({"bucket": 0} if multi_seed else {"id": 1000}, name="a"), edge({"type": "X"}, name="e"),
+           n({"kind": "Person"}, name="b"), rows(),
+           select([("source", "a.id"), ("target", "b.id"), ("value", "b.value"), ("weight", "e.weight")])]
+    from graphistry.compute.gfql.index.api import with_index_policy
+    direct = _try_point_rows_polars(with_index_policy(g, "force"), ops)
+    assert direct is not None
+    with routes_off(["polars-point-rows"]):
+        expected = g.gfql(ops, engine="polars", index_policy="force")
+    assert_frame_equal(direct._nodes, expected._nodes)
+    assert_frame_equal(direct._edges, expected._edges)
+    for attr in ("_node", "_edge", "_source", "_destination", "_gfql_rows_base_graph", "_gfql_start_nodes"):
+        assert getattr(direct, attr) == getattr(expected, attr)
+
+
+@pytest.mark.parametrize("items", [
+    [("out", "a.id + 1")], [("out", "coalesce(a.content, b.content)")],
+    [("out", "missing.id")], [("out", "a.missing")],
+    [("out", "a.id"), ("out", "b.id")],
+])
+def test_joined_projection_declines_unsupported_items(items):
+    g = make_graph()
+    ops = [n({"id": 1000}, name="a"), e_forward({"type": "X"}), n(name="b"), rows(), select(items)]
+    assert _try_point_rows_polars(g, ops) is None
+
+
+def test_joined_projection_temporal_constructor_text_declines():
+    g = make_graph()
+    g = graphistry.nodes(g._nodes.with_columns(pl.lit("date({year: 2020})").alias("text")), "key").edges(g._edges, "s", "d", "eid").gfql_index_all(engine="polars")
+    ops = [n({"key": 0}, name="a"), e_forward({"type": "X"}), n(name="b"), rows(), select([("text", "b.text")])]
+    assert _try_point_rows_polars(g, ops) is None

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
@@ -107,8 +107,30 @@ def test_joined_projection_declines_unsupported_items(items):
     assert _try_point_rows_polars(g, ops) is None
 
 
-def test_joined_projection_temporal_constructor_text_declines():
+@pytest.mark.parametrize("tail_filter", [{}, {"id": 1001}])
+def test_joined_projection_temporal_constructor_text_declines(tail_filter):
     g = make_graph()
     g = graphistry.nodes(g._nodes.with_columns(pl.lit("date({year: 2020})").alias("text")), "key").edges(g._edges, "s", "d", "eid").gfql_index_all(engine="polars")
-    ops = [n({"key": 0}, name="a"), e_forward({"type": "X"}), n(name="b"), rows(), select([("text", "b.text")])]
+    ops = [n({"key": 0}, name="a"), e_forward({"type": "X"}), n(tail_filter, name="b"), rows(), select([("text", "b.text")])]
     assert _try_point_rows_polars(g, ops) is None
+
+
+@pytest.mark.parametrize("variant", ["base", "nullable", "categorical", "timestamp", "float-null", "empty"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("include_edge", [False, True])
+def test_singleton_joined_projection_preserves_edge_bag(variant, reverse, include_edge):
+    from polars.testing import assert_frame_equal
+    g = make_graph(variant)
+    edge = e_reverse if reverse else e_forward
+    items = [("source", "a.id"), ("target", "b.id"), ("value", "b.value")]
+    if include_edge:
+        items.append(("weight", "e.weight"))
+    ops = [n({"id": 1000}, name="a"), edge({"type": "X"}, name="e"),
+           n({"id": 1001}, name="b"), rows(), select(items)]
+    direct = _try_point_rows_polars(g, ops)
+    assert direct is not None
+    with routes_off(["polars-point-rows"]):
+        expected = g.gfql(ops, engine="polars")
+    assert_frame_equal(direct._nodes, expected._nodes)
+    assert_frame_equal(direct._edges, expected._edges)
+    assert direct._nodes.height == (0 if variant == "empty" else 1 if reverse else 2)

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
@@ -134,3 +134,41 @@ def test_singleton_joined_projection_preserves_edge_bag(variant, reverse, includ
     assert_frame_equal(direct._nodes, expected._nodes)
     assert_frame_equal(direct._edges, expected._edges)
     assert direct._nodes.height == (0 if variant == "empty" else 1 if reverse else 2)
+
+
+@pytest.mark.parametrize("variant", ["single", "parallel", "loop", "dangling", "null", "filtered", "mixed", "empty", "large-ids", "two-seeds"])
+@pytest.mark.parametrize("source", ["a", "b"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_singleton_bookkeeping_preserves_indexed_endpoint_semantics(variant, source, reverse):
+    from polars.testing import assert_frame_equal
+    offset = 2**63 + 2 if variant == "large-ids" else 0
+    dtype = pl.UInt64 if variant == "large-ids" else pl.Int64
+    nodes = pl.DataFrame({
+        "key": pl.Series([offset + i for i in range(100)], dtype=dtype),
+        "id": [1000 + i for i in range(100)],
+        "kind": ["Other" if i == 2 else "Person" for i in range(100)],
+    })
+    targets = {"parallel": [1, 1, 1], "loop": [0], "dangling": [9999], "null": [None],
+               "filtered": [2], "mixed": [1, 2, 9999, None, 1], "empty": []}.get(variant, [1])
+    starts = [0] * len(targets)
+    if variant == "two-seeds":
+        nodes = nodes.with_columns(pl.when(pl.col("key") == 2).then(1000).otherwise(pl.col("id")).alias("id"))
+        starts, targets = [0, 2], [1, 1]
+    columns = {"s": starts, "d": targets} if not reverse else {"s": targets, "d": starts}
+    edges = pl.DataFrame({
+        **{column: pl.Series([None if value is None else value + offset for value in values], dtype=dtype)
+           for column, values in columns.items()},
+        "eid": pl.Series(range(len(targets)), dtype=pl.Int64),
+        "type": pl.Series(["X"] * len(targets), dtype=pl.String),
+    })
+    g = graphistry.nodes(nodes, "key").edges(edges, "s", "d", "eid").gfql_index_all(engine="polars").gfql_index_node_props(["id"], engine="polars")
+    before_nodes, before_edges = g._nodes.clone(), g._edges.clone()
+    edge = e_reverse if reverse else e_forward
+    ops = [n({"id": 1000}, name="a"), edge({"type": "X"}, name="e"), n({"kind": "Person"}, name="b"), rows(source=source)]
+    actual = g.gfql(ops, engine="polars", index_policy="use")
+    with routes_off(["polars-point-rows"]):
+        expected = g.gfql(ops, engine="polars", index_policy="use")
+    assert_frame_equal(actual._nodes, expected._nodes)
+    assert_frame_equal(actual._edges, expected._edges)
+    assert_frame_equal(g._nodes, before_nodes)
+    assert_frame_equal(g._edges, before_edges)

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_point_rows.py
@@ -1,0 +1,72 @@
+"""Native indexed source rows preserve the existing Polars result contract."""
+import pytest
+import graphistry
+from graphistry.compute.ast import e_forward, e_reverse, n, rows, select
+from graphistry.compute.gfql.lazy.engine.polars.chain_specializations.point_rows import _try_point_rows_polars
+from graphistry.tests.compute.chain_specializations.test_point_rows import graph
+from graphistry.tests.compute.gfql.routes.switch import routes_off
+
+pl = pytest.importorskip("polars")
+
+
+def make_graph(variant="base"):
+    base = graph("pandas", variant)
+    nodes = pl.from_pandas(base._nodes).reverse()
+    edges = pl.from_pandas(base._edges)
+    return graphistry.nodes(nodes, "key").edges(edges, "s", "d", "eid").gfql_index_all(engine="polars").gfql_index_node_props(["id"], engine="polars")
+
+
+@pytest.mark.parametrize("variant", ["base", "loop", "dangling", "nonleading", "empty", "nullable", "timestamp", "float-null"])
+@pytest.mark.parametrize("source", ["a", "b"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("project", [False, True])
+def test_source_rows_exact_parity(variant, source, reverse, project):
+    g = make_graph(variant)
+    edge = e_reverse if reverse else e_forward
+    ops = [n({"id": 1000}, name="a"), edge({"type": "X"}, name="e"), n({"kind": "Person"}, name="b"), rows(source=source)]
+    if project:
+        ops.append(select([("id", source + ".id"), ("value", source + ".value")]))
+    direct = _try_point_rows_polars(g, ops)
+    assert direct is not None
+    with routes_off(["polars-point-rows"]):
+        expected = g.gfql(ops, engine="polars")
+    actual = g.gfql(ops, engine="polars")
+    from polars.testing import assert_frame_equal
+    for result in (direct, actual):
+        assert_frame_equal(result._nodes, expected._nodes)
+        assert_frame_equal(result._edges, expected._edges)
+        for attr in ("_node", "_edge", "_source", "_destination", "_gfql_rows_base_graph", "_gfql_start_nodes"):
+            assert getattr(result, attr) == getattr(expected, attr)
+
+
+@pytest.mark.parametrize("reason", ["unindexed", "collision", "start", "gpu", "extra-params"])
+def test_source_rows_decline_boundaries(reason):
+    from graphistry.compute.gfql.lazy import target_mode, ExecutionTarget
+    g = make_graph()
+    ops = [n({"id": 1000}, name="a"), rows(source="a")]
+    start = None
+    if reason == "unindexed":
+        g = graphistry.nodes(g._nodes.clone(), "key").edges(g._edges.clone(), "s", "d")
+    elif reason == "collision":
+        g = g.nodes(g._nodes.with_columns(pl.lit("user").alias("a")))
+    elif reason == "start":
+        start = g._nodes.head(1)
+    elif reason == "extra-params":
+        ops[-1].params["attach_prop_aliases"] = ["a"]
+    with target_mode(ExecutionTarget.GPU if reason == "gpu" else ExecutionTarget.CPU):
+        assert _try_point_rows_polars(g, ops, start) is None
+
+
+@pytest.mark.parametrize("project", [False, True])
+def test_single_node_property_multihit_order(project):
+    from polars.testing import assert_frame_equal
+    g = make_graph()
+    g = graphistry.nodes(g._nodes.with_columns((pl.col("id") % 2).alias("bucket")), "key").edges(g._edges, "s", "d", "eid")
+    g = g.gfql_index_all(engine="polars").gfql_index_node_props(["bucket"], engine="polars")
+    ops = [n({"bucket": 0}, name="a"), rows(source="a")]
+    if project:
+        ops.append(select([("id", "a.id")]))
+    with routes_off(["polars-point-rows"]):
+        expected = g.gfql(ops, engine="polars", index_policy="force")
+    actual = g.gfql(ops, engine="polars", index_policy="force")
+    assert_frame_equal(actual._nodes, expected._nodes)

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
@@ -80,10 +80,11 @@ def test_seeded_lane_never_serves_a_shape_it_does_not_admit(name):
     ops = by_name()[name].ops()
     g = _indexed_polars_graph()
     real = pchain._try_seeded_chain_polars
-    hit = {"n": 0}
+    hit = {"n": 0, "invalid": 0}
 
-    def spy(*a, **k):
-        r = real(*a, **k)
+    def spy(graph, lane_ops, *a, **k):
+        r = real(graph, lane_ops, *a, **k)
+        hit["invalid"] += r is not None and not polars_seeded_lane_admits(lane_ops)
         hit["n"] += r is not None
         return r
     pchain._try_seeded_chain_polars = spy
@@ -93,7 +94,8 @@ def test_seeded_lane_never_serves_a_shape_it_does_not_admit(name):
         pass
     finally:
         pchain._try_seeded_chain_polars = real
-    assert hit["n"] == 0 or polars_seeded_lane_admits(ops), f"{name}: served without admission"
+
+    assert hit["invalid"] == 0, f"{name}: served without admission"
 
 
 SEEDED_LANE_SERVES_DIRECTLY = SEEDED_LANE_ADMITS - {

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/chain_specializations/test_polars_admission.py
@@ -129,3 +129,41 @@ def test_prune_to_endpoints_is_a_typed_decline_on_polars_and_served_on_pandas(op
     assert _sig(g_pd.gfql(ops, engine="pandas"))[0] == [2, 3]
     assert polars_plain_single_hop_admits(ops, None) is None
     assert polars_plain_single_hop_admits([n({"key": 1}), e_forward(), n()], None) == "seeded-index"
+
+
+@pytest.mark.parametrize("engine_name", ["pandas", "polars", "polars-gpu"])
+@pytest.mark.parametrize("values", [[], [None], [1], ["a"], [None, None], [1, 1], [1, 2], [1, None]])
+@pytest.mark.parametrize("n_keys", [1, 50, 51, 100])
+@pytest.mark.parametrize("edge_count", [0, 500])
+def test_indexed_frontier_cost_matches_native_unique_count(engine_name, values, n_keys, edge_count):
+    from types import SimpleNamespace
+    import numpy as np
+    from graphistry.Engine import Engine
+    from graphistry.compute.chain_specializations.admission import _indexed_kernel_admits
+    from graphistry.compute.gfql.index.cost import cost_gate_frac
+
+    engine = Engine(engine_name)
+    if engine == Engine.PANDAS:
+        seeds = pd.DataFrame({"key": values})
+        count = int(seeds["key"].nunique())
+        edges = pd.DataFrame({"s": [1] * edge_count})
+    else:
+        seeds = pl.DataFrame({"key": values})
+        count = seeds["key"].n_unique()
+        edges = pl.DataFrame({"s": [1] * edge_count})
+    frac = cost_gate_frac(engine)
+    expected = count < frac * n_keys and edge_count < frac * 1000
+    ctx = (None, SimpleNamespace(n_keys=n_keys), np, engine)
+    assert _indexed_kernel_admits(seeds, edges, {"key": 1}, "key", "property_index", ctx, 100, 1000) == expected
+
+
+def test_singleton_frontier_preserves_missing_binding_error():
+    from types import SimpleNamespace
+    import numpy as np
+    from graphistry.Engine import Engine
+    from graphistry.compute.chain_specializations.admission import _indexed_kernel_admits
+
+    seeds = pl.DataFrame({"other": [1]})
+    ctx = (None, SimpleNamespace(n_keys=100), np, Engine.POLARS)
+    with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        _indexed_kernel_admits(seeds, seeds.clear(), {"key": 1}, "key", "property_index", ctx, 100, 1000)

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/test_predicates.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/test_predicates.py
@@ -1,0 +1,102 @@
+"""Singleton filters preserve expression filtering, including errors and fallback."""
+import pytest
+
+pl = pytest.importorskip("polars")
+from polars.testing import assert_frame_equal
+from graphistry.Engine import Engine
+from graphistry.compute.chain_fast_paths import _verify_scalar_filters_on_hit
+from graphistry.compute.gfql.lazy import ExecutionTarget, target_mode
+from graphistry.compute.gfql.lazy.engine.polars.predicates import (
+    _filter_singleton_equalities, filter_by_dict_polars, filter_expr_by_dict_polars,
+)
+
+
+def oracle(frame, filters):
+    expr = filter_expr_by_dict_polars(frame, filters)
+    return frame if expr is None else frame.filter(expr)
+
+
+@pytest.mark.parametrize("dtype,bits,signed", [
+    (pl.Int8, 8, True), (pl.Int16, 16, True), (pl.Int32, 32, True), (pl.Int64, 64, True),
+    (pl.UInt8, 8, False), (pl.UInt16, 16, False), (pl.UInt32, 32, False), (pl.UInt64, 64, False),
+])
+def test_integer_boundaries(dtype, bits, signed):
+    low, high = (-(2 ** (bits - 1)), 2 ** (bits - 1) - 1) if signed else (0, 2**bits - 1)
+    for actual in (None, low, high, 0, 1):
+        frame = pl.DataFrame({"x": pl.Series([actual], dtype=dtype), "keep": ["payload"]})
+        original = frame.clone()
+        for expected in (low - 1, low, high, high + 1, -1, 0, 1, 2**53 + 1, 2**63 - 1):
+            filters = {"x": expected}
+            assert_frame_equal(filter_by_dict_polars(frame, filters), oracle(frame, filters))
+            verified = _verify_scalar_filters_on_hit(frame, filters, Engine.POLARS)
+            if verified is not None:
+                assert_frame_equal(verified, oracle(frame, filters))
+        assert_frame_equal(frame, original)
+
+
+@pytest.mark.parametrize("dtype,value,expected", [
+    (pl.Boolean, True, True), (pl.Boolean, False, True), (pl.Boolean, None, False),
+    (pl.String, "", ""), (pl.String, "雪", "雪"), (pl.String, None, "x"),
+    (pl.String, "date('2020-01-01')", "date('2020-01-01')"),
+])
+def test_supported_scalar_parity(dtype, value, expected):
+    frame = pl.DataFrame({"x": pl.Series([value], dtype=dtype)})
+    result = _filter_singleton_equalities(frame, {"x": expected})
+    assert result is not None
+    assert_frame_equal(result, oracle(frame, {"x": expected}))
+
+
+@pytest.mark.parametrize("value", [1.0, float("nan"), None, [1], True, "1"])
+def test_unsupported_values_and_errors(value):
+    frame = pl.DataFrame({"first": [False], "x": [1]})
+    filters = {"first": True, "x": value}
+    assert _filter_singleton_equalities(frame, filters) is None
+    try:
+        expected = oracle(frame, filters)
+    except Exception as error:
+        with pytest.raises(type(error)) as caught:
+            filter_by_dict_polars(frame, filters)
+        assert str(caught.value) == str(error)
+    else:
+        assert_frame_equal(filter_by_dict_polars(frame, filters), expected)
+
+
+@pytest.mark.parametrize("frame,filters", [
+    (pl.DataFrame({"x": []}, schema={"x": pl.Int64}), {"x": 1}),
+    (pl.DataFrame({"x": [1, 1]}), {"x": 1}),
+    (pl.DataFrame({"x": [1]}).lazy(), {"x": 1}),
+    (pl.DataFrame({"x": [1]}), {}),
+    (pl.DataFrame({"x": [None]}), {"x": 1}),
+    (pl.DataFrame({"type": ["Person"]}), {"label__Person": True}),
+    (pl.DataFrame({"labels": [["Person"]]}), {"labels": "Person"}),
+    (pl.DataFrame({"label__Person": [True]}), {"type": "Person"}),
+    (pl.DataFrame({"x": [1.0]}), {"x": 1}),
+])
+def test_fallback_parity(frame, filters):
+    assert _filter_singleton_equalities(frame, filters) is None
+    actual, expected = filter_by_dict_polars(frame, filters), oracle(frame, filters)
+    if isinstance(actual, pl.LazyFrame):
+        actual, expected = actual.collect(), expected.collect()
+    assert_frame_equal(actual, expected)
+
+
+def test_missing_column_error_after_mismatch():
+    frame = pl.DataFrame({"x": [1]})
+    filters = {"x": 2, "missing": 1}
+    assert _filter_singleton_equalities(frame, filters) is None
+    with pytest.raises(Exception) as expected:
+        oracle(frame, filters)
+    with pytest.raises(type(expected.value)) as actual:
+        filter_by_dict_polars(frame, filters)
+    assert str(actual.value) == str(expected.value)
+
+
+def test_gpu_target_declines_scalar_read(monkeypatch):
+    frame = pl.DataFrame({"x": [1]})
+    def forbidden(*args, **kwargs):
+        raise AssertionError("GPU target must not extract a Python scalar")
+    monkeypatch.setattr(pl.Series, "item", forbidden)
+    with target_mode(ExecutionTarget.GPU):
+        assert _filter_singleton_equalities(frame, {"x": 1}) is None
+        assert _verify_scalar_filters_on_hit(frame, {"x": 1}, Engine.POLARS) is None
+        assert_frame_equal(filter_by_dict_polars(frame, {"x": 1}), frame)

--- a/graphistry/tests/compute/gfql/lazy/engine/polars/test_predicates.py
+++ b/graphistry/tests/compute/gfql/lazy/engine/polars/test_predicates.py
@@ -1,4 +1,4 @@
-"""Singleton filters preserve expression filtering, including errors and fallback."""
+"""Small CPU filters preserve expression filtering, including errors and fallback."""
 import pytest
 
 pl = pytest.importorskip("polars")
@@ -7,7 +7,7 @@ from graphistry.Engine import Engine
 from graphistry.compute.chain_fast_paths import _verify_scalar_filters_on_hit
 from graphistry.compute.gfql.lazy import ExecutionTarget, target_mode
 from graphistry.compute.gfql.lazy.engine.polars.predicates import (
-    _filter_singleton_equalities, filter_by_dict_polars, filter_expr_by_dict_polars,
+    _filter_singleton_equalities, _filter_small_equalities, filter_by_dict_polars, filter_expr_by_dict_polars,
 )
 
 
@@ -20,10 +20,11 @@ def oracle(frame, filters):
     (pl.Int8, 8, True), (pl.Int16, 16, True), (pl.Int32, 32, True), (pl.Int64, 64, True),
     (pl.UInt8, 8, False), (pl.UInt16, 16, False), (pl.UInt32, 32, False), (pl.UInt64, 64, False),
 ])
-def test_integer_boundaries(dtype, bits, signed):
+@pytest.mark.parametrize("height", [1, 2, 32, 33])
+def test_integer_boundaries(dtype, bits, signed, height):
     low, high = (-(2 ** (bits - 1)), 2 ** (bits - 1) - 1) if signed else (0, 2**bits - 1)
     for actual in (None, low, high, 0, 1):
-        frame = pl.DataFrame({"x": pl.Series([actual], dtype=dtype), "keep": ["payload"]})
+        frame = pl.DataFrame({"x": pl.Series([actual] * height, dtype=dtype), "keep": ["payload"] * height})
         original = frame.clone()
         for expected in (low - 1, low, high, high + 1, -1, 0, 1, 2**53 + 1, 2**63 - 1):
             filters = {"x": expected}
@@ -100,3 +101,67 @@ def test_gpu_target_declines_scalar_read(monkeypatch):
         assert _filter_singleton_equalities(frame, {"x": 1}) is None
         assert _verify_scalar_filters_on_hit(frame, {"x": 1}, Engine.POLARS) is None
         assert_frame_equal(filter_by_dict_polars(frame, {"x": 1}), frame)
+
+
+@pytest.mark.parametrize("height", [2, 3, 31, 32, 33])
+@pytest.mark.parametrize("dtype,hit,miss", [(pl.Int64, 2**53 + 1, 2**53),
+                                           (pl.String, "雪", ""), (pl.Boolean, True, False)])
+@pytest.mark.parametrize("pattern", ["all", "none", "prefix", "suffix", "alternating", "nulls"])
+def test_small_filter_expression_parity(height, dtype, hit, miss, pattern):
+    flags = {"all": [True] * height, "none": [False] * height,
+             "prefix": [i < height // 2 for i in range(height)],
+             "suffix": [i >= height // 2 for i in range(height)],
+             "alternating": [i % 2 == 0 for i in range(height)],
+             "nulls": [i % 3 == 0 for i in range(height)]}[pattern]
+    values = [hit if flag else None if pattern == "nulls" else miss for flag in flags]
+    frame = pl.DataFrame({"x": pl.Series(values, dtype=dtype), "order": range(height)})
+    original = frame.clone()
+    filters = {"x": hit}
+    direct = _filter_small_equalities(frame, filters)
+    if height <= 32:
+        assert direct is not None
+        assert_frame_equal(direct, oracle(frame, filters))
+    else:
+        assert direct is None
+    assert_frame_equal(filter_by_dict_polars(frame, filters), oracle(frame, filters))
+    assert_frame_equal(frame, original)
+
+
+@pytest.mark.parametrize("height", [2, 32])
+@pytest.mark.parametrize("filters", [{"x": 99, "missing": 1}, {"x": 99, "s": 1},
+                                    {"x": 99, "s": ["a"]}, {"x": 99, "x2": 1.0}])
+def test_small_filter_preserves_later_fallback_or_error(height, filters):
+    frame = pl.DataFrame({"x": [1] * height, "s": ["a"] * height, "x2": [1] * height})
+    assert _filter_small_equalities(frame, filters) is None
+    try:
+        expected = oracle(frame, filters)
+    except Exception as error:
+        with pytest.raises(type(error)) as caught:
+            filter_by_dict_polars(frame, filters)
+        assert str(caught.value) == str(error)
+    else:
+        assert_frame_equal(filter_by_dict_polars(frame, filters), expected)
+
+
+def test_small_gpu_filter_does_not_extract_values(monkeypatch):
+    frame = pl.DataFrame({"x": [1, 2, None]})
+    def forbidden(*args, **kwargs):
+        raise AssertionError("GPU target must not extract Python values")
+    monkeypatch.setattr(pl.Series, "to_list", forbidden)
+    with target_mode(ExecutionTarget.GPU):
+        assert _filter_small_equalities(frame, {"x": 1}) is None
+        assert _verify_scalar_filters_on_hit(frame, {"x": 1}, Engine.POLARS) is None
+        assert_frame_equal(filter_by_dict_polars(frame, {"x": 1}), frame.slice(0, 1))
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_small_filter_intersects_multiple_supported_predicates(reverse):
+    frame = pl.DataFrame({"x": [1, 1, 2, 1, 1, None],
+                          "flag": [True, False, True, True, None, True],
+                          "order": range(6)})
+    entries = [("x", 1), ("flag", True)]
+    filters = dict(reversed(entries) if reverse else entries)
+    actual = _filter_small_equalities(frame, filters)
+    assert actual is not None
+    assert actual.get_column("order").to_list() == [0, 3]
+    assert_frame_equal(actual, oracle(frame, filters))

--- a/graphistry/tests/compute/gfql/routes/corpus.py
+++ b/graphistry/tests/compute/gfql/routes/corpus.py
@@ -1,4 +1,8 @@
-"""Shared shape corpus for the chain routes.
+"""Supplemental shape corpus for the chain route engagement matrix.
+
+This matrix measures admission and engagement; it does not replace existing correctness
+tests. ``bin/test-routes-off.sh`` broadcasts the existing suites through every route
+switch and all routes disabled, retaining their independently written assertions.
 
 Every entry is a native op-list shape variant; a route test filters the corpus with the
 route's own admission predicate (the function its dispatcher calls), so one corpus is reused

--- a/graphistry/tests/compute/gfql/routes/corpus.py
+++ b/graphistry/tests/compute/gfql/routes/corpus.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, List, NamedTuple, Tuple
 
 import pandas as pd
 
-from graphistry.compute.ast import ASTObject, e_forward, e_reverse, e_undirected, n
+from graphistry.compute.ast import ASTObject, e_forward, e_reverse, e_undirected, n, rows, select
 from graphistry.compute.predicates.numeric import GT
 from graphistry.tests.compute.gfql.routes.registry import Frames, register
 
@@ -33,6 +33,12 @@ NODES = pd.DataFrame({"key": [1, 2, 3, 4, 5], "id": [10, 20, 30, 40, 50], "type"
 EDGES = pd.DataFrame({"s": [1, 1, 2, 3, 3, 4], "d": [2, 3, 3, 1, 1, 5], "type": ["KNOWS", "KNOWS", "LIKES", "KNOWS", "KNOWS", "LIKES"], "eid": [0, 1, 2, 3, 4, 5], "w": [1, 2, 3, 4, 5, 6]})
 
 CORPUS: List[Entry] = [
+    _entry("point node rows", lambda k: [n({"key": k(1)}, name="a"), rows(source="a")], ("point-rows", "single-node")),
+    _entry("point node projection", lambda k: [n({"key": k(1)}, name="a"), rows(source="a"), select(["key", ("value", "a.w")])], ("point-rows", "single-node", "projection")),
+    _entry("point typed hop rows", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(source="b")], ("point-rows", "single-hop")),
+    _entry("point typed hop seed rows", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(source="a")], ("point-rows", "single-hop")),
+    _entry("point reverse hop projection", lambda k: [n({"key": k(1)}, name="a"), e_reverse({"type": "KNOWS"}), n(name="b"), rows(source="b"), select(["key", ("value", "b.w")])], ("point-rows", "single-hop", "reverse", "projection")),
+
     _entry("single node, scalar filter", lambda k: [n({"id": 30})], ("single-node",)),
     _entry("single node, named", lambda k: [n({"id": 30}, name="a")], ("single-node", "alias")),
     _entry("single node, predicate filter", lambda k: [n({"w": GT(2)})], ("single-node", "predicate")),

--- a/graphistry/tests/compute/gfql/routes/corpus.py
+++ b/graphistry/tests/compute/gfql/routes/corpus.py
@@ -35,6 +35,7 @@ EDGES = pd.DataFrame({"s": [1, 1, 2, 3, 3, 4], "d": [2, 3, 3, 1, 1, 5], "type": 
 CORPUS: List[Entry] = [
     _entry("point node rows", lambda k: [n({"key": k(1)}, name="a"), rows(source="a")], ("point-rows", "single-node")),
     _entry("point node projection", lambda k: [n({"key": k(1)}, name="a"), rows(source="a"), select(["key", ("value", "a.w")])], ("point-rows", "single-node", "projection")),
+    _entry("point joined hop projection", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(), select([("key", "b.key"), ("seed", "a.w"), ("tail", "b.w")])], ("point-rows", "single-hop", "projection")),
     _entry("point typed hop rows", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(source="b")], ("point-rows", "single-hop")),
     _entry("point typed hop seed rows", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(source="a")], ("point-rows", "single-hop")),
     _entry("point reverse hop projection", lambda k: [n({"key": k(1)}, name="a"), e_reverse({"type": "KNOWS"}), n(name="b"), rows(source="b"), select(["key", ("value", "b.w")])], ("point-rows", "single-hop", "reverse", "projection")),

--- a/graphistry/tests/compute/gfql/routes/corpus.py
+++ b/graphistry/tests/compute/gfql/routes/corpus.py
@@ -35,6 +35,7 @@ EDGES = pd.DataFrame({"s": [1, 1, 2, 3, 3, 4], "d": [2, 3, 3, 1, 1, 5], "type": 
 CORPUS: List[Entry] = [
     _entry("point node rows", lambda k: [n({"key": k(1)}, name="a"), rows(source="a")], ("point-rows", "single-node")),
     _entry("point node projection", lambda k: [n({"key": k(1)}, name="a"), rows(source="a"), select(["key", ("value", "a.w")])], ("point-rows", "single-node", "projection")),
+    _entry("point node coalesce", lambda k: [n({"key": k(1)}, name="a"), rows(source="a"), select([("key", "a.key"), ("value", "coalesce(a.w, a.key)")])], ("point-rows", "single-node", "projection")),
     _entry("point joined hop projection", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(), select([("key", "b.key"), ("seed", "a.w"), ("tail", "b.w")])], ("point-rows", "single-hop", "projection")),
     _entry("point typed hop rows", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(source="b")], ("point-rows", "single-hop")),
     _entry("point typed hop seed rows", lambda k: [n({"key": k(1)}, name="a"), e_forward({"type": "KNOWS"}), n(name="b"), rows(source="a")], ("point-rows", "single-hop")),

--- a/graphistry/tests/compute/gfql/routes/registry.py
+++ b/graphistry/tests/compute/gfql/routes/registry.py
@@ -69,4 +69,8 @@ def graph_for(shape: Shape, engine: str, indexed: bool = False) -> Plottable:
     import graphistry
     f = shape.frames
     g = graphistry.nodes(to_engine(f.nodes, engine), f.node).edges(to_engine(f.edges, engine), f.src, f.dst, f.edge)
+    if indexed and engine == "cudf" and any(
+        df[col].dtype.kind == "O" for df, col in ((f.nodes, f.node), (f.edges, f.src), (f.edges, f.dst))
+    ):
+        return g
     return g.gfql_index_all(engine=engine) if indexed else g

--- a/graphistry/tests/compute/gfql/routes/switch.py
+++ b/graphistry/tests/compute/gfql/routes/switch.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 from typing import Iterable, Iterator, List, Tuple
 
-ROUTES = ("native-fast", "polars-single-node", "polars-seeded", "polars-plain", "index-hop", "indexed-kernel", "cypher-fast")
+ROUTES = ("point-rows", "native-fast", "polars-single-node", "polars-seeded", "polars-plain", "index-hop", "indexed-kernel", "cypher-fast")
 
 
 def _none(*a, **k):
@@ -20,6 +20,8 @@ def _targets(routes: Iterable[str]) -> List[Tuple[object, str]]:
     unknown = routes - set(ROUTES)
     assert not unknown, f"unknown route(s) {sorted(unknown)}; known: {ROUTES}"
     out: List[Tuple[object, str]] = []
+    if "point-rows" in routes:
+        out.append((chain_mod, "_try_point_rows"))
     if "native-fast" in routes:
         out.append((chain_mod, "_try_chain_fast_path"))
     if "polars-single-node" in routes:

--- a/graphistry/tests/compute/gfql/routes/switch.py
+++ b/graphistry/tests/compute/gfql/routes/switch.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 from typing import Iterable, Iterator, List, Tuple
 
-ROUTES = ("point-rows", "native-fast", "polars-single-node", "polars-seeded", "polars-plain", "index-hop", "indexed-kernel", "cypher-fast")
+ROUTES = ("polars-point-rows", "point-rows", "native-fast", "polars-single-node", "polars-seeded", "polars-plain", "index-hop", "indexed-kernel", "cypher-fast")
 
 
 def _none(*a, **k):
@@ -20,6 +20,8 @@ def _targets(routes: Iterable[str]) -> List[Tuple[object, str]]:
     unknown = routes - set(ROUTES)
     assert not unknown, f"unknown route(s) {sorted(unknown)}; known: {ROUTES}"
     out: List[Tuple[object, str]] = []
+    if "polars-point-rows" in routes:
+        out.append((pchain, "_try_point_rows_polars"))
     if "point-rows" in routes:
         out.append((chain_mod, "_try_point_rows"))
     if "native-fast" in routes:

--- a/graphistry/tests/compute/gfql/routes/test_has_collision_contract.py
+++ b/graphistry/tests/compute/gfql/routes/test_has_collision_contract.py
@@ -1,0 +1,31 @@
+"""HAS destination narrowing depends on reached collisions before node predicates."""
+import pandas as pd
+import pytest
+import graphistry
+from graphistry.tests.compute.gfql.routes.registry import to_engine
+from graphistry.tests.compute.gfql.routes.switch import ROUTES, routes_off
+
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
+@pytest.mark.parametrize("reverse_rows", [False, True])
+@pytest.mark.parametrize("collision", [False, True])
+@pytest.mark.parametrize("explicit_label", [False, True])
+@pytest.mark.parametrize("property_filter", [False, True])
+def test_reached_has_collision_before_destination_filter(engine, reverse_rows, collision, explicit_label, property_filter):
+    records = [(601, True, False, None), (300, False, False, "f300"),
+               (400, False, True, "t4"), (400 if collision else 401, False, False, "f4"),
+               (500, False, True, "t5"), (500, False, False, "f5")]
+    nodes = pd.DataFrame(records[::-1] if reverse_rows else records,
+                         columns=["id", "label__Post", "label__Tag", "name"])
+    edges = pd.DataFrame({"s": [601, 601], "d": [400, 300], "type": ["HAS_TAG", "HAS_TAG"]})
+    graph = graphistry.nodes(to_engine(nodes, engine), "id").edges(to_engine(edges, engine), "s", "d")
+    label = ":Tag" if explicit_label else ""
+    predicate = " {name: 'f300'}" if property_filter else ""
+    query = "MATCH (p:Post {id: 601})-[:HAS_TAG]->(t" + label + predicate + ") RETURN t.name AS name ORDER BY name"
+    expected = (["t4"] if collision or explicit_label else ["f300", "t4"])
+    if property_filter:
+        expected = [value for value in expected if value == "f300"]
+    for disabled in ((), ROUTES):
+        with routes_off(disabled):
+            frame = graph.gfql(query, engine=engine)._nodes
+        values = frame["name"].to_list() if engine == "polars" else (frame.to_pandas() if engine == "cudf" else frame)["name"].tolist()
+        assert values == expected, (engine, disabled, collision, explicit_label, property_filter)

--- a/graphistry/tests/compute/gfql/routes/test_node_selection_rows.py
+++ b/graphistry/tests/compute/gfql/routes/test_node_selection_rows.py
@@ -1,0 +1,47 @@
+"""Node selection preserves source-row identity without traversal set semantics."""
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute import n
+from graphistry.compute.chain import chain
+from graphistry.tests.compute.gfql.routes.registry import to_engine
+from graphistry.tests.compute.gfql.routes.switch import ROUTES, routes_off
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
+@pytest.mark.parametrize("named", [False, True])
+@pytest.mark.parametrize("selection", ["all", "matching", "missing"])
+@pytest.mark.parametrize("seeded", [False, True])
+def test_node_selection_retains_source_rows(engine, named, selection, seeded):
+    ids = [1, 1, None, 2]
+    values = [10, 11, 12, 13]
+    nodes = pd.DataFrame({"id": pd.Series(ids, dtype="Int64"), "value": values,
+                          "keep": [True, True, True, False]})
+    edges = pd.DataFrame({"s": pd.Series([], dtype="Int64"), "d": pd.Series([], dtype="Int64")})
+    graph = graphistry.nodes(to_engine(nodes, engine), "id").edges(to_engine(edges, engine), "s", "d")
+    start = to_engine(nodes.iloc[[0, 3]], engine) if seeded else None
+    filters = {} if selection == "all" else ({"keep": True} if selection == "matching" else {"value": 99})
+    expected = [{"id": node_id, "value": value} for position, (node_id, value) in enumerate(zip(ids, values))
+                if (not seeded or position in (0, 3))
+                and (selection == "all" or (selection == "matching" and value != 13))]
+    for disabled in ((), ROUTES):
+        with routes_off(disabled):
+            ops = [n(filters, name="picked" if named else None)]
+            result = (chain(graph, ops, engine=engine, start_nodes=start) if seeded
+                      else graph.gfql(ops, engine=engine))
+        frame = result._nodes
+        expected_columns = (["id", "picked", "value", "keep"] if named and engine != "polars"
+                            else ["id", "value", "keep"] + (["picked"] if named else []))
+        assert list(frame.columns) == expected_columns
+        if engine == "polars":
+            actual = frame.select(["id", "value"]).to_dicts()
+            flags = frame["picked"].to_list() if named else []
+        else:
+            frame = frame.to_pandas() if engine == "cudf" else frame
+            actual = [{"id": None if pd.isna(node_id) else int(node_id), "value": int(value)}
+                      for node_id, value in zip(frame["id"], frame["value"])]
+            flags = frame["picked"].tolist() if named else []
+        assert actual == expected, (engine, disabled, seeded)
+        assert flags == ([True] * len(expected) if named else [])
+        assert len(result._edges) == 0

--- a/graphistry/tests/compute/gfql/routes/test_point_boundaries.py
+++ b/graphistry/tests/compute/gfql/routes/test_point_boundaries.py
@@ -1,0 +1,46 @@
+"""Broadcast a graph-theoretic bag oracle across point-row size boundaries."""
+import os
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import e_forward, e_reverse, n, rows, select
+from graphistry.tests.compute.gfql.routes.registry import to_engine
+from graphistry.tests.compute.gfql.routes.switch import ROUTES, routes_off
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
+@pytest.mark.parametrize("count", [0, 1, 2, 8, 9, 32, 33])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("aliases", [("a", "b"), ("seed_node", "target_node")])
+def test_point_joined_bag_matches_input_edge_oracle(engine, count, reverse, aliases):
+    if engine == "cudf" and os.environ.get("TEST_CUDF") != "1":
+        pytest.skip("cuDF lane runs with TEST_CUDF=1")
+    # Repeated destinations are distinct paths, and a different edge type is excluded.
+    targets = [1 + i % 3 for i in range(count)]
+    nodes = pd.DataFrame({"key": [0, 1, 2, 3], "value": [11, 22, 33, 44]})
+    starts, ends = [0] * (count + 1), targets + [3]
+    if reverse:
+        starts, ends = ends, starts
+    edges = pd.DataFrame({"s": starts, "d": ends, "eid": range(count + 1),
+                          "type": ["X"] * count + ["Y"]})
+    g = graphistry.nodes(to_engine(nodes, engine), "key").edges(
+        to_engine(edges, engine), "s", "d", "eid").gfql_index_all(engine=engine)
+    a, b = aliases
+    ops = [n({"key": 0}, name=a), (e_reverse if reverse else e_forward)({"type": "X"}, name="link"),
+           n(name=b), rows(), select([("seed", f"{a}.value"), ("target", f"{b}.value"),
+                                      ("edge", "link.eid")])]
+    expected = sorted((11, (target + 1) * 11, i) for i, target in enumerate(targets))
+
+    def values(result):
+        frame = result._nodes
+        if hasattr(frame, "to_dicts"):
+            return sorted((r["seed"], r["target"], r["edge"]) for r in frame.to_dicts())
+        if hasattr(frame, "to_pandas"):
+            frame = frame.to_pandas()
+        return sorted(frame[["seed", "target", "edge"]].itertuples(index=False, name=None))
+
+    assert values(g.gfql(ops, engine=engine, index_policy="force")) == expected
+    with routes_off(ROUTES):
+        assert values(g.gfql(ops, engine=engine, index_policy="force")) == expected

--- a/graphistry/tests/compute/gfql/routes/test_point_boundaries.py
+++ b/graphistry/tests/compute/gfql/routes/test_point_boundaries.py
@@ -44,3 +44,49 @@ def test_point_joined_bag_matches_input_edge_oracle(engine, count, reverse, alia
     assert values(g.gfql(ops, engine=engine, index_policy="force")) == expected
     with routes_off(ROUTES):
         assert values(g.gfql(ops, engine=engine, index_policy="force")) == expected
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars", "cudf"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("reverse_nodes", [False, True])
+@pytest.mark.parametrize("reverse_edges", [False, True])
+@pytest.mark.parametrize("hops", [1, 2])
+@pytest.mark.parametrize("property_index", [False, True])
+def test_joined_path_order_matches_input_positions(engine, reverse, reverse_nodes, reverse_edges, hops, property_index):
+    if engine == "cudf" and os.environ.get("TEST_CUDF") != "1":
+        pytest.skip("cuDF lane runs with TEST_CUDF=1")
+    node_ids = [20, 10, 30, 40][::-1 if reverse_nodes else 1]
+    edge_rows = [(10, 30, 0), (20, 30, 1), (10, 40, 2),
+                 (30, 40, 3), (20, 40, 4), (10, 30, 5)][::-1 if reverse_edges else 1]
+    seeds = {30, 40} if reverse else {10, 20}
+    nodes = pd.DataFrame({"id": node_ids, "seed": [int(node in seeds) for node in node_ids]})
+    edges = pd.DataFrame(edge_rows, columns=["s", "d", "eid"])
+    graph = graphistry.nodes(to_engine(nodes, engine), "id").edges(
+        to_engine(edges, engine), "s", "d", "eid").gfql_index_all(engine=engine)
+    if property_index:
+        graph = graph.gfql_index_node_props(["seed"], engine=engine)
+    paths = [(node, node, ()) for node in node_ids if node in seeds]
+    ops = [n({"seed": 1}, name="a0")]
+    for step in range(hops):
+        expanded = []
+        for seed, current, used in paths:
+            for src, dst, eid in edge_rows:
+                before, after = (dst, src) if reverse else (src, dst)
+                if before == current and eid not in used:
+                    expanded.append((seed, after, (*used, eid)))
+        paths = expanded
+        ops += [(e_reverse if reverse else e_forward)(name=f"e{step}"), n(name=f"a{step + 1}")]
+    projection = [("seed", "a0.id"), ("target", f"a{hops}.id")]
+    projection += [(f"edge_{step}", f"e{step}.eid") for step in range(hops)]
+    ops += [rows(), select(projection)]
+    expected = [{"seed": seed, "target": target, **{f"edge_{step}": eid for step, eid in enumerate(used)}}
+                for seed, target, used in paths]
+    for disabled in ((), ROUTES):
+        with routes_off(disabled):
+            result = graph.gfql(ops, engine=engine, index_policy="force")._nodes
+        assert list(result.columns) == [name for name, _ in projection]
+        if engine == "polars":
+            actual = result.to_dicts()
+        else:
+            actual = (result.to_pandas() if engine == "cudf" else result).to_dict("records")
+        assert actual == expected, (engine, disabled, property_index)

--- a/graphistry/tests/compute/gfql/routes/test_replay.py
+++ b/graphistry/tests/compute/gfql/routes/test_replay.py
@@ -1,0 +1,37 @@
+"""The existing-suite replay is a failing gate and includes every route switch."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from graphistry.tests.compute.gfql.routes.switch import ROUTES
+
+
+@pytest.mark.parametrize("failure", [False, True])
+def test_replay_broadcasts_existing_tests_and_propagates_failures(tmp_path, failure):
+    root = Path(__file__).resolve().parents[5]
+    fake = tmp_path / "python"
+    # Use the real registry import, replacing only pytest execution with a recorder.
+    fake.write_text(
+        "#!/bin/bash\n"
+        f'if [ "$1" = "-c" ]; then exec "{sys.executable}" "$@"; fi\n'
+        'echo "$GFQL_ROUTES_OFF|$*" >> "$REPLAY_CALLS"\n'
+        'if [ "$REPLAY_FAIL" = 1 ] && [ "$GFQL_ROUTES_OFF" = point-rows ]; then exit 2; fi\n'
+        'echo "1 passed"\n'
+    )
+    fake.chmod(0o755)
+    calls = tmp_path / "calls"
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}",
+           "OUT": str(tmp_path / "logs"), "REPLAY_CALLS": str(calls),
+           "REPLAY_FAIL": str(int(failure)),
+           "SUITES": "graphistry/tests/compute/test_chain.py"}
+    env.pop("MODES", None)
+    result = subprocess.run(["bash", str(root / "bin/test-routes-off.sh")], env=env,
+                            cwd=root, text=True, capture_output=True)
+    assert result.returncode == int(failure), result.stderr
+    records = [line.split("|", 1) for line in calls.read_text().splitlines()]
+    assert [record[0] for record in records] == [*ROUTES, ",".join(ROUTES)]
+    assert all("graphistry/tests/compute/test_chain.py" in record[1] for record in records)
+    assert all((tmp_path / "logs" / f"{mode}.log").is_file() for mode in (*ROUTES, "all-off"))

--- a/graphistry/tests/compute/gfql/routes/test_replay.py
+++ b/graphistry/tests/compute/gfql/routes/test_replay.py
@@ -1,6 +1,7 @@
 """The existing-suite replay is a failing gate and includes every route switch."""
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -35,3 +36,25 @@ def test_replay_broadcasts_existing_tests_and_propagates_failures(tmp_path, fail
     assert [record[0] for record in records] == [*ROUTES, ",".join(ROUTES)]
     assert all("graphistry/tests/compute/test_chain.py" in record[1] for record in records)
     assert all((tmp_path / "logs" / f"{mode}.log").is_file() for mode in (*ROUTES, "all-off"))
+
+
+def _hosted_replay_job() -> str:
+    root = Path(__file__).resolve().parents[5]
+    workflow = (root / ".github/workflows/ci.yml").read_text()
+    job = re.search(r"^  gfql-routes-off:\n(.*?)(?=^  [\w-]+:|\Z)", workflow, re.M | re.S)
+    assert job is not None, "The hosted existing-suite replay job is missing"
+    return job.group(1)
+
+
+def test_hosted_replay_matrix_covers_every_registered_route():
+    job = _hosted_replay_job()
+    matrix = re.search(r"^        mode: \[(.*?)\]$", job, re.M)
+    assert matrix is not None, "Update this guard if the workflow matrix representation changes"
+    modes = [mode.strip() for mode in matrix.group(1).split(",")]
+    assert sorted(modes) == sorted([*ROUTES, "all-off"])
+
+
+def test_hosted_replay_failures_fail_the_workflow():
+    # The shell runner's nonzero exit must not be suppressed at job or step scope.
+    allowances = re.findall(r"^\s+continue-on-error:\s*(.*?)\s*$", _hosted_replay_job(), re.M)
+    assert all(value == "false" for value in allowances), allowances

--- a/graphistry/tests/compute/gfql/routes/test_route_harness.py
+++ b/graphistry/tests/compute/gfql/routes/test_route_harness.py
@@ -16,7 +16,7 @@ import graphistry.compute.chain as chain_mod
 import graphistry.compute.gfql.lazy.engine.polars.chain as pchain
 from graphistry.Engine import Engine
 from graphistry.compute.ast import ASTObject
-from graphistry.compute.chain_specializations.admission import native_fast_path_admits
+from graphistry.compute.chain_specializations.admission import native_fast_path_admits, point_rows_admits
 from graphistry.compute.gfql.lazy.engine.polars.chain_specializations.admission import (
     polars_single_node_admits,
     polars_plain_single_hop_admits, polars_seeded_lane_admits,
@@ -38,6 +38,9 @@ class Route(NamedTuple):
 
 
 ROUTES = [
+    Route("point-rows", ("pandas", "cudf"),
+          lambda ops, engine: point_rows_admits(ops, Engine(engine), None) is not None,
+          (chain_mod, "_try_point_rows"), True),
     Route("native-fast", ("pandas", "cudf"),
           lambda ops, engine: native_fast_path_admits(ops, Engine(engine), None) is not None,
           (chain_mod, "_try_chain_fast_path"), False),
@@ -53,6 +56,7 @@ ROUTES = [
 ]
 
 KNOWN: Dict[Tuple[str, str], str] = {  # (route, tag) -> issue: strict xfail until it lands (non-strict on frame variants, where a shape may coincide)
+    ("point-rows", "dup-ids"): "graphistry/pygraphistry#2034",
     ("native-fast", "#2034"): "graphistry/pygraphistry#2034",
     ("polars-single-node", "#2034"): "graphistry/pygraphistry#2034",
     ("polars-single-node", "dup-ids"): "graphistry/pygraphistry#2034",
@@ -165,7 +169,7 @@ def test_admitted_shape_is_served_and_matches_the_general_path(case: Case, reque
         pytest.xfail(f"{case.id}: admitted by the predicate, declined by the lane body (attenuation ledger)")
 
 
-@pytest.mark.route_engaged("native-fast", "polars-single-node", "polars-plain", "polars-seeded")
+@pytest.mark.route_engaged("point-rows", "native-fast", "polars-single-node", "polars-plain", "polars-seeded")
 def test_every_route_serves_most_of_what_it_admits(monkeypatch):
     """A lane that declines most admitted shapes has a predicate that no longer describes it."""
     per_route: Dict[str, List[int]] = {}

--- a/graphistry/tests/compute/gfql/routes/test_route_harness.py
+++ b/graphistry/tests/compute/gfql/routes/test_route_harness.py
@@ -37,7 +37,12 @@ class Route(NamedTuple):
     indexed: bool
 
 
+from graphistry.compute.gfql.lazy.engine.polars.chain_specializations.point_rows import polars_point_rows_admits
+
 ROUTES = [
+    Route("polars-point-rows", ("polars",),
+          lambda ops, engine: polars_point_rows_admits(ops) is not None,
+          (pchain, "_try_point_rows_polars"), True),
     Route("point-rows", ("pandas", "cudf"),
           lambda ops, engine: point_rows_admits(ops, Engine(engine), None) is not None,
           (chain_mod, "_try_point_rows"), True),
@@ -56,6 +61,7 @@ ROUTES = [
 ]
 
 KNOWN: Dict[Tuple[str, str], str] = {  # (route, tag) -> issue: strict xfail until it lands (non-strict on frame variants, where a shape may coincide)
+    ("polars-point-rows", "dup-ids"): "graphistry/pygraphistry#2034",
     ("point-rows", "dup-ids"): "graphistry/pygraphistry#2034",
     ("native-fast", "#2034"): "graphistry/pygraphistry#2034",
     ("polars-single-node", "#2034"): "graphistry/pygraphistry#2034",
@@ -169,7 +175,7 @@ def test_admitted_shape_is_served_and_matches_the_general_path(case: Case, reque
         pytest.xfail(f"{case.id}: admitted by the predicate, declined by the lane body (attenuation ledger)")
 
 
-@pytest.mark.route_engaged("point-rows", "native-fast", "polars-single-node", "polars-plain", "polars-seeded")
+@pytest.mark.route_engaged("polars-point-rows", "point-rows", "native-fast", "polars-single-node", "polars-plain", "polars-seeded")
 def test_every_route_serves_most_of_what_it_admits(monkeypatch):
     """A lane that declines most admitted shapes has a predicate that no longer describes it."""
     per_route: Dict[str, List[int]] = {}

--- a/graphistry/tests/compute/gfql/same_path/test_native_shortest_path.py
+++ b/graphistry/tests/compute/gfql/same_path/test_native_shortest_path.py
@@ -147,12 +147,20 @@ class TestTryNativeShortestPath:
         assert len(cache) == 1
 
     def test_returns_none_on_cudf_without_cugraph(self):
-        # cugraph is not installed in test env; must return None gracefully
         sp = _step_pairs([1], [2])
-        result = try_native_shortest_path(
-            sp, [1], [2], max_hops=None, directed=False, engine=Engine.CUDF
-        )
+        with patch.dict(sys.modules, {"cugraph": None}):
+            result = try_native_shortest_path(
+                sp, [1], [2], max_hops=None, directed=False, engine=Engine.CUDF
+            )
         assert result is None
+
+    def test_explicit_cugraph_backend_raises_without_cugraph(self):
+        sp = _step_pairs([1], [2])
+        with patch.dict(sys.modules, {"cugraph": None}), pytest.raises(ImportError):
+            try_native_shortest_path(
+                sp, [1], [2], max_hops=None, directed=False,
+                engine=Engine.CUDF, backend="cugraph",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
+++ b/graphistry/tests/compute/gfql/test_alias_scoping_semantics.py
@@ -615,7 +615,7 @@ def test_mixed_whole_entity_and_self_named_property_projection(engine: str) -> N
 def test_restore_alias_shadowed_user_column_branches() -> None:
     """Helper-level pins for the rows-route restore: no-op without a base, a shadowed
     column, or when the base column is itself a boolean marker (intermediate dispatch
-    graph); index-keyed restore; key-merge fallback when the index cannot re-key."""
+    graph); binding-key restore; index fallback when no unique binding key exists."""
     from types import SimpleNamespace
 
     from graphistry.compute.gfql.identifiers import shadow_restore_column
@@ -634,11 +634,11 @@ def test_restore_alias_shadowed_user_column_branches() -> None:
     # base column is itself a boolean marker (an intermediate dispatch graph): unchanged
     base_marker = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"], "kind": [True, False]}), _edges=None, _node="id", _edge=None)
     assert _restore_alias_shadowed_user_column(ctx_for(base_marker), marked, "nodes", "kind") is marked
-    # index-keyed restore adds the internal restore column and keeps the marker boolean
+    # Keyed restore keeps the marker boolean.
     base = SimpleNamespace(_nodes=pd.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}), _edges=None, _node="id", _edge=None)
     out = _restore_alias_shadowed_user_column(ctx_for(base), marked, "nodes", "kind")
     assert list(out[restore_col]) == ["K1", "K2"] and list(out["kind"]) == [True, True]
-    # base index cannot re-key (duplicate labels): fall back to the id-key merge
+    # Duplicate dataframe indexes do not affect entity-key lookup.
     dup_index_nodes = pd.DataFrame({"id": ["a", "b"], "kind": ["K1", "K2"]}, index=[0, 0])
     base_dup = SimpleNamespace(_nodes=dup_index_nodes, _edges=None, _node="id", _edge=None)
     out = _restore_alias_shadowed_user_column(ctx_for(base_dup), marked, "nodes", "kind")
@@ -646,7 +646,7 @@ def test_restore_alias_shadowed_user_column_branches() -> None:
     # neither index nor key can re-key: unchanged (marker stays, as before)
     base_no_key = SimpleNamespace(_nodes=dup_index_nodes, _edges=None, _node=None, _edge=None)
     assert _restore_alias_shadowed_user_column(ctx_for(base_no_key), marked, "nodes", "kind") is marked
-    # row-table labels absent from a unique base index: guarded .loc declines to the key merge
+    # Reset dataframe indexes do not affect entity-key lookup.
     shifted = pd.DataFrame({"id": ["a", "b"], "kind": [True, True]}, index=[10, 11])
     out = _restore_alias_shadowed_user_column(ctx_for(base), shifted, "nodes", "kind")
     assert list(out[restore_col]) == ["K1", "K2"]
@@ -692,3 +692,35 @@ def test_cudf_unshadow_and_rebind_guard_parity() -> None:
     with pytest.raises(GFQLValidationError) as exc_info:
         g.gfql("MATCH (a:P)-[r:K]->(b:P) WITH a AS b RETURN b.name", engine="cudf")
     assert "rebind an entity alias" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("backend", ["pandas", "cudf"])
+@pytest.mark.parametrize("keys", [[], [2, 1], [2, 1, 2], [2, 99, 1]])
+@pytest.mark.parametrize("duplicate_index", [False, True])
+@pytest.mark.parametrize("values", [[10, 20], ["first", "second"]])
+def test_alias_restore_uses_entity_keys_after_row_reordering(backend, keys, duplicate_index, values):
+    from types import SimpleNamespace
+    from graphistry.compute.gfql.identifiers import shadow_restore_column
+    from graphistry.compute.gfql.row.frame_ops import _restore_alias_shadowed_user_column
+
+    base = pd.DataFrame({"id": [1, 2], "value": values})
+    index = [0] * len(keys) if duplicate_index else list(range(len(keys)))
+    marked = pd.DataFrame({"id": pd.Series(keys, dtype="int64"),
+                           "value": pd.Series([True] * len(keys), dtype="bool")})
+    marked.index = index
+    if backend == "cudf":
+        cudf = pytest.importorskip("cudf")
+        base, marked = cudf.from_pandas(base), cudf.from_pandas(marked)
+    ctx = SimpleNamespace(_gfql_rows_base_graph=SimpleNamespace(
+        _nodes=base, _edges=None, _node="id", _edge=None), _g=None)
+    result = _restore_alias_shadowed_user_column(ctx, marked, "nodes", "value")
+    result_pd = result.to_pandas() if backend == "cudf" else result
+    marked_pd = marked.to_pandas() if backend == "cudf" else marked
+    assert result_pd["id"].tolist() == keys
+    assert result_pd.index.tolist() == index
+    assert result_pd["value"].tolist() == [True] * len(keys)
+    actual = [None if pd.isna(value) else value for value in result_pd[shadow_restore_column("value")]]
+    expected = [{1: values[0], 2: values[1]}.get(key) for key in keys]
+    assert actual == expected
+    assert list(marked_pd.columns) == ["id", "value"]
+    assert marked_pd["value"].tolist() == [True] * len(keys)

--- a/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
+++ b/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
@@ -3,8 +3,8 @@
 ``_tag_fast_path_aliases`` attaches the alias flag columns a named seeded hop carries; on
 pandas it now builds them with one copy and in-place inserts. Pins: for every alias shape
 the pandas branch returns exactly (columns, order, dtypes, index of every touched frame) what the generic
-path returns, and the shapes it cannot reproduce in place (binding column not first, colliding
-alias names, float or object ids) decline to the generic path.
+path returns, and the shapes it cannot reproduce in place (colliding alias names, float or
+object ids) decline to the generic path.
 """
 import numpy as np
 import pandas as pd
@@ -55,8 +55,10 @@ SHAPES = {
 
 @pytest.mark.parametrize("shape", list(SHAPES))
 @pytest.mark.parametrize("direction", ["forward", "reverse"])
-def test_pandas_branch_is_frame_identical_to_generic_tagging(shape, direction):
-    fast, generic, branch = _both(_res(NODES, EDGES), SHAPES[shape], direction)
+@pytest.mark.parametrize("binding_first", [True, False])
+def test_pandas_branch_is_frame_identical_to_generic_tagging(shape, direction, binding_first):
+    nodes = NODES if binding_first else NODES[["x", "k", "w"]]
+    fast, generic, branch = _both(_res(nodes, EDGES), SHAPES[shape], direction)
     assert branch == 1
     pd.testing.assert_frame_equal(fast._nodes, generic._nodes)
     pd.testing.assert_frame_equal(fast._edges, generic._edges)
@@ -75,7 +77,6 @@ def test_dead_end_seed_is_tagged_false_on_both_paths():
 
 
 DECLINE_SHAPES = {
-    "binding column not first": (NODES[["x", "k", "w"]], EDGES, ("m", "e", "p")),
     "colliding node alias": (NODES.assign(m=0), EDGES, ("m", "e", "p")),
     "colliding edge alias": (NODES, EDGES.assign(e=0), ("m", "e", "p")),
     "float ids": (NODES.assign(k=NODES["k"].astype(float)), EDGES, ("m", None, "p")),

--- a/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
+++ b/graphistry/tests/compute/gfql/test_alias_tagging_pandas_inplace.py
@@ -112,9 +112,11 @@ def test_end_to_end_named_seeded_hop_matches_the_full_path():
 @pytest.mark.parametrize("engine", ["pandas", "cudf"])
 @pytest.mark.parametrize("direction", ["forward", "reverse"])
 @pytest.mark.parametrize("empty", [False, True])
+@pytest.mark.parametrize("binding_first", [False, True])
 @pytest.mark.parametrize("shape", list(SHAPES))
-def test_eager_alias_tags_keep_backend_and_inputs(engine, direction, empty, shape):
-    nodes, edges = NODES.copy(), EDGES.iloc[:0].copy() if empty else EDGES.copy()
+def test_eager_alias_tags_keep_backend_and_inputs(engine, direction, empty, binding_first, shape):
+    original_nodes = NODES if binding_first else NODES[["x", "k", "w"]]
+    nodes, edges = original_nodes.copy(), EDGES.iloc[:0].copy() if empty else EDGES.copy()
     if engine == "cudf":
         cudf = pytest.importorskip("cudf")
         nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
@@ -125,7 +127,7 @@ def test_eager_alias_tags_keep_backend_and_inputs(engine, direction, empty, shap
         if engine == "cudf":
             actual, expected = actual.to_pandas(), expected.to_pandas()
         pd.testing.assert_frame_equal(actual, expected)
-    pd.testing.assert_frame_equal(nodes.to_pandas() if engine == "cudf" else nodes, NODES)
+    pd.testing.assert_frame_equal(nodes.to_pandas() if engine == "cudf" else nodes, original_nodes)
     pd.testing.assert_frame_equal(edges.to_pandas() if engine == "cudf" else edges,
                                   EDGES.iloc[:0] if empty else EDGES)
 

--- a/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
@@ -803,3 +803,105 @@ def test_gpu_temporal_guard_does_not_extract_string_scalars(monkeypatch):
     with target_mode(ExecutionTarget.GPU):
         assert _columns_have_temporal_constructor_text(pl.DataFrame({"s": ["plain"]}), ["s"]) is False
         assert _columns_have_temporal_constructor_text(pl.DataFrame({"s": ["date('2020-01-01')"]}), ["s"]) is True
+
+
+@pytest.mark.parametrize("size", [0, 1, 2, 33])
+@pytest.mark.parametrize("dtype,values", [
+    ("Int64", [2**53 + 1, 2**53 + 2]),
+    ("String", ["first", "second"]),
+    ("Boolean", [False, True]),
+    ("Float64", [0.0, float("nan")]),
+])
+@pytest.mark.parametrize("prefix_null", [False, True, "all"])
+def test_uniform_coalesce_preserves_values_without_projection_plan(size, dtype, values, prefix_null, monkeypatch):
+    import importlib
+    import polars as pl
+    from polars.testing import assert_frame_equal
+
+    native = importlib.import_module("graphistry.compute.gfql.lazy.engine.polars.row_pipeline")
+    selected = [None if prefix_null == "all" else values[i % 2] for i in range(size)]
+    table = pl.DataFrame({
+        "left": pl.Series([None] * size if prefix_null else selected, dtype=getattr(pl, dtype)),
+        "right": pl.Series(selected if prefix_null else [None] * size, dtype=getattr(pl, dtype)),
+        "a": [True] * size,
+    })
+    original = table.clone()
+    expected = pl.DataFrame({"value": pl.Series(selected, dtype=getattr(pl, dtype))})
+    expression_oracle = table.select(pl.coalesce("left", "right").alias("value"))
+    assert_frame_equal(expected, expression_oracle)
+
+    def unexpected_plan(*args, **kwargs):
+        raise AssertionError("Uniform projection entered an expression execution plan")
+
+    monkeypatch.setattr(native, "_project_preserving_height", unexpected_plan)
+    result = native.select_polars(graphistry.nodes(table), [("value", "coalesce(a.left, a.right)")])
+    assert result is not None
+    assert_frame_equal(result._nodes, expected)
+    assert_frame_equal(table, original)
+
+
+@pytest.mark.parametrize("items,columns,expected", [
+    ([("value", "coalesce(left, right)")], {"left": [None, 1], "right": [2, 3]}, [2, 1]),
+    ([("value", "coalesce(left, right)")], {"left": [1, 2], "right": [2.5, 3.5]}, [1.0, 2.0]),
+    ([("value", "coalesce(left + 1, right)")], {"left": [None, 1], "right": [2, 3]}, [2, 2]),
+    ([("value", "7")], {"left": [1, 2], "right": [2, 3]}, [7, 7]),
+])
+def test_eager_projection_decline_boundaries_keep_generic_results(items, columns, expected, monkeypatch):
+    import importlib
+    import polars as pl
+
+    native = importlib.import_module("graphistry.compute.gfql.lazy.engine.polars.row_pipeline")
+    original = native._project_preserving_height
+    calls = []
+
+    def observe(*args, **kwargs):
+        calls.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(native, "_project_preserving_height", observe)
+    result = native.select_polars(graphistry.nodes(pl.DataFrame(columns)), items)
+    assert result is not None
+    assert result._nodes.to_dicts() == [{"value": value} for value in expected]
+    assert calls == [True]
+
+
+@pytest.mark.parametrize("size", [0, 1, 3, 33])
+def test_eager_column_projection_repeats_sources_and_preserves_order(size, monkeypatch):
+    import importlib
+    import polars as pl
+    from polars.testing import assert_frame_equal
+
+    native = importlib.import_module("graphistry.compute.gfql.lazy.engine.polars.row_pipeline")
+    values = [None if i % 2 else 2**53 + i for i in reversed(range(size))]
+    table = pl.DataFrame({"x": pl.Series(values, dtype=pl.Int64)})
+    def unexpected_plan(*args, **kwargs):
+        raise AssertionError("Column projection entered an expression execution plan")
+    monkeypatch.setattr(native, "_project_preserving_height", unexpected_plan)
+    result = native.select_polars(graphistry.nodes(table), [("second", "x"), ("first", "x")])
+    assert result is not None
+    expected = pl.DataFrame({"second": pl.Series(values, dtype=pl.Int64), "first": pl.Series(values, dtype=pl.Int64)})
+    assert_frame_equal(result._nodes, expected)
+
+
+@pytest.mark.parametrize("dtype,values", [
+    (pl.Categorical, ["a", "b"]),
+    (pl.Enum(["a", "b"]), ["a", "b"]),
+    (pl.List(pl.Int64), [[1, None], [2, 3]]),
+    (pl.Struct({"x": pl.Int64}), [{"x": 1}, {"x": None}]),
+])
+@pytest.mark.parametrize("size", [0, 2])
+def test_uniform_coalesce_preserves_nonprimitive_dtypes(dtype, values, size, monkeypatch):
+    import importlib
+    from polars.testing import assert_frame_equal
+
+    native = importlib.import_module("graphistry.compute.gfql.lazy.engine.polars.row_pipeline")
+    table = pl.DataFrame({"left": pl.Series([None] * size, dtype=dtype),
+                          "right": pl.Series(values[:size], dtype=dtype)})
+    expected = table.select(pl.coalesce("left", "right").alias("value"))
+    def unexpected_plan(*args, **kwargs):
+        raise AssertionError("Uniform typed coalesce entered an expression execution plan")
+    monkeypatch.setattr(native, "_project_preserving_height", unexpected_plan)
+    result = native.select_polars(graphistry.nodes(table), [("value", "coalesce(left, right)")])
+    assert result is not None
+    assert_frame_equal(result._nodes, expected)
+    assert result._nodes["value"].to_list() == values[:size]

--- a/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
@@ -743,3 +743,22 @@ def test_projection_temporal_text_guard_across_columns(values, expected, column)
 def test_projection_temporal_text_guard_without_string_columns():
     from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import _select_emits_temporal_constructor_text
     assert not _select_emits_temporal_constructor_text(pl.DataFrame({"number": [1], "flag": [True]}))
+
+
+@pytest.mark.parametrize("lazy_input", [False, True])
+@pytest.mark.parametrize("decline", [False, True])
+def test_property_attachment_preserves_schema_error_policy(lazy_input, decline):
+    from graphistry.compute import ast
+    from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import (
+        _finish_binding_rows_polars, WALK_CURRENT_COL,
+    )
+    state = pl.DataFrame({WALK_CURRENT_COL: [1], "a": ["one"]})
+    lookup = pl.DataFrame({"id": [1], "value": ["x"]})
+    if lazy_input:
+        state, lookup = state.lazy(), lookup.lazy()
+    args = (graphistry.nodes(pl.DataFrame({"id": [1]}), "id"), [ast.n(name="a")], state, {"a": lookup}, "id", None)
+    if decline:
+        assert _finish_binding_rows_polars(*args, decline_on_schema_error=True) is None
+    else:
+        with pytest.raises(pl.exceptions.SchemaError):
+            _finish_binding_rows_polars(*args, decline_on_schema_error=False)

--- a/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
@@ -717,3 +717,29 @@ def test_frame_ops_polars_rows_empty_table():
     empty = g.nodes(g._nodes.clear(), g._node)
     out = fo.rows(_adapter(empty), table="nodes")._nodes
     assert "polars" in type(out).__module__ and out.height == 0
+
+
+@pytest.mark.parametrize("values,expected", [
+    ([], False), ([None], False), (["ordinary", None], False),
+    (["update({year: 2020})", "my date({year: 2020})"], False),
+    ([None, "date({year: 2020})"], True),
+    (["  datetime({year: 2020})", None], True),
+])
+@pytest.mark.parametrize("column", ["first", "last"])
+def test_projection_temporal_text_guard_across_columns(values, expected, column):
+    from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import (
+        _select_emits_temporal_constructor_text, select_polars,
+    )
+    data = {"first": ["plain"] * len(values), "last": [None] * len(values)}
+    data[column] = values
+    table = pl.DataFrame(data, schema={"first": pl.String, "last": pl.String})
+    assert _select_emits_temporal_constructor_text(table) is expected
+    result = select_polars(graphistry.nodes(table), [("a", "first"), ("b", "last")])
+    assert (result is None) is expected
+    if result is not None:
+        assert result._nodes.to_dicts() == table.rename({"first": "a", "last": "b"}).to_dicts()
+
+
+def test_projection_temporal_text_guard_without_string_columns():
+    from graphistry.compute.gfql.lazy.engine.polars.row_pipeline import _select_emits_temporal_constructor_text
+    assert not _select_emits_temporal_constructor_text(pl.DataFrame({"number": [1], "flag": [True]}))

--- a/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_row_pipeline.py
@@ -762,3 +762,44 @@ def test_property_attachment_preserves_schema_error_policy(lazy_input, decline):
     else:
         with pytest.raises(pl.exceptions.SchemaError):
             _finish_binding_rows_polars(*args, decline_on_schema_error=False)
+
+
+@pytest.mark.parametrize("value", [
+    None, "", "ordinary", "雪", "a\nlong string", "\u001cdate", "\u0085date", "(", ")", "a(b)",
+    "date('2020-01-01')", "time('12:00:00')", "localtime('12:00:00')",
+    "datetime({year: 2020})", "localdatetime({year: 2020})", "duration({days: 1})",
+    "  date('2020-01-01')", "\u001cdate('2020-01-01')", "\u0085date('2020-01-01')",
+    "my date({year: 2020})", "update({year: 2020})", "date(", "date({nested: (1)})",
+])
+@pytest.mark.parametrize("height", [1, 2])
+def test_temporal_text_guard_matches_native_expression(value, height):
+    from graphistry.compute.gfql.lazy.engine.polars.projection import _columns_have_temporal_constructor_text
+    from graphistry.compute.gfql.temporal.constructors import TEMPORAL_CALL_EXPR_RE
+    table = pl.DataFrame({"first": ["plain"] * height, "last": [value] * height}, schema={"first": pl.String, "last": pl.String})
+    original = table.clone()
+    pattern = r"^\s*" + TEMPORAL_CALL_EXPR_RE.pattern
+    expected = bool(table.select(pl.any_horizontal([pl.col(c).str.contains(pattern).any() for c in table.columns])).item())
+    assert _columns_have_temporal_constructor_text(table, table.columns) is expected
+    from polars.testing import assert_frame_equal
+    assert_frame_equal(table, original)
+
+
+def test_temporal_text_guard_keeps_invalid_column_behavior():
+    from graphistry.compute.gfql.lazy.engine.polars.projection import _columns_have_temporal_constructor_text
+    table = pl.DataFrame({"text": ["date('2020-01-01')"], "number": [1]})
+    assert _columns_have_temporal_constructor_text(table, ["text", "missing"]) is False
+    assert _columns_have_temporal_constructor_text(table, ["text", "number"]) is False
+    assert _columns_have_temporal_constructor_text(table, []) is False
+
+
+def test_gpu_temporal_guard_does_not_extract_string_scalars(monkeypatch):
+    from graphistry.compute.gfql.lazy import ExecutionTarget, target_mode
+    from graphistry.compute.gfql.lazy.engine.polars.projection import _columns_have_temporal_constructor_text
+    original_item = pl.Series.item
+    def checked_item(series, *args, **kwargs):
+        assert series.dtype != pl.String, "GPU guard must retain native string evaluation"
+        return original_item(series, *args, **kwargs)
+    monkeypatch.setattr(pl.Series, "item", checked_item)
+    with target_mode(ExecutionTarget.GPU):
+        assert _columns_have_temporal_constructor_text(pl.DataFrame({"s": ["plain"]}), ["s"]) is False
+        assert _columns_have_temporal_constructor_text(pl.DataFrame({"s": ["date('2020-01-01')"]}), ["s"]) is True

--- a/graphistry/tests/compute/gfql/test_engine_polars_with_match_reentry.py
+++ b/graphistry/tests/compute/gfql/test_engine_polars_with_match_reentry.py
@@ -401,3 +401,29 @@ class TestReentryPolarsFramesServingEngineMatrix:
             engine="pandas",
         )._nodes
         assert _to_pandas(out).to_dict("records") == [{"av": 10, "bid": 1}]
+
+
+@pytest.mark.parametrize("node_id", ["id", "__node__", "custom_key"])
+@pytest.mark.parametrize("return_clause, aliases", [
+    ("RETURN x", ["x"]),
+    ("RETURN x AS target", ["target"]),
+    ("RETURN a, x", ["a", "x"]),
+    ("RETURN x.name", []),
+])
+def test_multi_match_whole_entity_identity(node_id, return_clause, aliases):
+    graph = graphistry.nodes(pd.DataFrame({
+        node_id: [10, 20, 30, 40], "name": ["A", "B", "x1", "x2"],
+    }), node_id).edges(pd.DataFrame({
+        "s": [10, 10, 20, 20], "d": [30, 40, 30, 40],
+    }), "s", "d")
+    query = "MATCH (a {name: 'A'}), (b {name: 'B'}) MATCH (a)-->(x)<-->(b) " + return_clause
+    result = graph.gfql(query, engine="polars")
+    reference = graph.gfql(query, engine="pandas")
+    actual = result._nodes.to_pandas().sort_values("x.name" if not aliases else aliases[-1] + ".name").reset_index(drop=True)
+    expected = reference._nodes.sort_values("x.name" if not aliases else aliases[-1] + ".name").reset_index(drop=True)
+    pd.testing.assert_frame_equal(actual, expected, check_like=True)
+    meta = getattr(result, "_cypher_entity_projection_meta", {})
+    assert set(meta) == set(aliases)
+    for alias in aliases:
+        assert meta[alias]["id_column"] == node_id
+        assert meta[alias]["ids"].to_list() == result._nodes[alias + "." + node_id].to_list()

--- a/graphistry/tests/compute/gfql/test_gfql_unified_routing_contracts.py
+++ b/graphistry/tests/compute/gfql/test_gfql_unified_routing_contracts.py
@@ -315,3 +315,36 @@ def test_auto_polars_decline_reruns_on_pandas_with_coerced_frames(monkeypatch):
     assert pandas_call_frames and all(m == "pandas" for m in pandas_call_frames), (
         f"pandas executors were handed non-pandas frames: {calls}")
     assert out is not None
+
+
+@pytest.mark.parametrize("engine", ["pandas", "cudf", "polars", "polars-gpu"])
+@pytest.mark.parametrize("wrapped", [False, True], ids=["list", "chain"])
+@pytest.mark.parametrize("invalid", ["negative_hops", "non_operation"])
+def test_invalid_ast_precedes_engine_dependencies(engine, wrapped, invalid):
+    from graphistry.compute.ast import n, e_forward
+    from graphistry.compute.chain import Chain
+    from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
+
+    ops = [n(), e_forward(hops=-1), n()] if invalid == "negative_hops" else [n(), "invalid"]
+    query = Chain(ops, validate=False) if wrapped else ops
+    expected = ErrorCode.E103 if invalid == "negative_hops" else ErrorCode.E101
+    with pytest.raises(GFQLValidationError) as exc:
+        _polars_graph().gfql(query, engine=engine)
+    assert exc.value.code == expected
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+@pytest.mark.parametrize("wrapped", [False, True], ids=["list", "chain"])
+def test_reused_query_is_validated_after_mutation(engine, wrapped):
+    from graphistry.compute.ast import n, e_forward
+    from graphistry.compute.chain import Chain
+    from graphistry.compute.exceptions import ErrorCode, GFQLValidationError
+
+    ops = [n(), e_forward(), n()]
+    query = Chain(ops) if wrapped else ops
+    graph = _polars_graph()
+    graph.gfql(query, engine=engine)
+    ops[1].hops = -1
+    with pytest.raises(GFQLValidationError) as exc:
+        graph.gfql(query, engine=engine)
+    assert exc.value.code == ErrorCode.E103

--- a/graphistry/tests/compute/gfql/test_join_backend_contracts.py
+++ b/graphistry/tests/compute/gfql/test_join_backend_contracts.py
@@ -1,0 +1,53 @@
+"""Join helper contracts at backend, multiplicity, and empty-input boundaries."""
+import os
+
+import pandas as pd
+import pytest
+
+from graphistry.Engine import Engine
+from graphistry.compute.dataframe.join import semijoin_by_column
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars", "polars-lazy", "cudf"])
+@pytest.mark.parametrize("key_values", [[], [2], [2, 2], [2, 3]])
+def test_semijoin_keeps_left_duplicates_without_multiplying_by_right(backend, key_values):
+    left = pd.DataFrame({"id": [2, 1, 2, 3], "payload": [20, 10, 21, 30]})
+    right = pd.DataFrame({"key": pd.Series(key_values, dtype="int64")})
+    if backend == "cudf":
+        if not os.environ.get("TEST_CUDF"):
+            pytest.skip("TEST_CUDF is required for GPU tests")
+        cudf = pytest.importorskip("cudf")
+        frame, keys = cudf.from_pandas(left), cudf.from_pandas(right)
+        engine = Engine.CUDF
+    elif backend.startswith("polars"):
+        pl = pytest.importorskip("polars")
+        frame, keys = pl.from_pandas(left), pl.from_pandas(right)
+        if backend == "polars-lazy":
+            frame, keys = frame.lazy(), keys.lazy()
+        engine = Engine.POLARS
+    else:
+        frame, keys, engine = left.copy(), right.copy(), Engine.PANDAS
+    result = semijoin_by_column(frame, keys, left_on="id", right_on="key", engine=engine)
+    if backend == "polars-lazy":
+        assert isinstance(result, pl.LazyFrame)
+        result = result.collect()
+    if backend.startswith("polars"):
+        records = result.to_dicts()
+    else:
+        records = (result.to_pandas() if backend == "cudf" else result).to_dict("records")
+    assert sorted(records, key=lambda row: row["payload"]) == sorted(
+        left[left.id.isin(key_values)].to_dict("records"), key=lambda row: row["payload"]
+    )
+    assert list(result.columns) == ["id", "payload"]
+
+
+@pytest.mark.parametrize("lazy_left", [False, True])
+def test_polars_semijoin_rejects_mixed_frame_flavors(lazy_left):
+    pl = pytest.importorskip("polars")
+    frame, keys = pl.DataFrame({"id": [1]}), pl.DataFrame({"key": [1]})
+    if lazy_left:
+        frame = frame.lazy()
+    else:
+        keys = keys.lazy()
+    with pytest.raises(AssertionError):
+        semijoin_by_column(frame, keys, left_on="id", right_on="key", engine=Engine.POLARS)

--- a/graphistry/tests/compute/gfql/test_native_seed_lane_explain.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_lane_explain.py
@@ -34,26 +34,45 @@ NAMED_HOP = [n({"id": 30, "kind": "Message"}, name="m"), e_forward({"type": "HAS
 ENGINES = ["pandas", "polars", "cudf"]
 
 
-@pytest.mark.route_engaged("native-fast")
-@pytest.mark.parametrize("engine", ENGINES)
-def test_node_only_lookup_served_by_the_property_index_is_explained(engine):
-    g = _graph(engine)
-    report = g.gfql_explain(NODE_ONLY, index_policy="use", engine=engine)
-    assert report["used_index"] is True, report
-    assert [(s["seam"], s["reason"], s["hops"]) for s in report["steps"]] == [("native_seed_lookup", "property_index", 0)]
-    assert len(g.gfql(NODE_ONLY, engine=engine, index_policy="use")._nodes) == 1
+def _engine_cases(polars_route):
+    return [
+        pytest.param(engine, engagement,
+                     marks=pytest.mark.route_engaged(
+                         polars_route if engine == "polars" else "native-fast") if engagement else (),
+                     id=f"{engine}-{'engagement' if engagement else 'result'}")
+        for engine in ENGINES for engagement in (False, True)
+    ]
 
 
-@pytest.mark.route_engaged("native-fast", "polars-seeded")
-@pytest.mark.parametrize("engine", ENGINES)
-def test_seeded_typed_hop_served_by_the_resident_indexes_is_explained(engine):
+def _node_keys(graph, engine):
+    keys = graph._nodes["key"]
+    return keys.to_arrow().to_pylist() if engine == "cudf" else keys.to_list()
+
+
+@pytest.mark.parametrize("engine,check_engagement", _engine_cases("polars-single-node"))
+def test_node_only_lookup_served_by_the_property_index_is_explained(engine, check_engagement):
     g = _graph(engine)
-    report = g.gfql_explain(NAMED_HOP, index_policy="use", engine=engine)
-    assert report["used_index"] is True, report
-    assert [s["seam"] for s in report["steps"] if s["path"] == "index"] == ["native_seeded_hop"]
+    if check_engagement:
+        report = g.gfql_explain(NODE_ONLY, index_policy="use", engine=engine)
+        assert report["used_index"] is True, report
+        assert [(s["seam"], s["reason"], s["hops"]) for s in report["steps"]] == [("native_seed_lookup", "property_index", 0)]
+    out = g.gfql(NODE_ONLY, engine=engine, index_policy="use")
+    assert _node_keys(out, engine) == [1]
+    assert len(out._edges) == 0
+
+
+@pytest.mark.parametrize("engine,check_engagement", _engine_cases("polars-seeded"))
+def test_seeded_typed_hop_served_by_the_resident_indexes_is_explained(engine, check_engagement):
+    g = _graph(engine)
+    if check_engagement:
+        report = g.gfql_explain(NAMED_HOP, index_policy="use", engine=engine)
+        assert report["used_index"] is True, report
+        assert [s["seam"] for s in report["steps"] if s["path"] == "index"] == ["native_seeded_hop"]
     with index_trace() as steps:
         out = g.gfql(NAMED_HOP, engine=engine, index_policy="use")
-    assert [s["path"] for s in steps] == ["index"]
+    if check_engagement:
+        assert [s["path"] for s in steps] == ["index"]
+    assert sorted(_node_keys(out, engine)) == [1, 3]
     assert len(out._edges) == 1
 
 

--- a/graphistry/tests/compute/gfql/test_native_seed_resolution_2027.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_resolution_2027.py
@@ -239,10 +239,7 @@ def test_non_scalar_seed_predicates_keep_parity_without_the_index(engine, seed):
 @pytest.mark.route_engaged("native-fast")
 @pytest.mark.parametrize("engine", ENGINES)
 def test_duplicate_node_rows_are_answered_once_each_on_the_native_lookup(engine):
-    """A node table that repeats a key row (a contract violation the engine tolerates): the
-    native lookup answers one row per matching node-table row, which is what the polars
-    lanes answer; the pandas/cuDF full path self-joins the duplicates into 2**3 rows (a
-    pre-existing blow-up, recorded here so a change to either side flips this pin)."""
+    """Native and generic lookup preserve each matching source row exactly once."""
     g = _lane_graph(engine)
     nodes = g._nodes
     dup = nodes.iloc[[7]]
@@ -258,4 +255,5 @@ def test_duplicate_node_rows_are_answered_once_each_on_the_native_lookup(engine)
     assert hits == 1
     fast_keys = _canon(fast._nodes)["key"].tolist()
     assert fast_keys == [7.0, 7.0], fast_keys
-    assert len(full._nodes) == 8  # the full path's duplicate self-join; not the native lane's answer
+    assert _canon(full._nodes)["key"].tolist() == [7.0, 7.0]
+    pd.testing.assert_frame_equal(_canon(fast._nodes), _canon(full._nodes))

--- a/graphistry/tests/compute/gfql/test_native_seed_resolution_2027.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_resolution_2027.py
@@ -7,6 +7,9 @@ seeded hops whenever the traversal indexes were resident. Pins: a lane-shaped gr
 the fast path with parity to the full path, the alias columns sit where the full path
 puts them, and the property index is the seam that resolves the seed.
 """
+from contextlib import ExitStack
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -52,18 +55,19 @@ def _canon(frame):
 
 
 def _run(g, ops, engine, fast):
-    real = chain_mod._try_chain_fast_path
     hits = {"n": 0}
 
-    def spy(*a, **k):
-        r = real(*a, **k)
-        hits["n"] += r is not None
-        return r
-    chain_mod._try_chain_fast_path = (lambda *a, **k: None) if not fast else spy
-    try:
+    def spy(real):
+        def run(*a, **k):
+            result = real(*a, **k) if fast else None
+            hits["n"] += result is not None
+            return result
+        return run
+
+    with ExitStack() as stack:
+        for name in ("_try_chain_fast_path", "_try_point_rows"):
+            stack.enter_context(patch.object(chain_mod, name, spy(getattr(chain_mod, name))))
         return g.gfql(ops, engine=engine, index_policy="use"), hits["n"]
-    finally:
-        chain_mod._try_chain_fast_path = real
 
 
 SHAPES = {
@@ -79,7 +83,7 @@ SHAPES = {
 }
 
 
-@pytest.mark.route_engaged("native-fast")
+@pytest.mark.route_engaged("native-fast", "point-rows")
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("shape", list(SHAPES))
 def test_lane_shapes_are_served_with_exact_parity(engine, shape):
@@ -182,12 +186,9 @@ def _same_values(fast, full):
 
 
 def _run_policy(g, ops, engine, fast, index_policy):
-    real = chain_mod._try_chain_fast_path
-    chain_mod._try_chain_fast_path = real if fast else (lambda *a, **k: None)
-    try:
+    from graphistry.tests.compute.gfql.routes.switch import routes_off
+    with routes_off(()) if fast else routes_off(("native-fast", "point-rows")):
         return g.gfql(ops, engine=engine, index_policy=index_policy)
-    finally:
-        chain_mod._try_chain_fast_path = real
 
 
 @pytest.mark.parametrize("engine", ENGINES)

--- a/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
+++ b/graphistry/tests/compute/gfql/test_native_seed_skip_refilter.py
@@ -88,12 +88,16 @@ SKIP_SHAPES = {
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("shape", list(SKIP_SHAPES))
-def test_exact_index_hit_skips_the_refilter_with_parity(engine, shape):
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("native-fast")),
+])
+def test_exact_index_hit_skips_the_refilter_with_parity(engine, shape, require_engagement):
     g = _graph(engine)
     ops = SKIP_SHAPES[shape]()
     _assert_parity(g, ops, engine)
     _, refilters = _run(g, ops, engine, "use")
-    assert refilters == 0, "an exact single-predicate index hit must not re-filter its rows"
+    if require_engagement:
+        assert refilters == 0, "an exact single-predicate index hit must not re-filter its rows"
 
 
 VERIFIED_SHAPES = {  # an index hit plus residual scalar equalities: verified on the hit rows, never re-filtered
@@ -109,30 +113,42 @@ REFILTER_SHAPES = {  # no index hit (the index declines a float on an integer pr
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("shape", list(VERIFIED_SHAPES))
-def test_an_index_hit_with_residual_scalar_predicates_is_verified_not_refiltered(engine, shape):
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("native-fast")),
+])
+def test_an_index_hit_with_residual_scalar_predicates_is_verified_not_refiltered(engine, shape, require_engagement):
     g = _graph(engine)
     ops = VERIFIED_SHAPES[shape]()
     _assert_parity(g, ops, engine)
     _, refilters = _run(g, ops, engine, "use")
-    assert refilters == 0, "residual scalar equalities are verified on the hit rows, not re-filtered"
+    if require_engagement:
+        assert refilters == 0, "residual scalar equalities are verified on the hit rows, not re-filtered"
 
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("shape", list(REFILTER_SHAPES))
-def test_every_other_shape_still_runs_the_canonical_filter(engine, shape):
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("native-fast")),
+])
+def test_every_other_shape_still_runs_the_canonical_filter(engine, shape, require_engagement):
     g = _graph(engine)
     ops = REFILTER_SHAPES[shape]()
     _assert_parity(g, ops, engine)
     _, refilters = _run(g, ops, engine, "use")
-    assert refilters >= 1, "without an index hit the canonical filter runs"
+    if require_engagement:
+        assert refilters >= 1, "without an index hit the canonical filter runs"
 
 
-def test_bool_on_integer_column_is_never_index_served():
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("native-fast")),
+])
+def test_bool_on_integer_column_is_never_index_served(require_engagement):
     g = _graph("pandas")
     ops = [n({"id": True})]
     _assert_parity(g, ops, "pandas")
     _, refilters = _run(g, ops, "pandas", "use")
-    assert refilters >= 1
+    if require_engagement:
+        assert refilters >= 1
 
 
 def test_bool_on_integer_column_raises_the_same_way_on_cudf_either_policy():
@@ -154,14 +170,18 @@ def test_string_on_integer_column_keeps_the_typed_error_on_both_policies(engine,
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_no_resident_index_still_filters(engine):
+@pytest.mark.parametrize("require_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("native-fast")),
+])
+def test_no_resident_index_still_filters(engine, require_engagement):
     g = _graph(engine)
     plain = graphistry.nodes(g._nodes, "key").edges(g._edges, "s", "d")
     ops = [n({"key": 7})]
     served, refilters = _run(plain, ops, engine, "use")
     full, _ = _run(plain, ops, engine, "off")
     pd.testing.assert_frame_equal(_canon(served._nodes), _canon(full._nodes))
-    assert refilters >= 1
+    if require_engagement:
+        assert refilters >= 1
 
 
 # ---- residual verify on an index hit (the multi-predicate seed) ----

--- a/graphistry/tests/compute/gfql/test_polars_indexed_join_helpers.py
+++ b/graphistry/tests/compute/gfql/test_polars_indexed_join_helpers.py
@@ -1,0 +1,36 @@
+"""Indexed join helpers retain path order and collect on the active target."""
+import pytest
+
+from graphistry.Engine import Engine
+from graphistry.compute.dataframe.join import estimate_inner_join_rows, path_ordered_expand_join
+
+pl = pytest.importorskip("polars")
+
+
+@pytest.mark.parametrize("empty", [False, True])
+def test_polars_join_helpers_collect_once_and_keep_path_bag(monkeypatch, empty):
+    from graphistry.compute.gfql import lazy
+    state = pl.DataFrame({"current": [2, 1, 2, None], "seed": [20, 10, 21, 30]})
+    step = pl.DataFrame({"from": [2, 1, 2, None], "to": [8, 9, 7, 6], "edge_order": [2, 0, 1, 3]})
+    if empty:
+        step = step.clear()
+    calls = []
+    original = lazy.collect
+
+    def collect(frame):
+        calls.append(frame)
+        return original(frame)
+
+    monkeypatch.setattr(lazy, "collect", collect)
+    estimate = estimate_inner_join_rows(state, step, left_on="current", right_on="from", engine=Engine.POLARS)
+    assert estimate == (0 if empty else 5)
+    assert len(calls) == (0 if empty else 1)
+    calls.clear()
+    result = path_ordered_expand_join(
+        state, step, current_col="current", from_col="from", to_col="to",
+        path_order_col="path_order", tiebreak_cols=["edge_order"], alias="tail", engine=Engine.POLARS,
+    )
+    assert len(calls) == 1
+    assert result.columns == ["seed", "current", "tail"]
+    assert result.schema == {"seed": pl.Int64, "current": pl.Int64, "tail": pl.Int64}
+    assert result.rows() == ([] if empty else [(20, 7, 7), (20, 8, 8), (10, 9, 9), (21, 7, 7), (21, 8, 8)])

--- a/graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
+++ b/graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
@@ -33,11 +33,13 @@ def _graph(reverse=False, indexed=True, padding=0):
     return g.gfql_index_all(engine="polars").gfql_index_node_props(["id"], engine="polars") if indexed else g
 
 
-@pytest.mark.route_engaged("polars-seeded")
+@pytest.mark.parametrize("check_engagement", [
+    False, pytest.param(True, marks=pytest.mark.route_engaged("polars-seeded")),
+])
 @pytest.mark.parametrize("reverse", [False, True])
 @pytest.mark.parametrize("indexed", [False, True])
 @pytest.mark.parametrize("seed", [{"id": 104}, {"kind": "Message"}, {"id": 105}, {"id": 999}])
-def test_native_named_typed_hop_preserves_full_path_tables(reverse, indexed, seed, monkeypatch):
+def test_native_named_typed_hop_preserves_full_path_tables(reverse, indexed, seed, check_engagement, monkeypatch):
     g = _graph(reverse, indexed)
     edge = e_reverse if reverse else e_forward
     ops = [n(seed, name="m"), edge({"type": "T"}, name="e"), n({"kind": "Person"}, name="p")]
@@ -51,7 +53,8 @@ def test_native_named_typed_hop_preserves_full_path_tables(reverse, indexed, see
 
     monkeypatch.setattr(chain_polars, "_try_seeded_chain_polars", spy)
     fast = g.gfql(ops, engine="polars", index_policy="use")
-    assert served == [indexed]
+    if check_engagement:
+        assert served == [indexed]
     monkeypatch.setattr(chain_polars, "_try_seeded_chain_polars", lambda *args: None)
     full = g.gfql(ops, engine="polars", index_policy="use")
     assert_frame_equal(fast._nodes, full._nodes)
@@ -100,10 +103,15 @@ def test_native_seeded_hop_declines_without_a_usable_index(policy, monkeypatch):
     assert_frame_equal(fast._edges, full._edges)
 
 
-@pytest.mark.route_engaged("polars-seeded")
-@pytest.mark.parametrize("single_node", [False, True])
+@pytest.mark.parametrize("single_node,check_engagement", [
+    pytest.param(single_node, engagement,
+                 marks=pytest.mark.route_engaged(
+                     "polars-single-node" if single_node else "polars-seeded") if engagement else (),
+                 id=f"{'single' if single_node else 'hop'}-{'engagement' if engagement else 'result'}")
+    for single_node in (False, True) for engagement in (False, True)
+])
 @pytest.mark.parametrize("build_engine", ["polars", "polars-gpu"])
-def test_native_property_seed_uses_resident_index(single_node, build_engine, monkeypatch):
+def test_native_property_seed_uses_resident_index(single_node, check_engagement, build_engine, monkeypatch):
     import graphistry.compute.gfql.index.bindings as bindings
     g = _graph(indexed=False, padding=100).gfql_index_all(engine=build_engine).gfql_index_node_props(["id"], engine=build_engine)
     real = bindings._seed_rows_via_property_index
@@ -119,8 +127,10 @@ def test_native_property_seed_uses_resident_index(single_node, build_engine, mon
     if not single_node:
         ops += [e_forward({"type": "T"}), n({"kind": "Person"}, name="p")]
     out = g.gfql(ops, engine="polars", index_policy="use")
-    assert any(hits)
-    assert out._nodes.height == (1 if single_node else 3)
+    if check_engagement:
+        assert any(hits)
+    assert sorted(out._nodes["key"].to_list()) == ([4] if single_node else [1, 2, 4])
+    assert out._edges["value"].to_list() == ([] if single_node else [1, 2])
 
 
 def test_stale_property_index_does_not_select_old_seed(monkeypatch):

--- a/graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
+++ b/graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
@@ -248,3 +248,22 @@ def test_property_seed_never_reuses_other_frame_family():
     from graphistry.compute.gfql.index.bindings import _seed_rows_via_property_index
     g = _graph(indexed=False, padding=1000).gfql_index_node_props(["id"], engine="polars-gpu")
     assert _seed_rows_via_property_index(get_registry(g), g._nodes, {"id": 104}, Engine.PANDAS, np, policy="force") is None
+
+
+@pytest.mark.parametrize("dtype, values", [
+    (pl.Int64, [2**53 + 1, 2**53 + 2]),
+    (pl.Int64, [-2**53 - 1, -2**53 - 2]),
+    (pl.UInt64, [2**63 + 1, 2**63 + 2]),
+    (pl.UInt64, [2**64 - 2, 2**64 - 1]),
+])
+@pytest.mark.parametrize("nullable", [False, True])
+def test_polars_index_keys_keep_integer_precision(dtype, values, nullable):
+    import numpy as np
+    from graphistry.compute.chain_fast_paths import _ids_to_key_array
+
+    keys = pl.Series(values, dtype=dtype).to_numpy()
+    series = pl.Series([values[0], None, values[1], values[0]] if nullable else values, dtype=dtype)
+    result = _ids_to_key_array(series, keys, np)
+    assert result is not None
+    assert result.dtype == keys.dtype
+    np.testing.assert_array_equal(result, np.unique(keys))

--- a/graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
+++ b/graphistry/tests/compute/gfql/test_polars_native_seed_resolution.py
@@ -102,9 +102,10 @@ def test_native_seeded_hop_declines_without_a_usable_index(policy, monkeypatch):
 
 @pytest.mark.route_engaged("polars-seeded")
 @pytest.mark.parametrize("single_node", [False, True])
-def test_native_property_seed_uses_resident_index(single_node, monkeypatch):
+@pytest.mark.parametrize("build_engine", ["polars", "polars-gpu"])
+def test_native_property_seed_uses_resident_index(single_node, build_engine, monkeypatch):
     import graphistry.compute.gfql.index.bindings as bindings
-    g = _graph(padding=100)
+    g = _graph(indexed=False, padding=100).gfql_index_all(engine=build_engine).gfql_index_node_props(["id"], engine=build_engine)
     real = bindings._seed_rows_via_property_index
     hits = []
 
@@ -200,3 +201,50 @@ def test_seeded_chain_with_start_nodes_never_takes_the_native_lane(monkeypatch):
     full = chain_polars.chain_polars(g, _NAMED_TYPED_HOP, start_nodes=seeds)
     assert_frame_equal(out._nodes, full._nodes)
     assert_frame_equal(out._edges, full._edges)
+
+
+@pytest.mark.parametrize("build_engine", ["polars", "polars-gpu"])
+@pytest.mark.parametrize("lookup_engine", ["polars", "polars-gpu"])
+@pytest.mark.parametrize("value", [104, 99999])
+def test_property_seed_engine_keys_preserve_rows(build_engine, lookup_engine, value):
+    from graphistry.Engine import Engine
+    from graphistry.compute.chain_fast_paths import _seed_rows_via_prop_index_frame
+    g = _graph(indexed=False, padding=1000)
+    g = g.nodes(pl.concat([g._nodes, g._nodes.filter(pl.col("id") == 104)]))
+    g = g.gfql_index_node_props(["id"], engine=build_engine)
+    actual = _seed_rows_via_prop_index_frame(g, g._nodes, {"id": value}, Engine(lookup_engine))
+    assert actual is not None
+    assert_frame_equal(actual, g._nodes.filter(pl.col("id") == value))
+
+
+@pytest.mark.parametrize("build_engine,lookup_engine", [("polars", "polars-gpu"), ("polars-gpu", "polars")])
+@pytest.mark.parametrize("change", ["clone", "reverse", "values"])
+def test_property_seed_other_engine_key_rejects_rebound_frame(build_engine, lookup_engine, change):
+    from graphistry.Engine import Engine
+    from graphistry.compute.chain_fast_paths import _seed_rows_via_prop_index_frame
+    g = _graph(indexed=False, padding=1000).gfql_index_node_props(["id"], engine=build_engine)
+    frame = (g._nodes.clone() if change == "clone" else g._nodes.reverse() if change == "reverse"
+             else g._nodes.with_columns((pl.col("id") + 1).alias("id")))
+    assert _seed_rows_via_prop_index_frame(g, frame, {"id": 104}, Engine(lookup_engine)) is None
+
+
+@pytest.mark.parametrize("policy,served", [("off", False), ("use", False), ("force", True)])
+def test_property_seed_other_engine_key_keeps_policy_and_cost(policy, served):
+    from graphistry.Engine import Engine
+    from graphistry.compute.chain_fast_paths import _seed_rows_via_prop_index_frame
+    from graphistry.compute.gfql.index.api import with_index_policy
+    g = _graph(indexed=False).gfql_index_node_props(["id"], engine="polars-gpu")
+    g = with_index_policy(g, policy)
+    actual = _seed_rows_via_prop_index_frame(g, g._nodes, {"id": 104}, Engine.POLARS)
+    assert (actual is not None) is served
+    if served:
+        assert_frame_equal(actual, g._nodes.filter(pl.col("id") == 104))
+
+
+def test_property_seed_never_reuses_other_frame_family():
+    import numpy as np
+    from graphistry.Engine import Engine
+    from graphistry.compute.gfql.index import get_registry
+    from graphistry.compute.gfql.index.bindings import _seed_rows_via_property_index
+    g = _graph(indexed=False, padding=1000).gfql_index_node_props(["id"], engine="polars-gpu")
+    assert _seed_rows_via_property_index(get_registry(g), g._nodes, {"id": 104}, Engine.PANDAS, np, policy="force") is None

--- a/graphistry/tests/compute/gfql/test_polars_rows_entity_groupby.py
+++ b/graphistry/tests/compute/gfql/test_polars_rows_entity_groupby.py
@@ -198,13 +198,12 @@ def test_binding_rows_dup_id_pandas_narrows_order_independent(tag_first: bool) -
 
 @pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")
 @pytest.mark.parametrize("tag_first", [True, False])
-def test_binding_rows_dup_id_polars_declines_nie(tag_first: bool) -> None:
-    """Duplicate node ids + HAS_<Label> gate shape → honest NIE on polars, never a
-    silently row-order-dependent native answer (parity-or-error contract)."""
+def test_binding_rows_dup_id_polars_narrows_order_independent(tag_first: bool) -> None:
+    """Reached label collisions select the correct row in either input order."""
     nodes, edges = _dup_id_frames(tag_first)
     g = graphistry.nodes(pl.from_pandas(nodes), "id").edges(pl.from_pandas(edges), "src", "dst")
-    with pytest.raises(NotImplementedError):
-        g.gfql(COLLIDE_BINDINGS, params={"personId": 1}, engine="polars")
+    res = g.gfql(COLLIDE_BINDINGS, params={"personId": 1}, engine="polars")
+    assert res._nodes.select(["tagName", "cd"]).to_dicts() == [{"tagName": "t1", "cd": 150.0}]
 
 
 @pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")

--- a/graphistry/tests/compute/gfql/test_seeded_typed_hop_fastpath.py
+++ b/graphistry/tests/compute/gfql/test_seeded_typed_hop_fastpath.py
@@ -1135,3 +1135,26 @@ class TestResidentIndexSeededFastPath:
         _patch_index_rows(monkeypatch, "_index_edge_rows", oe)
         assert serves["e"] > 0, "adjacency index did not serve the property-seeded lookup"
         pd.testing.assert_frame_equal(self._canon(indexed), self._canon(plain))
+
+
+@pytest.mark.parametrize("indexed", [False, True])
+@pytest.mark.parametrize("direction", ["forward", "reverse"])
+@pytest.mark.parametrize("duplicate_tail", [False, True])
+def test_polars_tail_reduction_retains_only_linked_filtered_nodes(indexed, direction, duplicate_tail):
+    pl = pytest.importorskip("polars")
+    from graphistry.compute.gfql.lazy.engine.polars.chain_specializations.hotpaths import _seeded_typed_return_dst_polars
+    nodes = pl.DataFrame({"id": [0, 1, 2, 3], "keep": [False, True, False, True]})
+    if duplicate_tail:
+        nodes = pl.concat([nodes, nodes.filter(pl.col("id") == 1)])
+    edges = pl.DataFrame({"src": [0, 0, 0, 0, 0, 3], "dst": [1, 1, 2, 99, None, 1], "order": list(range(6))})
+    if direction == "reverse":
+        edges = edges.rename({"src": "dst", "dst": "src"})
+    g = graphistry.nodes(nodes, "id").edges(edges, "src", "dst")
+    if indexed:
+        g = g.gfql_index_all(engine="polars")
+    edge = e_forward() if direction == "forward" else e_reverse()
+    result = _seeded_typed_return_dst_polars(g, n({"id": 0}), n({"keep": True}), edge, "src", "dst", "id", direction)
+    assert result is not None
+    tails, kept_edges, _, _ = result
+    assert tails.rows() == [(1, True)]
+    assert sorted(kept_edges.get_column("order").to_list()) == [0, 1]

--- a/graphistry/tests/compute/test_call_operations_gpu.py
+++ b/graphistry/tests/compute/test_call_operations_gpu.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from graphistry.tests.test_compute import CGFull
 from graphistry.Engine import Engine
-from graphistry.compute.ast import ASTCall, ASTLet, n
+from graphistry.compute.ast import ASTCall, ASTLet, ASTRef, n
 from graphistry.compute.chain_let import chain_let_impl
 from graphistry.compute.gfql.call.executor import execute_call
 from graphistry.compute.validate.validate_schema import validate_chain_schema
@@ -213,7 +213,8 @@ class TestCallOperationsGPU:
         assert len(result._nodes) == 3
     
     @skip_gpu
-    def test_chain_let_with_gpu_calls(self):
+    @pytest.mark.parametrize("dependent", [False, True])
+    def test_chain_let_with_gpu_calls(self, dependent):
         """Test DAG execution with Call operations on GPU."""
         import cudf
         
@@ -235,19 +236,19 @@ class TestCallOperationsGPU:
             .nodes(nodes_gdf)\
             .bind(source='source', destination='target', node='node')
         
-        # Create DAG with Call operations
+        degree_call = ASTCall('get_degrees', {'col': 'degree'})
         dag = ASTLet({
             'filtered': n({'type': 'user'}),
-            'with_degrees': ASTCall('get_degrees', {'col': 'degree'})
+            'with_degrees': ASTRef('filtered', [degree_call]) if dependent else degree_call
         })
         
         result = chain_let_impl(g, dag, Engine.CUDF)
         
         # Should have degrees column
         assert 'degree' in result._nodes.columns
-        # Check that we have the expected number of nodes
-        # The DAG filters for 'user' type first (3 users) then computes degrees
-        assert len(result._nodes) == 3  # 3 users after filtering
+        expected_ids = [0, 1, 3] if dependent else [0, 1, 2, 3]
+        assert isinstance(result._nodes, cudf.DataFrame)
+        assert sorted(result._nodes['node'].to_pandas().tolist()) == expected_ids
     
     @skip_gpu
     def test_schema_validation_with_cudf(self):

--- a/graphistry/tests/compute/test_chain_validation_execution.py
+++ b/graphistry/tests/compute/test_chain_validation_execution.py
@@ -1,0 +1,110 @@
+"""Execution must validate current ASTs, even after construction or prior execution."""
+
+import os
+
+import pandas as pd
+import pytest
+
+import graphistry
+from graphistry.compute.ast import ASTNode, e_forward, n
+from graphistry.compute.chain import Chain
+from graphistry.compute.exceptions import ErrorCode, GFQLTypeError
+
+
+@pytest.fixture(scope="module", params=["pandas", "polars", "cudf", "polars-gpu"])
+def engine(request):
+    from graphistry.tests.compute.gfql.routes.test_route_harness import _skip_unavailable
+    _skip_unavailable(request.param)
+    if request.param == "polars-gpu":
+        if os.environ.get("TEST_CUDF") != "1":
+            pytest.skip("GPU validation lane runs with TEST_CUDF=1")
+        import polars as pl
+        # An explicitly requested GPU run must fail if the backend is broken.
+        pl.DataFrame({"a": [1]}).lazy().collect(engine=pl.GPUEngine(raise_on_fail=True))
+    return request.param
+
+
+def graph(engine):
+    nodes = pd.DataFrame({"id": [0, 1], "value": [10, 20]})
+    edges = pd.DataFrame({"s": [0], "d": [1]})
+    if engine in ("polars", "polars-gpu"):
+        import polars as pl
+        nodes, edges = pl.from_pandas(nodes), pl.from_pandas(edges)
+    elif engine == "cudf":
+        import cudf
+        nodes, edges = cudf.from_pandas(nodes), cudf.from_pandas(edges)
+    return graphistry.nodes(nodes, "id").edges(edges, "s", "d")
+
+
+@pytest.mark.parametrize("entry", ["chain", "gfql"])
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_execution_revalidates_mutated_ast(engine, entry, wrapped):
+    g = graph(engine)
+    edge = e_forward(hops=1)
+    ops = [n({"id": 0}), edge, n()]
+    query = Chain(ops) if wrapped else ops
+    execute = getattr(g, entry)
+    assert len(execute(query, engine=engine)._edges) == 1
+    # Cross the valid one-hop boundary using the same graph, AST and container.
+    for invalid_hops in (0, -1, "1"):
+        edge.hops = invalid_hops
+        with pytest.raises(GFQLTypeError) as caught:
+            execute(query, engine=engine)
+        assert caught.value.code == ErrorCode.E103
+        assert caught.value.context["field"] == "hops"
+    edge.hops = 1
+    assert len(execute(query, engine=engine)._edges) == 1
+
+
+@pytest.mark.parametrize("entry", ["chain", "gfql"])
+def test_deferred_chain_checks_structure_before_schema(engine, entry):
+    g = graph(engine)
+    # The first operation has a missing property, but structural validation of
+    # the later edge must fail before schema lookup/execution starts.
+    query = Chain([n({"missing": 3}), e_forward(hops=0)], validate=False)
+    with pytest.raises(GFQLTypeError) as caught:
+        getattr(g, entry)(query, engine=engine)
+    assert caught.value.code == ErrorCode.E103
+    assert caught.value.context["field"] == "hops"
+
+
+@pytest.mark.parametrize("entry", ["chain", "gfql"])
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_mutated_operation_list_is_not_trusted(engine, entry, wrapped):
+    g = graph(engine)
+    ops = [n()]
+    query = Chain(ops) if wrapped else ops
+    assert len(getattr(g, entry)(query, engine=engine)._nodes) == 2
+    ops.append("invalid operation")
+    with pytest.raises(GFQLTypeError) as caught:
+        getattr(g, entry)(query, engine=engine)
+    assert caught.value.code == ErrorCode.E101
+    assert caught.value.context["operation_index"] == 1
+
+
+class RejectingNode(ASTNode):
+    """A supported AST subclass can impose an additional validation rule."""
+
+    def _validate_fields(self):
+        super()._validate_fields()
+        raise GFQLTypeError(ErrorCode.E103, "custom node rejected", field="custom")
+
+
+@pytest.mark.parametrize("entry", ["chain", "gfql"])
+def test_subclass_validator_cannot_be_bypassed(engine, entry):
+    query = Chain([RejectingNode()], validate=False)
+    with pytest.raises(GFQLTypeError, match="custom node rejected"):
+        getattr(graph(engine), entry)(query, engine=engine)
+
+
+def test_schema_opt_out_does_not_bypass_list_ast_validation(engine):
+    # validate_schema=False is not permission to accept malformed list input.
+    with pytest.raises(GFQLTypeError) as caught:
+        graph(engine).chain([e_forward(hops=0)], engine=engine, validate_schema=False)
+    assert caught.value.code == ErrorCode.E103
+
+
+def test_schema_opt_out_accepts_valid_chain(engine):
+    g = graph(engine)
+    query = Chain([n({"id": 0})])
+    assert len(g.chain(query, engine=engine, validate_schema=False)._nodes) == 1

--- a/graphistry/tests/compute/test_engine_coercion.py
+++ b/graphistry/tests/compute/test_engine_coercion.py
@@ -675,6 +675,21 @@ class TestChainCoercion(NoAuthTestCase):
         self.assertIsInstance(result._edges, pd.DataFrame)
 
     @unittest.skipUnless(HAS_DASK, "dask not installed")
+    def test_dask_auto_engine_is_independent_of_cudf_availability(self):
+        from unittest.mock import patch
+        from graphistry.Engine import resolve_engine
+        ddf = dd.from_pandas(EDGES_PD, npartitions=1)
+        for has_cudf in (False, True):
+            with self.subTest(has_cudf=has_cudf), patch(
+                "graphistry.utils.lazy_import.lazy_cudf_import",
+                return_value=(has_cudf, None, None),
+            ):
+                self.assertEqual(resolve_engine("auto", ddf), Engine.PANDAS)
+                self.assertEqual(resolve_engine("cudf", ddf), Engine.CUDF)
+                self.assertEqual(resolve_engine("polars", ddf), Engine.POLARS)
+                self.assertEqual(resolve_engine("polars-gpu", ddf), Engine.POLARS_GPU)
+
+    @unittest.skipUnless(HAS_DASK, "dask not installed")
     def test_chain_dask_edges(self):
         from graphistry.compute.ast import n, e_forward
         import dask.dataframe as dd

--- a/graphistry/tests/conftest.py
+++ b/graphistry/tests/conftest.py
@@ -5,7 +5,7 @@ session, so every existing test — written against one specialization or agains
 general path — is replayed through the other routes. Failures that appear only under a
 mode are the cases where that route and the rest disagree.
 
-Routes: native-fast (pandas/cuDF chain fast path), polars-seeded (polars seeded lane),
+Routes: polars-point-rows, point-rows, polars-single-node, native-fast (pandas/cuDF chain fast path), polars-seeded (polars seeded lane),
 polars-plain (polars plain single-hop branches), index-hop (hop() index path),
 indexed-kernel (indexed connected-bindings kernel), cypher-fast (the four Cypher lanes).
 

--- a/graphistry/tests/utils/test_json.py
+++ b/graphistry/tests/utils/test_json.py
@@ -1,4 +1,8 @@
-from graphistry.utils.json import assert_json_serializable
+import json
+
+import pytest
+
+from graphistry.utils.json import assert_json_serializable, is_json_serializable
 
 class TestAssertJsonSerializable():
 
@@ -28,36 +32,62 @@ class TestAssertJsonSerializable():
         assert_json_serializable({'a': [{'b': 1}, {'c': 2}]})
     
     def test_unserializable(self):
-
-        try:
-            assert_json_serializable(set())
-            assert False, 'Expected exception on set'
-        except AssertionError:
-            pass
-
-        try:
-            assert_json_serializable({'a': set()})
-            assert False, 'Expected exception on nested set'
-        except AssertionError:
-            pass
-
-        try:
-            assert_json_serializable({'a': [set()]})
-            assert False, 'Expected exception on nested set'
-        except AssertionError:
-            pass
-
-        try:
-            assert_json_serializable({'a': [{'b': set()}]})
-            assert False, 'Expected exception on nested set'
-        except AssertionError:
-            pass
-
         class Unserializable:
             pass
 
-        try:
-            assert_json_serializable(Unserializable())
-            assert False, 'Expected exception on class'
-        except AssertionError:
-            pass
+        values = [set(), {'a': set()}, {'a': [set()]}, {'a': [{'b': set()}]}, Unserializable()]
+        for value in values:
+            with pytest.raises(AssertionError):
+                assert_json_serializable(value)
+
+
+@pytest.mark.parametrize('value', [
+    None, False, True, '', 'unicode\u2603', '\ud800', 0, -1,
+    -(2**64), -(2**64) + 1, 2**63, 2**64 - 1, 2**64, 2**65,
+    0.0, float('nan'), float('inf'), float('-inf'),
+    [], [1, None], {'nested': [True, 'text']}, (1, 2), set(), {'bad': set()}, object(),
+])
+def test_serializability_matches_standard_encoder(value):
+    try:
+        json.dumps(value)
+    except TypeError:
+        assert is_json_serializable(value) is False
+    else:
+        assert is_json_serializable(value) is True
+
+
+def test_large_integer_keeps_encoder_limit_behavior():
+    value = 10**5000
+    try:
+        json.dumps(value)
+    except ValueError:
+        with pytest.raises(ValueError):
+            is_json_serializable(value)
+    else:
+        assert is_json_serializable(value) is True
+
+
+def test_circular_container_keeps_encoder_error():
+    value = []
+    value.append(value)
+    with pytest.raises(ValueError, match='Circular reference'):
+        is_json_serializable(value)
+
+
+def test_integer_subclass_does_not_call_its_bit_length():
+    class CustomInteger(int):
+        def bit_length(self):
+            raise AssertionError('Encoder does not call this override')
+
+    assert is_json_serializable(CustomInteger(1)) is True
+
+
+def test_metaclass_equality_cannot_admit_an_unsupported_object():
+    class EqualToAnyType(type):
+        def __eq__(cls, other):
+            return True
+
+    class Unsupported(metaclass=EqualToAnyType):
+        pass
+
+    assert is_json_serializable(Unsupported()) is False

--- a/graphistry/utils/json.py
+++ b/graphistry/utils/json.py
@@ -16,7 +16,11 @@ JSONVal = Union[
 ]
 
 
-def is_json_serializable(data):
+def is_json_serializable(data: object) -> bool:
+    if data is None or type(data) is bool or type(data) is str or type(data) is float:
+        return True
+    if type(data) is int and data.bit_length() <= 64:
+        return True
     try:
         json.dumps(data)
         return True


### PR DESCRIPTION
Scalar node and directed one-hop queries ending in `rows(...)` construct traversal results and evaluate expressions for very small outputs. This change gathers matching rows through resident indexes and projects them directly on pandas, cuDF, and CPU Polars. Joined projections retain one result per matching edge, including repeated matches.

The routes preserve row and column order, dtypes, aliases, empty schemas, graph metadata, validation, and unsupported-query fallback. Polars avoids redundant singleton operations, schema inspection, and validation. Supported equality filters on two to 32 eager Polars rows avoid expression plans; CPU Polars gathers of two to eight rows use slices, with scattered gathers limited to 32 columns. Larger and unsupported cases retain the generic path. Valid property indexes can be reused across CPU and GPU execution targets while retaining frame identity and fingerprint checks.

Review hardening includes:

- Shared identifier/expression parsers, narrower scalar/index/backend types, and removal of join type suppressions.
- Immediate Chain validation plus execution checks for mutation, reuse, custom validators, and error ordering.
- Native and generic path ordering, physical duplicate/null rows and supplied starting wavefronts, and HAS-label collision disambiguation before filtering/deduplication.
- Exact nullable Int64/UInt64 identifiers above 2^53, alias-property restoration through entity identity, and consistent empty-edge schemas/bindings.
- Independent boundary/generalization assertions, with result checks active when routes are disabled and engagement checks scoped to their actual engine/shape. Existing suites replay through all nine individual registered routes plus all-off; CI requires every replay to pass and guards against missing modes.

Current published head: `b5703a35c70b3176e4d815adac04bc1bc9252870`. Real-fixture phase probes on both preceding revisions identified variable one-row projection costs in Polars expression collection (roughly 0.12–0.32 ms). This repair builds resolved Cypher property columns directly from their Series. General Polars projection also gathers direct columns and short-circuits coalesce when matching dtypes and null counts prove the chosen column; mixed-null, mixed-type, and unsupported expression cases retain the generic path. Existing expression lowering, temporal checks, row cardinality, and source isolation remain in force.

The repair adds 64 cases to the existing Polars row-pipeline suite, covering empty/single/larger frames, integer precision, null boundaries, NaN, repeated columns, and categorical/enum/list/struct dtypes. The final focused suite passed 323 tests; broader point/boundary/latency integration passed 697 tests including actual cuDF. Full lint and typing for both changed source files passed. The total review addition is now 641 collected parameterized product cases, not independent bugs or additive execution passes.

Validation on this published revision:

- [Product CI](https://github.com/graphistry/pygraphistry/actions/runs/34728697531): all 85 jobs passed. All nine individual route replays plus all-off report zero divergences. All-off: 12,631 passed, 3,030 skipped, 405 expected failures, two non-strict unexpected passes.
- Full DGX compute plus JSON validation: 17,975 passed, 110 skipped, 102 expected failures, 14 non-strict unexpected passes, and two subtests in 501.74 seconds. Official RAPIDS 26.02, cuDF 26.02.01, Polars 1.35.2; CuPy compute and actual Polars GPU collection preflights passed. Transferred source hash and successful guarded runner/workload completion were verified.
- [pyg-bench candidate](https://github.com/graphistry/pyg-bench/actions/runs/34728758614): 53 mandatory checks passed, no skips.
- [TCK main](https://github.com/graphistry/tck-gfql/actions/runs/34728759781): 4,169 passed/six skipped/689 expected failures in each normal/all-nine-off mode.
- [TCK PR199](https://github.com/graphistry/tck-gfql/actions/runs/34728760728): 4,329 passed/86 skipped/689 expected failures in each mode. [PR199](https://github.com/graphistry/tck-gfql/pull/199) adds 240 regression cases for alias identity, nullable identifiers, path order, node selection, and HAS collisions. All candidate logs verify the exact product SHA.

The final latency sentinel passed unchanged absolute and 1.5× historical-baseline drift gates, including correctness, index engagement, and expected fallback. Eight native Polars shapes measured 0.120–0.281 ms against the 0.7 ms limit. IS5 measured 0.192 ms, seeded-hop properties 0.187 ms, and native coalesce 0.165 ms. The alias-collision fallback returned correct results at 23.525 ms. Sampling: eight warmups and 63 measurements.

Broader measurements use product `b5703a35c70b3176e4d815adac04bc1bc9252870` and frozen harness `557665417a8a5f6f0024b5500e1f9997729d37fe` on DGX Spark. All 12 current Polars/pandas runs and 18 retained matched competitor runs passed source, dataset, sampling, resource, and result validation. Competitor runs come from the earlier H557 campaign; they were not rerun with this product change. Every shared expected and actual result hash matches. Sampling: eight warmups, 31 measurements, three independent runs; timings include execution and full record materialization. Tables show median-of-run-medians in milliseconds. A dash means not measured. These are internal SNB-derived results, not official LDBC results.

SF0.1:

| Query | Polars | Kuzu | Neo4j | Memgraph |
| --- | ---: | ---: | ---: | ---: |
| seed-lookup | 1.071 | 2.404 | 3.212 | 0.638 |
| message-content | 0.171 | 0.648 | 1.838 | 0.373 |
| message-creator | 0.250 | 1.501 | 1.906 | 0.458 |
| message-replies | 9.370 | 24.287 | — | — |
| new-topics | 42.621 | 48.958 | — | — |
| recent-replies | 28.736 | 32.008 | 5.431 | 3.954 |

SF1:

| Query | Polars | Kuzu | Neo4j | Memgraph |
| --- | ---: | ---: | ---: | ---: |
| seed-lookup | 1.462 | 2.084 | 3.420 | 0.509 |
| message-content | 0.173 | 0.688 | 2.102 | 0.432 |
| message-creator | 0.247 | 1.778 | 2.021 | 0.452 |
| new-topics | 169.694 | 210.852 | — | — |

Polars leads Kuzu in all ten eligible comparisons. It leads Neo4j on all six point-query comparisons; Neo4j is faster on SF0.1 recent replies. Polars leads Memgraph on message content and creator at both scales; Memgraph is faster on seed lookup at both scales and SF0.1 recent replies. The ±10% ratio band is a reporting convention, not a statistical significance test; SF0.1 recent replies versus Kuzu is close to the boundary. Relative to the original product73565 run medians, message content improved from 0.417→0.171 ms at SF0.1 and 0.762→0.173 ms at SF1; creator improved from 0.513→0.250 ms and 0.708→0.247 ms. Seed lookup increased about 9% at each scale; other measured larger-query changes range from approximately −1% to +7%.

SF0.1 tag cooccurrence is excluded because its selected parameter returns zero rows. SF1 message replies and recent replies were not measured for Polars. Memgraph used a 4 GiB container/3072 MiB engine cap at SF0.1 and a 16 GiB container/12288 MiB engine cap at SF1, consistent across repetitions. The initial failed SF1 import with the smaller engine cap is retained and excluded.

Separate instrumented GPU/index probes passed all seven SF0.1 and four SF1 result checks on the final product revision. GPU collect calls were observed in five SF0.1 queries and two SF1 queries. Message content and creator used eager CPU paths despite the requested GPU target. Seed lookup, message content, and creator all engaged the property index at both scales. A GPU configuration label does not establish GPU execution for every operation. All instrumented timings are excluded from the comparison tables.

Earlier642be latency runs failed relative drift checks. All failures and alternating-pair/phase diagnostics were retained; phase evidence motivated the current direct-projection repair. Current b570 passed the original gates without threshold relaxation. Historical receipts retain their original revision labels.

The harness has correctness/index/route pins and a candidate latency profile requiring all eight native Polars shapes at or below 0.7 ms plus the expected collision fallback. Candidate checks fail on missing or skipped mandatory tests. [pyg-bench PR260](https://github.com/graphistry/pyg-bench/pull/260) adds automatic enforcement when configured. After product merge, actual-master baselines, measured pandas median×1.5 bounds, release configuration activation, and dependent TCK199 validation/merge remain required. They do not use a candidate result relabeled as master.

Colleague-owned aggregation execution/validation and whole-entity metadata work is tracked in [issue2074](https://github.com/graphistry/pygraphistry/issues/2074). Integration must preserve both sets of correctness expectations. Docs2017 follows the product and benchmark release gates.

An isolated merge of this head with current master `24233cb701e4757d9d6d71c9c0394ce9d4393351` is conflict-free. The combined tree passed 697 focused product tests (one skip; 64 Polars-GPU cases deselected locally) and all 240 TCK199 regressions with pandas, Polars, and cuDF enabled. This is local integration evidence; actual merged-master GPU and baseline validation still follows owner merge.
